### PR TITLE
Fix getKeysForNumber when staleDevices is not empty

### DIFF
--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -118,7 +118,7 @@ OutgoingMessage.prototype = {
             if (device.registrationId === 0) {
               window.log.info('device registrationId 0!');
             }
-            return builder.processPreKey(device).catch(error => {
+            return builder.processPreKey(device).then(() => true).catch(error => {
               if (error.message === 'Identity key changed') {
                 // eslint-disable-next-line no-param-reassign
                 error.timestamp = this.timestamp;
@@ -131,7 +131,7 @@ OutgoingMessage.prototype = {
             });
           }
 
-          return true;
+          return false;
         })
       );
     // TODO: check if still applicable
@@ -156,7 +156,7 @@ OutgoingMessage.prototype = {
               devices: [
                 { deviceId: device, preKey, signedPreKey, registrationId: 0 },
               ],
-            });
+            }).then(results => results.every(value => value === true));
           })
           .catch(e => {
             if (e.name === 'HTTPError' && e.code === 404) {


### PR DESCRIPTION
`getKeysForNumber` does not return a boolean consistently.
When the keys are actually present, but the device is marked as stale (e.g. there is no valid session yet) then the value returned is something like `[undefined, true]` (i.e. the return values of some functions). 
This PR simply merges the boolean values into one and makes sure that `true` is returned when everything goes according to plan.