### PR TITLE
Ignore friend request messages that couldn't be decrypted

### DIFF
--- a/libloki/libloki-protocol.js
+++ b/libloki/libloki-protocol.js
@@ -7,6 +7,7 @@
   const IV_LENGTH = 16;
 
   FallBackSessionCipher = function (address) {
+    this.identityKeyString = address.getName();
     this.pubKey = StringView.hexToArrayBuffer(address.getName());
 
     this.encrypt = async (plaintext) => {
@@ -37,11 +38,15 @@
       const myKeyPair = await textsecure.storage.protocol.getIdentityKeyPair();
       const myPrivateKey = myKeyPair.privKey;
       const symmetricKey = libsignal.Curve.calculateAgreement(this.pubKey, myPrivateKey);
-      const plaintext = await libsignal.crypto.decrypt(symmetricKey, cipherText, iv);
-      return plaintext;
+      try {
+        return await libsignal.crypto.decrypt(symmetricKey, cipherText, iv);
+      } catch(e) {
+        throw new FallBackDecryptionError('Could not decrypt message from ' + this.identityKeyString + ' using FallBack encryption.')
+      }
     }
   }
   
   window.libloki.FallBackSessionCipher = FallBackSessionCipher;
+  window.libloki.FallBackDecryptionError = FallBackDecryptionError;
 
 })();

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -694,6 +694,9 @@ MessageReceiver.prototype.extend({
             buffer.toArrayBuffer(),
             error.identityKey
           );
+        } else {
+          // re-throw
+          throw error;
         }
         const ev = new Event('error');
         ev.error = errorToThrow;
@@ -820,7 +823,11 @@ MessageReceiver.prototype.extend({
   handleContentMessage(envelope) {
     return this.decrypt(envelope, envelope.content).then(plaintext =>
       this.innerHandleContentMessage(envelope, plaintext)
-    );
+    ).catch(e => {
+      if (e instanceof libloki.FallBackDecryptionError) {
+        console.log(e.message + ' Ignoring message.');
+      }
+    });
   },
   innerHandleContentMessage(envelope, plaintext) {
     const content = textsecure.protobuf.Content.decode(plaintext);


### PR DESCRIPTION
If an incoming friend request message can't be decrypted, just ignore the message instead of displaying every failed decrypted message in a new conversation (not spam friendly!)

Possible reasons for failing to decrypt:
- it's spam
- the emitter didn't encrypt properly: different algo used, wrong iv shared, etc.
- the message was intended for someone else