### PR TITLE
Handle incoming friend request 

### DIFF
--- a/js/modules/migrations/migrations_0_database_with_attachment_data.js
+++ b/js/modules/migrations/migrations_0_database_with_attachment_data.js
@@ -52,9 +52,11 @@ const migrations = [
       
       const contactPreKeys = transaction.db.createObjectStore('contactPreKeys', { keyPath: 'id', autoIncrement : true });
       contactPreKeys.createIndex('identityKeyString', 'identityKeyString', { unique: false });
+      contactPreKeys.createIndex('keyId', 'keyId', { unique: false });
       
       const contactSignedPreKeys = transaction.db.createObjectStore('contactSignedPreKeys', { keyPath: 'id', autoIncrement : true });
       contactSignedPreKeys.createIndex('identityKeyString', 'identityKeyString', { unique: false });
+      contactSignedPreKeys.createIndex('keyId', 'keyId', { unique: false });
 
       window.log.info('creating debug log');
       transaction.db.createObjectStore('debug');

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -179,7 +179,23 @@
   const Group = Model.extend({ storeName: 'groups' });
   const Item = Model.extend({ storeName: 'items' });
   const ContactPreKey = Model.extend({ storeName: 'contactPreKeys' });
+  const ContactPreKeyCollection = Backbone.Collection.extend({
+    storeName: 'contactPreKeys',
+    database: Whisper.Database,
+    model: ContactPreKey,
+    fetchBy(filter) {
+      return this.fetch({ conditions: filter, });
+    },
+  });
   const ContactSignedPreKey = Model.extend({ storeName: 'contactSignedPreKeys' });
+  const ContactSignedPreKeyCollection = Backbone.Collection.extend({
+    storeName: 'contactSignedPreKeys',
+    database: Whisper.Database,
+    model: ContactSignedPreKey,
+    fetchBy(filter) {
+      return this.fetch({ conditions: filter, });
+    },
+  });
 
   function SignalProtocolStore() {}
 
@@ -261,6 +277,24 @@
         );
       });
     },
+    loadContactPreKeys(filters) {
+      const contactPreKeys = new ContactPreKeyCollection();
+      return new Promise((resolve, reject) => {
+        contactPreKeys.fetchBy(filters).then(() => {
+          resolve(
+            contactPreKeys.map(prekey => ({
+              id: prekey.get('id'),
+              keyId: prekey.get('keyId'),
+              publicKey: prekey.get('publicKey'),
+              identityKeyString: prekey.get('identityKeyString'),
+            }))
+          );
+        }).fail(e => {
+          window.log.error('Failed to fetch signed prekey with filters', filters);
+          reject(e);
+        });
+      });
+    },
     storeContactPreKey(pubKey, preKey) {
       const prekey = new ContactPreKey({
         // id: (autoincrement)
@@ -338,6 +372,27 @@
             window.log.error('Failed to fetch signed prekey:', keyId);
             resolve();
           });
+      });
+    },
+    loadContactSignedPreKeys(filters) {
+      const contactSignedPreKeys = new ContactSignedPreKeyCollection();
+      return new Promise((resolve, reject) => {
+        contactSignedPreKeys.fetchBy(filters).then(() => {
+          resolve(
+            contactSignedPreKeys.map(prekey => ({
+              id: prekey.get('id'),
+              identityKeyString: prekey.get('identityKeyString'),
+              publicKey: prekey.get('publicKey'),
+              signature: prekey.get('signature'),
+              created_at: prekey.get('created_at'),
+              keyId: prekey.get('keyId'),
+              confirmed: prekey.get('confirmed'),
+            }))
+          );
+        }).fail(e => {
+          window.log.error('Failed to fetch signed prekey with filters', filters);
+          reject(e);
+        });
       });
     },
     loadContactSignedPreKey(pubKey) {

--- a/libloki/libloki-protocol.js
+++ b/libloki/libloki-protocol.js
@@ -74,13 +74,13 @@
     ]);
 
     const preKeyMessage = new textsecure.protobuf.PreKeyBundleMessage({
-      identityKey,
+      identityKey: new Uint8Array(identityKey),
 	    deviceId: 1,        // TODO: fetch from somewhere
 	    preKeyId: preKey.keyId,
 	    signedKeyId,
-      preKey: preKey.pubKey,
-      signedKey: signedKey.pubKey,
-      signature: signedKey.signature,
+      preKey: new Uint8Array(preKey.pubKey),
+      signedKey: new Uint8Array(signedKey.pubKey),
+      signature: new Uint8Array(signedKey.signature),
     });
 
     return preKeyMessage;

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -829,8 +829,13 @@ MessageReceiver.prototype.extend({
       }
     });
   },
-  innerHandleContentMessage(envelope, plaintext) {
+  async innerHandleContentMessage(envelope, plaintext) {
     const content = textsecure.protobuf.Content.decode(plaintext);
+
+    if (content.preKeyBundleMessage) {
+      await this.handlePreKeyBundleMessage(envelope, content.preKeyBundleMessage);
+    }
+
     if (content.syncMessage) {
       return this.handleSyncMessage(envelope, content.syncMessage);
     } else if (content.dataMessage) {
@@ -1051,6 +1056,30 @@ MessageReceiver.prototype.extend({
     textsecure.storage.put('blocked-groups', groupIds);
 
     return this.removeFromCache(envelope);
+  },
+  async handlePreKeyBundleMessage(envelope, preKeyBundleMessage) {
+
+    const { preKeyId, signedKeyId } = preKeyBundleMessage;
+    const [ identityKey, preKey, signedKey, signature ] = [
+      preKeyBundleMessage.identityKey,
+      preKeyBundleMessage.preKey,
+      preKeyBundleMessage.signedKey,
+      preKeyBundleMessage.signature
+    ].map(k => dcodeIO.ByteBuffer.wrap(k).toArrayBuffer());
+
+    if (envelope.source != StringView.arrayBufferToHex(identityKey)) {
+      throw new Error("Error in handlePreKeyBundleMessage: envelope pubkey does not match pubkey in prekey bundle");
+    }
+    const pubKey = envelope.source;
+
+    return await libloki.savePreKeyBundleForNumber({
+      pubKey,
+      preKeyId,
+      signedKeyId,
+      preKey,
+      signedKey,
+      signature,
+    });
   },
   isBlocked(number) {
     return textsecure.storage.get('blocked', []).indexOf(number) >= 0;

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -409,3 +409,6 @@ OutgoingMessage.prototype = {
     );
   },
 };
+
+window.textsecure = window.textsecure || {};
+window.textsecure.OutgoingMessage = OutgoingMessage;

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -116,7 +116,7 @@ OutgoingMessage.prototype = {
     if (updateDevices === undefined) {
       return this.server.getKeysForNumber(number).then(handleResult);
     }
-    let promise = Promise.resolve();
+    let promise = Promise.resolve(true);
     updateDevices.forEach(device => {
       promise = promise.then(() =>
         Promise.all([
@@ -217,7 +217,7 @@ OutgoingMessage.prototype = {
       request: requestMessage
     });
     const bytes = new Uint8Array(websocketMessage.encode().toArrayBuffer())
-    bytes.toString(); // print bytes for debugging purposes: can be injected in mock socket server 
+    console.log(bytes.toString()); // print bytes for debugging purposes: can be injected in mock socket server
     return bytes;
   },
   doSendMessage(number, deviceIds, recurse) {


### PR DESCRIPTION
First pass of handling incoming friend requests:

- decode prekeyBundleMessage (handlePreKeyBundleMessage)
- then store prekeys in db (savePreKeyBundleForNumber ) if not existing yet (lookup for a pubkey - keyId pair: loadContactPreKeys and loadContactSignedPreKeys)
- add a function to send an empty reply (sendEmptyMessageWithPreKeys) Not used yet.
- a couple of fixes for the previous PR