### PR TITLE
Use correct log level in development mode

### DIFF
--- a/js/logging.js
+++ b/js/logging.js
@@ -53,6 +53,12 @@ function log(...args) {
 if (window.console) {
   console._log = console.log;
   console.log = log;
+  console._trace = console.trace;
+  console._debug = console.debug
+  console._info = console.info;
+  console._warn = console.warn;
+  console._error = console.error;
+  console._fatal = console.error;
 }
 
 // The mechanics of preparing a log for publish
@@ -95,12 +101,18 @@ function fetch() {
 }
 
 const publish = debuglogs.upload;
+const development = (window.getEnvironment() !== 'production');
 
 // A modern logging interface for the browser
 
 // The Bunyan API: https://github.com/trentm/node-bunyan#log-method-api
 function logAtLevel(level, prefix, ...args) {
-  console._log(prefix, now(), ...args);
+  if (development) {
+    const fn = `_${level}`;
+    console[fn](prefix, now(), ...args);
+  } else {
+    console._log(prefix, now(), ...args);
+  }
 
   const str = cleanArgsForIPC(args);
   const logText = Privacy.redactAll(str);

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -73,7 +73,7 @@ class LokiServer {
       timeout: undefined,
     };
 
-    log.info(options.type, options.url);
+    log.debug(options.type, options.url);
 
     const fetchOptions = {
       method: options.type,
@@ -108,7 +108,7 @@ class LokiServer {
     }
 
     if (response.status >= 0 && response.status < 400) {
-      log.info(options.type, options.url, response.status, 'Success');
+      log.debug(options.type, options.url, response.status, 'Success');
       return result;
     }
     log.error(options.type, options.url, response.status, 'Error');
@@ -126,7 +126,7 @@ class LokiServer {
       timeout: undefined,
     };
 
-    log.info(options.type, options.url);
+    log.debug(options.type, options.url);
 
     const headers = {
       'X-Loki-recipient': pubKey,
@@ -163,7 +163,7 @@ class LokiServer {
     }
 
     if (response.status >= 0 && response.status < 400) {
-      log.info(options.type, options.url, response.status, 'Success');
+      log.debug(options.type, options.url, response.status, 'Success');
       if (result.lastHash) {
         currentNode.lastHash = result.lastHash;
       }

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -365,7 +365,7 @@ MessageReceiver.prototype.extend({
     this.incoming = [];
 
     const dispatchEmpty = () => {
-      window.log.info("MessageReceiver: emitting 'empty' event");
+      window.log.debug("MessageReceiver: emitting 'empty' event");
       const ev = new Event('empty');
       return this.dispatchAndWait(ev);
     };


### PR DESCRIPTION
I noticed `log.warn` and `log.error` actually uses `console.log` under the hood.
This makes it all very difficult to filter the console by log level as well as spot actual warnings and errors.
This PR basically makes `log.xxx` actually use `console.xxx` when in development mode.
Production builds are left untouched as it is a best practice in the industry.

Additionally, this PR makes some logs use `log.debug` to filter out unimportant logs like HTTP polling, "empty"  events, etc.

BEFORE
<img width="709" alt="screen shot 2018-11-21 at 3 14 35 pm" src="https://user-images.githubusercontent.com/40749766/48818640-384e3580-eda0-11e8-804c-f497077cb421.png">
AFTER
<img width="714" alt="screen shot 2018-11-21 at 3 12 28 pm" src="https://user-images.githubusercontent.com/40749766/48818645-3d12e980-eda0-11e8-88da-df0c55be0177.png">
