### PR TITLE
Friend req ttl

### DIFF
--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -190,11 +190,6 @@ MessageSender.prototype = {
       );
   },
 
-  retransmitMessage(number, jsonData, timestamp) {
-    const outgoing = new OutgoingMessage(this.server);
-    return outgoing.transmitMessage(number, jsonData, timestamp);
-  },
-
   validateRetryContentMessage(content) {
     // We want at least one field set, but not more than one
     let count = 0;


### PR DESCRIPTION
This is a simple change to have a default 4 day ttl for friend request messages
If no ttl is supplied to transmitMessage the default value will be 24 hours
Eventually the ttl will need to be able to be manually set by the user which could change the location of this logic (possibly just getting attached to this.ttl similar to timestamp etc?)
Also changed to simply grab the first outgoing object, in the future will either need to modify to work with multiple devices or simply refactor everything to not use device ids

The target calculation in proof-of-work.js lowers the target value as the ttl raises, the rate at which this happens will likely need to be fine tuned later down the track when we have more information about how much load in the network needs to be mitigated etc