### PR TITLE
Clean up multi instance code.

### DIFF
--- a/config/development-1.json
+++ b/config/development-1.json
@@ -1,5 +1,5 @@
 {
-  "storageProfile": "development2",
+  "storageProfile": "development1",
   "disableAutoUpdate": true,
   "openDevTools": true
 }

--- a/main.js
+++ b/main.js
@@ -56,6 +56,7 @@ const importMode =
   process.argv.some(arg => arg === '--import') || config.get('import');
 
 const development = config.environment === 'development';
+const appInstance = config.util.getEnv('NODE_APP_INSTANCE') || 0;
 
 // We generally want to pull in our own modules after this point, after the user
 //   data directory has been set.
@@ -96,7 +97,7 @@ function showWindow() {
   }
 }
 
-if (!process.mas && !development) {
+if (!process.mas) {
   console.log('making app single instance');
   const shouldQuit = app.makeSingleInstance(() => {
     // Someone tried to run a second instance, we should focus our window
@@ -110,7 +111,7 @@ if (!process.mas && !development) {
     return true;
   });
 
-  if (shouldQuit) {
+  if (appInstance === 0 && shouldQuit) {
     console.log('quitting; we are the second instance');
     app.exit();
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "postinstall": "electron-builder install-app-deps && rimraf node_modules/dtrace-provider",
     "start": "electron .",
+    "start-multi": "NODE_APP_INSTANCE=1 electron .",
     "grunt": "grunt",
     "icon-gen": "electron-icon-maker --input=images/icon_1024.png --output=./build",
     "generate": "yarn icon-gen && yarn grunt",


### PR DESCRIPTION
This PR adds `yarn start-multi` command for easier launch.

Rather than setting `NODE_ENV`, we can instead set `NODE_APP_INSTANCE`.

This also fixes the problem where you can create multiple instances when using `production` environment.

