### PR TITLE
restore ciphertext padding

### DIFF
--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -705,16 +705,16 @@ MessageReceiver.prototype.extend({
     switch (envelope.type) {
       case textsecure.protobuf.Envelope.Type.CIPHERTEXT:
         window.log.info('message from', this.getEnvelopeId(envelope));
-        promise = sessionCipher.decryptWhisperMessage(ciphertext);
-        // TODO: restore unpadding (?)
-        // .then(this.unpad);
+        promise = sessionCipher.decryptWhisperMessage(ciphertext)
+          .then(this.unpad);
         break;
       case textsecure.protobuf.Envelope.Type.FRIEND_REQUEST:
         window.log.info('friend-request message from ', envelope.source);
         const fallBackSessionCipher = new libloki.FallBackSessionCipher(
           address
         );
-        promise = fallBackSessionCipher.decrypt(ciphertext.toArrayBuffer());
+        promise = fallBackSessionCipher.decrypt(ciphertext.toArrayBuffer())
+          .then(this.unpad);
         break;
       case textsecure.protobuf.Envelope.Type.PREKEY_BUNDLE:
         window.log.info('prekey message from', this.getEnvelopeId(envelope));
@@ -826,7 +826,6 @@ MessageReceiver.prototype.extend({
   },
   async decryptPreKeyWhisperMessage(ciphertext, sessionCipher, address) {
     const padded = await sessionCipher.decryptPreKeyWhisperMessage(ciphertext);
-    return padded;
 
     try {
       return this.unpad(padded);

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -207,13 +207,11 @@ OutgoingMessage.prototype = {
   getPlaintext() {
     if (!this.plaintext) {
       const messageBuffer = this.message.toArrayBuffer();
-      this.plaintext = new Uint8Array(messageBuffer.byteLength);
-      // TODO: figure out why we needed padding in the first place
-      // this.plaintext = new Uint8Array(
-      //   this.getPaddedMessageLength(messageBuffer.byteLength + 1) - 1
-      // );
+      this.plaintext = new Uint8Array(
+        this.getPaddedMessageLength(messageBuffer.byteLength + 1) - 1
+      );
       this.plaintext.set(new Uint8Array(messageBuffer));
-      // this.plaintext[messageBuffer.byteLength] = 0x80;
+      this.plaintext[messageBuffer.byteLength] = 0x80;
     }
     return this.plaintext;
   },


### PR DESCRIPTION
Initially commented out for debugging/development.
Now that we are getting things working, we want to restore padding.
The idea is keep the Signal crypto properties as pristine as possible.