### PR TITLE
create unique index for contact prekeys (to allow using REPLACE)

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -447,6 +447,11 @@ async function updateToSchemaVersion6(currentVersion, instance) {
     );`
   );
 
+  await instance.run(`CREATE UNIQUE INDEX contact_prekey_identity_key_string_keyid ON contactPreKeys (
+    identityKeyString,
+    keyId
+  );`);
+
   await instance.run(
     `CREATE TABLE contactSignedPreKeys(
       id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -455,6 +460,11 @@ async function updateToSchemaVersion6(currentVersion, instance) {
       json TEXT
     );`
   );
+
+  await instance.run(`CREATE UNIQUE INDEX contact_signed_prekey_identity_key_string_keyid ON contactSignedPreKeys (
+    identityKeyString,
+    keyId
+  );`);
 
   await instance.run('PRAGMA schema_version = 6;');
   await instance.run('COMMIT TRANSACTION;');


### PR DESCRIPTION
Currently, `addOrReplaceContact...` doesn't replace when providing an existing pair of (`keyIdentityString`, `keyId`), it just adds a new row.
This is because in SQL, `INSERT OR REPLACE INTO` works with unique indexes.
Tested by calling `window.textsecure.storage.protocol.storeContactPreKey` with various arguments, and verified that the values were updated when providing existing keyIdentityString,keyId.