### PR TITLE
Ensure the contact prekey returned is always the latest available

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -695,7 +695,7 @@ async function getContactPreKeyById(id) {
   return getById(CONTACT_PRE_KEYS_TABLE, id);
 }
 async function getContactPreKeyByIdentityKey(key) {
-  const row = await db.get(`SELECT * FROM ${CONTACT_PRE_KEYS_TABLE} WHERE identityKeyString = $identityKeyString;`, {
+  const row = await db.get(`SELECT * FROM ${CONTACT_PRE_KEYS_TABLE} WHERE identityKeyString = $identityKeyString ORDER BY keyId DESC LIMIT 1;`, {
     $identityKeyString: key,
   });
 


### PR DESCRIPTION
Tiny PR to support the following "session reset" reviews.

Basically, we want to ensure that the contact's prekeys we use are always the latest (highest keyId) available in the database.