### PR TITLE
Lock input friend request

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -816,6 +816,14 @@
     "message": "Send a message",
     "description": "Placeholder text in the message entry field"
   },
+  "sendMessageDisabled": {
+    "message": "Waiting for friend request approval",
+    "description": "Placeholder text in the message entry field when it is disabled while we are waiting for a friend request approval"
+  },
+  "sendMessageFriendRequest": {
+    "message": "Hi there! This is <insert name here> !",
+    "description": "Placeholder text in the message entry field when it is the first message sent to that contact"
+  },
   "groupMembers": {
     "message": "Group members"
   },

--- a/background.html
+++ b/background.html
@@ -129,16 +129,16 @@
             <form class='send clearfix'>
               <div class='attachment-previews'></div>
               <div class='flex'>
-                <button class='emoji'></button>
-                <textarea class='send-message' placeholder='{{ send-message }}' rows='1' dir='auto'></textarea>
+                <button class='emoji' {{#disable-inputs}} disabled="disabled" {{/disable-inputs}}></button>
+                <textarea class='send-message' placeholder='{{ send-message }}' rows='1' dir='auto' {{#disable-inputs}} disabled="disabled" {{/disable-inputs}}></textarea>
                 <div class='capture-audio'>
-                    <button class='microphone'></button>
+                    <button class='microphone' {{#disable-inputs}} disabled="disabled" {{/disable-inputs}}></button>
                 </div>
                 <div class='android-length-warning'>
                     {{ android-length-warning }}
                 </div>
                 <div class='choose-file'>
-                    <button class='paperclip thumbnail'></button>
+                    <button class='paperclip thumbnail' {{#disable-inputs}} disabled="disabled" {{/disable-inputs}}></button>
                     <input type='file' class='file-input'>
                 </div>
               </div>

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -69,9 +69,16 @@
     },
     template: $('#conversation').html(),
     render_attributes() {
+      let sendMessagePlaceholder = 'sendMessageFriendRequest';
+      const sendDisabled = this.model.waitingForFriendRequestApproval();
+      if (sendDisabled) {
+        sendMessagePlaceholder = 'sendMessageDisabled';
+      } else if (this.model.getFriendRequestStatus() === null) {
+        sendMessagePlaceholder = 'sendMessage';
+      }
       return {
-        'disable-inputs': this.model.shouldDisableInputs(),
-        'send-message': i18n('sendMessage'),
+        'disable-inputs': sendDisabled,
+        'send-message': i18n(sendMessagePlaceholder),
         'android-length-warning': i18n('androidMessageLengthWarning'),
       };
     },
@@ -82,6 +89,7 @@
       this.listenTo(this.model, 'opened', this.onOpened);
       this.listenTo(this.model, 'prune', this.onPrune);
       this.listenTo(this.model, 'disable:input', this.onDisableInput);
+      this.listenTo(this.model, 'change:placeholder', this.onChangePlaceholder);
       this.listenTo(
         this.model.messageCollection,
         'show-identity',
@@ -281,6 +289,22 @@
 
     onDisableInput(disable) {
       this.$('button.emoji, button.microphone, button.paperclip, .send-message').attr('disabled', disable);
+    },
+
+    onChangePlaceholder(type) {
+      let placeholder;
+      switch (type) {
+        case 'friend-request':
+          placeholder = i18n('sendMessageFriendRequest');
+          break;
+        case 'disabled':
+          placeholder = i18n('sendMessageDisabled');
+          break;
+        default:
+          placeholder = i18n('sendMessage');
+          break;
+      }
+      this.$messageField.attr('placeholder', placeholder);
     },
 
     unload(reason) {

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -70,6 +70,7 @@
     template: $('#conversation').html(),
     render_attributes() {
       return {
+        'disable-inputs': this.model.shouldDisableInputs(),
         'send-message': i18n('sendMessage'),
         'android-length-warning': i18n('androidMessageLengthWarning'),
       };
@@ -80,6 +81,7 @@
       this.listenTo(this.model, 'newmessage', this.addMessage);
       this.listenTo(this.model, 'opened', this.onOpened);
       this.listenTo(this.model, 'prune', this.onPrune);
+      this.listenTo(this.model, 'disable:input', this.onDisableInput);
       this.listenTo(
         this.model.messageCollection,
         'show-identity',
@@ -275,6 +277,10 @@
       } else if (this.view.atBottom()) {
         this.trim();
       }
+    },
+
+    onDisableInput(disable) {
+      this.$('button.emoji, button.microphone, button.paperclip, .send-message').attr('disabled', disable);
     },
 
     unload(reason) {

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -365,18 +365,22 @@ OutgoingMessage.prototype = {
   },
 
   sendToNumber(number) {
+    let conversation;
+    try {
+      conversation = ConversationController.get(number);
+    } catch(e) {
+    }
+
     return this.getStaleDeviceIdsForNumber(number).then(updateDevices =>
       this.getKeysForNumber(number, updateDevices)
         .then(async (keysFound) =>  {
-          const conversation = ConversationController.get(number);
           let attachPrekeys = false;
           if (!keysFound)
           {
             log.info("Fallback encryption enabled");
-            conversation.onFriendRequestSent();
             this.fallBackEncryption = true;
             attachPrekeys = true;
-          } else {
+          } else if (conversation) {
             try {
               attachPrekeys = !conversation.isKeyExchangeCompleted();
             } catch(e) {
@@ -389,6 +393,11 @@ OutgoingMessage.prototype = {
             this.message.preKeyBundleMessage = await libloki.getPreKeyBundleForNumber(number);
           }
         }).then(this.reloadDevicesAndSend(number, true))
+        .then(() => {
+          if (this.fallBackEncryption && conversation) {
+            conversation.onFriendRequestSent();
+          }
+        })
         .catch(error => {
           if (error.message === 'Identity key changed') {
             // eslint-disable-next-line no-param-reassign

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -368,15 +368,16 @@ OutgoingMessage.prototype = {
     return this.getStaleDeviceIdsForNumber(number).then(updateDevices =>
       this.getKeysForNumber(number, updateDevices)
         .then(async (keysFound) =>  {
+          const conversation = ConversationController.get(number);
           let attachPrekeys = false;
           if (!keysFound)
           {
             log.info("Fallback encryption enabled");
+            conversation.friendRequestSent();
             this.fallBackEncryption = true;
             attachPrekeys = true;
           } else {
             try {
-              const conversation = ConversationController.get(number);
               attachPrekeys = !conversation.isKeyExchangeCompleted();
             } catch(e) {
               // do nothing

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -373,7 +373,7 @@ OutgoingMessage.prototype = {
           if (!keysFound)
           {
             log.info("Fallback encryption enabled");
-            conversation.friendRequestSent();
+            conversation.onFriendRequestSent();
             this.fallBackEncryption = true;
             attachPrekeys = true;
           } else {

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -283,7 +283,7 @@
     font-family: inherit;
 
     &[disabled='disabled'] {
-      background: transparent;
+      background: $color-light-35;
     }
   }
   .capture-audio {


### PR DESCRIPTION
This is a first implementation of the friend request lock, sender side (i.e. it does not yet check whether the friend request has been accepted).
Basically, this allows the user to send one message (the friend request message) then it locks the text editor until the timer expires (or onFriendRequestApproved is called)
This PR also changes the placeholder text in the editor, to display whether

1. the user is typing a friend request message
2. the editor is locked because we're waiting for a friend request approval
3. the user can just send messages at will