### PR TITLE
Fix accessing $messageField before assignment

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -298,6 +298,8 @@
     },
 
     onChangePlaceholder(type) {
+      if (!this.$messageField)
+        return;
       let placeholder;
       switch (type) {
         case 'friend-request':


### PR DESCRIPTION
I was getting errors after refreshing the app with an existing conversation.
Basically `onChangePlaceholder` is triggered once before the `initialize` function has the chance to assign `this.$messageField`. Then it's triggered again twice, so I thought simply guarding `onChangePlaceholder` might be easier than changing the order in which stuff happens in `initialize`.
Thoughts?