### PR TITLE
Friend request fixes

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1590,6 +1590,10 @@
     "message": "Friend request declined",
     "description": "Shown in the conversation history when the user declines a friend request"
   },
+  "friendRequestExpired": {
+    "message": "Friend request expired",
+    "description": "Shown in the conversation history when the users friend request expires"
+  },
   "friendRequestNotificationTitle": {
     "message": "Friend request",
     "description": "Shown in a notification title when receiving a friend request"

--- a/js/background.js
+++ b/js/background.js
@@ -570,12 +570,6 @@
       }
     });
 
-    Whisper.events.on('showFriendRequest', friendRequest => {
-      if (appView) {
-        appView.showFriendRequest(friendRequest);
-      }
-    });
-
     Whisper.events.on('calculatingPoW', ({ pubKey, timestamp }) => {
       try {
         const conversation = ConversationController.get(pubKey);
@@ -1268,6 +1262,7 @@
       unidentifiedDeliveryReceived: data.unidentifiedDeliveryReceived,
       type: 'incoming',
       unread: 1,
+      preKeyBundle: data.preKeyBundle || null,
     };
 
     if (data.type === 'friend-request') {
@@ -1275,7 +1270,6 @@
         ...messageData,
         type: 'friend-request',
         friendStatus: 'pending',
-        preKeyBundle: data.preKeyBundle || null,
         direction: 'incoming',
       }
     }

--- a/js/background.js
+++ b/js/background.js
@@ -1259,7 +1259,7 @@
   async function initIncomingMessage(data, options = {}) {
     const { isError } = options;
 
-    const message = new Whisper.Message({
+    let messageData = {
       source: data.source,
       sourceDevice: data.sourceDevice,
       sent_at: data.timestamp,
@@ -1268,7 +1268,19 @@
       unidentifiedDeliveryReceived: data.unidentifiedDeliveryReceived,
       type: 'incoming',
       unread: 1,
-    });
+    };
+
+    if (data.type === 'friend-request') {
+      messageData = {
+        ...messageData,
+        type: 'friend-request',
+        friendStatus: 'pending',
+        preKeyBundle: data.preKeyBundle || null,
+        direction: 'incoming',
+      }
+    }
+
+    const message = new Whisper.Message(messageData);
 
     // If we don't return early here, we can get into infinite error loops. So, no
     //   delivery receipts for sealed sender errors.

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -80,7 +80,6 @@
         verified: textsecure.storage.protocol.VerifiedStatus.DEFAULT,
         isFriend: false,
         keyExchangeCompleted: false,
-        blockInput: false,
         unlockTimestamp: null, // Timestamp used for expiring friend requests.
       };
     },
@@ -1094,31 +1093,21 @@
         return true;
       });
     },
-    async updateBlockInput(blockInput) {
-      if (this.get('blockInput') === blockInput) return;
-      this.set({ blockInput });
-      await window.Signal.Data.updateConversation(this.id, this.attributes, {
-        Conversation: Whisper.Conversation,
-      });
-    },
     async updateTextInputState() {
       // Check if we need to disable the text field
       if (!this.isFriend()) {
         // Disable the input if we're waiting for friend request approval
         const waiting = await this.waitingForFriendRequestApproval();
         if (waiting) {
-          await this.updateBlockInput(true);
           this.trigger('disable:input', true);
           this.trigger('change:placeholder', 'disabled');
           return;
         }
         // Tell the user to introduce themselves
-        await this.updateBlockInput(false);
         this.trigger('disable:input', false);
         this.trigger('change:placeholder', 'friend-request');
         return;
       }
-      await this.updateBlockInput(false);
       this.trigger('disable:input', false);
       this.trigger('change:placeholder', 'chat');
     },

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -54,7 +54,7 @@
 
   /**
    * A few key things that need to be known in this is the difference
-   *  between isFriend() and isKeyExhangeCompleted().
+   *  between isFriend() and isKeyExchangeCompleted().
    *
    * `isFriend` returns whether we have accepted the other user as a friend.
    *    - This is implicitly checked by whether we have a session
@@ -464,6 +464,9 @@
       return this.get('keyExchangeCompleted') || false;
     },
     async setKeyExchangeCompleted(value) {
+      // Only update the value if it's different
+      if (this.get('keyExchangeCompleted') === value) return;
+
       this.set({ keyExchangeCompleted: value });
       await window.Signal.Data.updateConversation(this.id, this.attributes, {
         Conversation: Whisper.Conversation,

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -60,7 +60,7 @@
    *    - This is explicilty stored as a state in the conversation
    *
    * `isKeyExchangeCompleted` return whether we know for certain
-   *   that both of our preKeyBundles have been exhanged.
+   *   that both of our preKeyBundles have been exchanged.
    *    - This will be set when we receive a valid CIPHER or
    *      PREKEY_BUNDLE message from the other user.
    *        * Valid meaning we can decypher the message using the preKeys provided

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -62,13 +62,14 @@
    *
    * `isKeyExchangeCompleted` return whether we know for certain
    *   that both of our preKeyBundles have been exhanged.
-   *    - This will be set when we receive a valid CIPHER message from the other user.
+   *    - This will be set when we receive a valid CIPHER or
+   *      PREKEY_BUNDLE message from the other user.
    *        * Valid meaning we can decypher the message using the preKeys provided
    *           or the keys we have stored.
    *
    * `isFriend` will determine whether we should send a FRIEND_REQUEST message.
    *
-   * `isKeyExhangeCompleted` will determine whether we keep
+   * `isKeyExchangeCompleted` will determine whether we keep
    *   sending preKeyBundle to the other user.
    */
 
@@ -513,8 +514,9 @@
       // Update our local state
       await this.updatePendingFriendRequests();
 
-      // Send the notification
-      this.notifyFriendRequest(this.id, 'accepted')
+      // Send the notification if we had an outgoing friend request
+      if (pending.length > 0)
+        this.notifyFriendRequest(this.id, 'accepted')
     },
     async onFriendRequestSent() {
       return this.updateFriendRequestUI();
@@ -1224,7 +1226,7 @@
         );
 
         // We also need to update any outgoing pending requests and set them to denied.
-        //  when we get an incoming friend request.
+        // when we get an incoming friend request.
         const outgoing = await this.getPendingFriendRequests('outgoing');
         await Promise.all(
           outgoing.map(async request => {

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -57,8 +57,7 @@
    *  between isFriend() and isKeyExchangeCompleted().
    *
    * `isFriend` returns whether we have accepted the other user as a friend.
-   *    - This is implicitly checked by whether we have a session
-   *       or we have the preKeyBundle of the user.
+   *    - This is explicilty stored as a state in the conversation
    *
    * `isKeyExchangeCompleted` return whether we know for certain
    *   that both of our preKeyBundles have been exhanged.

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1227,15 +1227,7 @@
             hasVisualMediaAttachments: dataMessage.hasVisualMediaAttachments,
             quote: dataMessage.quote,
             schemaVersion: dataMessage.schemaVersion,
-            preKeyBundle: dataMessage.preKeyBundle || null,
           });
-
-          if (type === 'friend-request') {
-            message.set({
-              friendStatus: dataMessage.friendStatus,
-              direction: dataMessage.direction,
-            });
-          }
 
           if (type === 'outgoing') {
             const receipts = Whisper.DeliveryReceipts.forMessage(

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -297,34 +297,42 @@
       // It doesn't need anything right now!
       return {};
     },
+
+    async acceptFriendRequest() {
+      if (this.get('friendStatus') !== 'pending') return;
+      const conversation = this.getConversation();
+
+      this.set({ friendStatus: 'accepted' });
+      await window.Signal.Data.saveMessage(this.attributes, {
+        Message: Whisper.Message,
+      });
+
+      window.Whisper.events.trigger('friendRequestUpdated', {
+        pubKey: conversation.id,
+        ...this.attributes,
+      });
+    },
+    async declineFriendRequest() {
+      if (this.get('friendStatus') !== 'pending') return;
+      const conversation = this.getConversation();
+
+      this.set({ friendStatus: 'declined' });
+      await window.Signal.Data.saveMessage(this.attributes, {
+        Message: Whisper.Message,
+      });
+
+      window.Whisper.events.trigger('friendRequestUpdated', {
+        pubKey: conversation.id,
+        ...this.attributes,
+      });
+    },
     getPropsForFriendRequest() {
       const friendStatus = this.get('friendStatus') || 'pending';
       const direction = this.get('direction') || 'incoming';
       const conversation = this.getConversation();
 
-      const onAccept = async () => {
-        this.set({ friendStatus: 'accepted' });
-        await window.Signal.Data.saveMessage(this.attributes, {
-          Message: Whisper.Message,
-        });
-
-        window.Whisper.events.trigger('friendRequestUpdated', {
-          pubKey: conversation.id,
-          ...this.attributes,
-        });
-      };
-
-      const onDecline = async () => {
-        this.set({ friendStatus: 'declined' });
-        await window.Signal.Data.saveMessage(this.attributes, {
-          Message: Whisper.Message,
-        });
-
-        window.Whisper.events.trigger('friendRequestUpdated', {
-          pubKey: conversation.id,
-          ...this.attributes,
-        });
-      };
+      const onAccept = () => this.acceptFriendRequest();
+      const onDecline = () => this.declineFriendRequest()
 
       const onDeleteConversation = async () => {
         // Delete the whole conversation

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1227,7 +1227,16 @@
             hasVisualMediaAttachments: dataMessage.hasVisualMediaAttachments,
             quote: dataMessage.quote,
             schemaVersion: dataMessage.schemaVersion,
+            preKeyBundle: dataMessage.preKeyBundle || null,
           });
+
+          if (type === 'friend-request') {
+            message.set({
+              friendStatus: dataMessage.friendStatus,
+              direction: dataMessage.direction,
+            });
+          }
+
           if (type === 'outgoing') {
             const receipts = Whisper.DeliveryReceipts.forMessage(
               conversation,
@@ -1291,7 +1300,7 @@
               );
             }
           }
-          if (type === 'incoming') {
+          if (type === 'incoming' || type === 'friend-request') {
             const readSync = Whisper.ReadSyncs.forMessage(message);
             if (readSync) {
               if (

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -178,15 +178,5 @@
         });
       }
     },
-    async showFriendRequest({ pubKey, message, preKeyBundle, options }) {
-      const controller = window.ConversationController;
-      const conversation = await controller.getOrCreateAndWait(pubKey, 'private');
-      if (conversation) {
-        conversation.addFriendRequest(message, {
-          preKeyBundle: preKeyBundle || null,
-          ...options,
-        });
-      }
-    },
   });
 })();

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -70,10 +70,14 @@
     template: $('#conversation').html(),
     render_attributes() {
       let sendMessagePlaceholder = 'sendMessageFriendRequest';
-      if (this.model.isFriend()) {
+      const sendDisabled = this.model.get('blockInput');
+      if (sendDisabled) {
+        sendMessagePlaceholder = 'sendMessageDisabled';
+      } else if (this.model.isFriend()) {
         sendMessagePlaceholder = 'sendMessage';
       }
       return {
+        'disable-inputs': sendDisabled,
         'send-message': i18n(sendMessagePlaceholder),
         'android-length-warning': i18n('androidMessageLengthWarning'),
       };
@@ -139,6 +143,8 @@
       );
 
       this.render();
+
+      this.model.updateTextInputState();
 
       this.loadingScreen = new Whisper.ConversationLoadingScreen();
       this.loadingScreen.render();

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -70,14 +70,10 @@
     template: $('#conversation').html(),
     render_attributes() {
       let sendMessagePlaceholder = 'sendMessageFriendRequest';
-      const sendDisabled = this.model.waitingForFriendRequestApproval();
-      if (sendDisabled) {
-        sendMessagePlaceholder = 'sendMessageDisabled';
-      } else if (this.model.getFriendRequestStatus() === null) {
+      if (this.model.isFriend()) {
         sendMessagePlaceholder = 'sendMessage';
       }
       return {
-        'disable-inputs': sendDisabled,
         'send-message': i18n(sendMessagePlaceholder),
         'android-length-warning': i18n('androidMessageLengthWarning'),
       };
@@ -240,6 +236,8 @@
       this.$('.send-message').blur(this.unfocusBottomBar.bind(this));
 
       this.$emojiPanelContainer = this.$('.emoji-panel-container');
+
+      this.model.updateFriendRequestUI();
     },
 
     events: {

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -69,16 +69,9 @@
     },
     template: $('#conversation').html(),
     render_attributes() {
-      let sendMessagePlaceholder = 'sendMessageFriendRequest';
-      const sendDisabled = this.model.get('blockInput');
-      if (sendDisabled) {
-        sendMessagePlaceholder = 'sendMessageDisabled';
-      } else if (this.model.isFriend()) {
-        sendMessagePlaceholder = 'sendMessage';
-      }
       return {
-        'disable-inputs': sendDisabled,
-        'send-message': i18n(sendMessagePlaceholder),
+        'disable-inputs': false,
+        'send-message': i18n('sendMessage'),
         'android-length-warning': i18n('androidMessageLengthWarning'),
       };
     },

--- a/libloki/proof-of-work.js
+++ b/libloki/proof-of-work.js
@@ -4,7 +4,7 @@ const { BigInteger } = require('jsbn');
 
 const NONCE_LEN = 8;
 // Modify this value for difficulty scaling
-const NONCE_TRIALS = 1000;
+const NONCE_TRIALS = 10;
 
 // Increment Uint8Array nonce by 1 with carrying
 function incrementNonce(nonce) {

--- a/libloki/proof-of-work.js
+++ b/libloki/proof-of-work.js
@@ -4,7 +4,7 @@ const { BigInteger } = require('jsbn');
 
 const NONCE_LEN = 8;
 // Modify this value for difficulty scaling
-const NONCE_TRIALS = 10;
+const NONCE_TRIALS = 1000;
 
 // Increment Uint8Array nonce by 1 with carrying
 function incrementNonce(nonce) {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1048,7 +1048,7 @@ MessageReceiver.prototype.extend({
         // ref: libsignal-protocol.js:36120
         envelope.type === textsecure.protobuf.Envelope.Type.PREKEY_BUNDLE
       ) {
-      // We know for sure that keys are exhanged
+      // We know for sure that keys are exchanged
       if (conversation) {
         await conversation.setKeyExchangeCompleted(true);
 

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1020,12 +1020,13 @@ MessageReceiver.prototype.extend({
         );
       }
 
+      // Accept the friend request
+      if (conversation) {
+        await conversation.onFriendRequestAccepted();
+      }
+
       // Send a reply back
       libloki.sendEmptyMessageWithPreKeys(pubKey);
-
-      if (conversation) {
-        await conversation.updateFriendRequestUI();
-      }
     }
     window.log.info(`Friend request for ${pubKey} was ${message.friendStatus}`, message);
   },
@@ -1047,10 +1048,12 @@ MessageReceiver.prototype.extend({
         // ref: libsignal-protocol.js:36120
         envelope.type === textsecure.protobuf.Envelope.Type.PREKEY_BUNDLE
       ) {
-      // If we get a cipher text and we are friends then we can mark keys as exchanged
-      if (conversation && conversation.isFriend()) {
+      // We know for sure that keys are exhanged
+      if (conversation) {
         await conversation.setKeyExchangeCompleted(true);
-        await conversation.updateFriendRequestUI();
+
+        // TODO: We should probably set this based on the PKB type
+        await conversation.onFriendRequestAccepted();
       }
     }
 

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -202,15 +202,19 @@ OutgoingMessage.prototype = {
 
     return messagePartCount * 160;
   },
+  convertMessageToText(message) {
+    const messageBuffer = message.toArrayBuffer();
+    const plaintext = new Uint8Array(
+      this.getPaddedMessageLength(messageBuffer.byteLength + 1) - 1
+    );
+    plaintext.set(new Uint8Array(messageBuffer));
+    plaintext[messageBuffer.byteLength] = 0x80;
 
+    return plaintext;
+  },
   getPlaintext() {
     if (!this.plaintext) {
-      const messageBuffer = this.message.toArrayBuffer();
-      this.plaintext = new Uint8Array(
-        this.getPaddedMessageLength(messageBuffer.byteLength + 1) - 1
-      );
-      this.plaintext.set(new Uint8Array(messageBuffer));
-      this.plaintext[messageBuffer.byteLength] = 0x80;
+      this.plaintext = this.convertMessageToText(this.message);
     }
     return this.plaintext;
   },
@@ -275,6 +279,18 @@ OutgoingMessage.prototype = {
         const address = new libsignal.SignalProtocolAddress(number, deviceId);
         const ourKey = textsecure.storage.user.getNumber();
         const options = {};
+        const fallBackEncryption = new libloki.FallBackSessionCipher(address);
+
+        // Check if we need to attach the preKeys
+        let preKeys = {};
+        if (this.attachPrekeys) {
+          // Encrypt them with the fallback
+          const preKeyBundleMessage = await libloki.getPreKeyBundleForNumber(number);
+          const textBundle = this.convertMessageToText(preKeyBundleMessage);
+          const encryptedBundle = await fallBackEncryption.encrypt(textBundle);
+          preKeys = { preKeyBundleMessage: encryptedBundle.body };
+          window.log.info('attaching prekeys to outgoing message');
+        }
 
         // No limit on message keys if we're communicating with our other devices
         if (ourKey === number) {
@@ -283,7 +299,7 @@ OutgoingMessage.prototype = {
 
         let sessionCipher;
         if (this.fallBackEncryption) {
-          sessionCipher = new libloki.FallBackSessionCipher(address);
+          sessionCipher = fallBackEncryption;
         } else {
           sessionCipher = new libsignal.SessionCipher(
             textsecure.storage.protocol,
@@ -292,26 +308,26 @@ OutgoingMessage.prototype = {
           );
         }
         ciphers[address.getDeviceId()] = sessionCipher;
-        return sessionCipher
-          .encrypt(plaintext)
-          .then(ciphertext => {
-            if (!this.fallBackEncryption)
-              // eslint-disable-next-line no-param-reassign
-              ciphertext.body = new Uint8Array(
-                dcodeIO.ByteBuffer.wrap(
-                  ciphertext.body,
-                  'binary'
-                ).toArrayBuffer()
-              );
-            return ciphertext;
-          })
-          .then(ciphertext => ({
-            type: ciphertext.type,
-            ourKey,
-            sourceDevice: 1,
-            destinationRegistrationId: ciphertext.registrationId,
-            content: ciphertext.body,
-          }));
+
+        // Encrypt our plain text
+        const ciphertext = await sessionCipher.encrypt(plaintext);
+        if (!this.fallBackEncryption) {
+          // eslint-disable-next-line no-param-reassign
+          ciphertext.body = new Uint8Array(
+            dcodeIO.ByteBuffer.wrap(
+              ciphertext.body,
+              'binary'
+            ).toArrayBuffer()
+          );
+        }
+        return {
+          type: ciphertext.type, // FallBackSessionCipher sets this to FRIEND_REQUEST
+          ourKey,
+          sourceDevice: 1,
+          destinationRegistrationId: ciphertext.registrationId,
+          content: ciphertext.body,
+          ...preKeys,
+        };
       })
     )
       .then(async outgoingObjects => {
@@ -441,14 +457,14 @@ OutgoingMessage.prototype = {
     return this.getStaleDeviceIdsForNumber(number).then(updateDevices =>
       this.getKeysForNumber(number, updateDevices)
         .then(async keysFound => {
-          let attachPrekeys = false;
+          this.attachPrekeys = false;
           if (!keysFound) {
             log.info('Fallback encryption enabled');
             this.fallBackEncryption = true;
-            attachPrekeys = true;
+            this.attachPrekeys = true;
           } else if (conversation) {
             try {
-              attachPrekeys = !conversation.isKeyExchangeCompleted();
+              this.attachPrekeys = !conversation.isKeyExchangeCompleted();
             } catch (e) {
               // do nothing
             }
@@ -456,13 +472,6 @@ OutgoingMessage.prototype = {
 
           if (this.fallBackEncryption && conversation) {
             conversation.onFriendRequestSent();
-          }
-
-          if (attachPrekeys) {
-            log.info('attaching prekeys to outgoing message');
-            this.message.preKeyBundleMessage = await libloki.getPreKeyBundleForNumber(
-              number
-            );
           }
         })
         .then(this.reloadDevicesAndSend(number, true))

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -219,12 +219,16 @@ OutgoingMessage.prototype = {
     return this.plaintext;
   },
   async wrapInWebsocketMessage(outgoingObject) {
+    const preKeyEnvelope = outgoingObject.preKeyBundleMessage ? {
+      preKeyBundleMessage: outgoingObject.preKeyBundleMessage,
+    } : {};
     const messageEnvelope = new textsecure.protobuf.Envelope({
       type: outgoingObject.type,
       source: outgoingObject.ourKey,
       sourceDevice: outgoingObject.sourceDevice,
       timestamp: this.timestamp,
       content: outgoingObject.content,
+      ...preKeyEnvelope,
     });
     const requestMessage = new textsecure.protobuf.WebSocketRequestMessage({
       id: new Uint8Array(libsignal.crypto.getRandomBytes(1))[0], // random ID for now

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -475,7 +475,7 @@ OutgoingMessage.prototype = {
           }
 
           if (this.fallBackEncryption && conversation) {
-            conversation.onFriendRequestSent();
+            await conversation.onFriendRequestSent();
           }
         })
         .then(this.reloadDevicesAndSend(number, true))

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -468,7 +468,7 @@ OutgoingMessage.prototype = {
         .then(this.reloadDevicesAndSend(number, true))
         .catch(error => {
           if (this.fallBackEncryption && conversation) {
-            conversation.onFriendRequestTimedOut();
+            conversation.updateFriendRequestUI();
           }
           if (error.message === 'Identity key changed') {
             // eslint-disable-next-line no-param-reassign

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -9,7 +9,7 @@ message Envelope {
     UNKNOWN       = 0;
     CIPHERTEXT    = 1;
     KEY_EXCHANGE  = 2;
-    PREKEY_BUNDLE = 3;
+    PREKEY_BUNDLE = 3; //Used By Signal. DO NOT TOUCH! we don't use this at all.
     RECEIPT       = 5;
     UNIDENTIFIED_SENDER = 6;
     FRIEND_REQUEST = 101; // contains prekeys + message and is using simple encryption

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -24,6 +24,7 @@ message Envelope {
   optional bytes  content         = 8; // Contains an encrypted Content
   optional string serverGuid      = 9;
   optional uint64 serverTimestamp = 10;
+  optional PreKeyBundleMessage preKeyBundleMessage = 101;
 
 }
 
@@ -33,7 +34,6 @@ message Content {
   optional CallMessage    callMessage    = 3;
   optional NullMessage    nullMessage    = 4;
   optional ReceiptMessage receiptMessage = 5;
-  optional PreKeyBundleMessage preKeyBundleMessage = 6;
 }
 
 message PreKeyBundleMessage {

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -24,7 +24,7 @@ message Envelope {
   optional bytes  content         = 8; // Contains an encrypted Content
   optional string serverGuid      = 9;
   optional uint64 serverTimestamp = 10;
-  optional PreKeyBundleMessage preKeyBundleMessage = 101;
+  optional bytes preKeyBundleMessage = 101;
 
 }
 

--- a/ts/components/conversation/FriendRequest.tsx
+++ b/ts/components/conversation/FriendRequest.tsx
@@ -8,7 +8,7 @@ interface Props {
   text: string;
   direction: 'incoming' | 'outgoing';
   status: string;
-  friendStatus: 'pending' | 'accepted' | 'declined';
+  friendStatus: 'pending' | 'accepted' | 'declined' | 'expired';
   i18n: Localizer;
   onAccept: () => void;
   onDecline: () => void;
@@ -22,11 +22,13 @@ export class FriendRequest extends React.Component<Props> {
 
     switch (friendStatus) {
       case 'pending':
-        return `friendRequestPending`;
+        return 'friendRequestPending';
       case 'accepted':
-        return `friendRequestAccepted`;
+        return 'friendRequestAccepted';
       case 'declined':
-        return `friendRequestDeclined`;
+        return 'friendRequestDeclined';
+      case 'expired':
+        return 'friendRequestExpired'
       default:
         throw new Error(`Invalid friend request status: ${friendStatus}`);
     }
@@ -45,7 +47,6 @@ export class FriendRequest extends React.Component<Props> {
           <MessageBody text={text || ''} i18n={i18n} />
         </div>
       </div>
-      
     );
   }
 
@@ -137,7 +138,7 @@ export class FriendRequest extends React.Component<Props> {
 
   public render() {
     const { direction } = this.props;
-    
+
     return (
       <div
         className={classNames(
@@ -153,7 +154,7 @@ export class FriendRequest extends React.Component<Props> {
             'module-message-friend-request__container',
           )}
         >
-            <div 
+            <div
               className={classNames(
                 'module-message__text',
                 `module-message__text--${direction}`,


### PR DESCRIPTION
This PR fixes the logic issues with the previously implemented friend request.

I also refactored some things and moved the logic of adding friend requests out into `message_receiver` and `background`

The new logic is the following:

`isFriend = Whether we are friends`
`isKeyExchanged = No cipher text received`

- If not `isFriend` then use fallback encryption.
    - This sets the message type to `FRIEND_REQUEST`.
- For every message sent, if not `isKeyExchanged` then we attach `preKeyBundle` to the `Envelope`.
    - `preKeyBundle` used to be inside the `Envelope` content but was moved outside of it.
    - `preKeyBundle` is always encrypted using the fallback encryption.
- If we get an encrypted message from the other user then set `isKeyExchanged` to `true`.