### PR TITLE
change FRIEND_REQUEST value to prevent clash with upstream

### DIFF
--- a/libloki/libloki-protocol.js
+++ b/libloki/libloki-protocol.js
@@ -32,7 +32,7 @@
       ivAndCiphertext.set(new Uint8Array(ciphertext), iv.byteLength);
 
       return {
-        type: 6, // friend request
+        type: textsecure.protobuf.Envelope.Type.FRIEND_REQUEST, // friend request
         body: ivAndCiphertext,
         registrationId: null,
       };

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -12,7 +12,7 @@ message Envelope {
     PREKEY_BUNDLE = 3;
     RECEIPT       = 5;
     UNIDENTIFIED_SENDER = 6;
-    FRIEND_REQUEST = 7; // contains prekeys + message and is using simple encryption
+    FRIEND_REQUEST = 101; // contains prekeys + message and is using simple encryption
   }
 
   optional Type   type            = 1;


### PR DESCRIPTION
Following the latest merge with upstream, a new message type was introduced with value 6, clashing with our loki-specific FRIEND_REQUEST type.
This sets our FRIEND_REQUEST type to 101 to prevent clashing with future merges.