### PR TITLE
Fix glitch in last message shown in conversation list

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1039,14 +1039,6 @@
         this.lastMessage = message.getNotificationText();
         this.lastMessageStatus = 'sending';
 
-        this.set({
-          active_at: now,
-          timestamp: now,
-        });
-        await window.Signal.Data.updateConversation(this.id, this.attributes, {
-          Conversation: Whisper.Conversation,
-        });
-
         if (this.isPrivate()) {
           message.set({ destination });
         }
@@ -1055,6 +1047,14 @@
           Message: Whisper.Message,
         });
         message.set({ id });
+
+        this.set({
+          active_at: now,
+          timestamp: now,
+        });
+        await window.Signal.Data.updateConversation(this.id, this.attributes, {
+          Conversation: Whisper.Conversation,
+        });
 
         // We're offline!
         if (!textsecure.messaging) {


### PR DESCRIPTION
(For posterity)
I noticed a glitch in the rendering of the last message shown in the conversation list, upon sending a new message.

Basically, the issue was simply ordering since we need to save the new message to database first before we update some timestamps on conversation, which triggers to fetch the last message from the database.