### PR TITLE
Clean up function names and loki store

### DIFF
--- a/background.html
+++ b/background.html
@@ -649,6 +649,7 @@
   <script type='text/javascript' src='js/storage.js'></script>
   <script type='text/javascript' src='js/legacy_storage.js'></script>
   <script type='text/javascript' src='js/signal_protocol_store.js'></script>
+  <script type='text/javascript' src='js/loki_protocol_store.js'></script>
   <script type='text/javascript' src='js/libtextsecure.js'></script>
   <script type='text/javascript' src='js/libloki.js'></script>
 

--- a/js/loki_protocol_store.js
+++ b/js/loki_protocol_store.js
@@ -1,0 +1,120 @@
+// eslint-disable-next-line func-names
+(function() {
+  'use strict';
+
+  const store = window.SignalProtocolStore.prototype;
+
+  store.storeContactPreKey = async (pubKey, preKey) => {
+    const key = {
+      // id: (autoincrement)
+      identityKeyString: pubKey,
+      publicKey: preKey.publicKey,
+      keyId: preKey.keyId,
+    };
+
+    await window.Signal.Data.createOrUpdateContactPreKey(key);
+  };
+
+  store.loadContactPreKey = async pubKey => {
+    const preKey = await window.Signal.Data.getContactPreKeyByIdentityKey(pubKey);
+    if (preKey) {
+      return {
+        id: preKey.id,
+        keyId: preKey.keyId,
+        publicKey: preKey.publicKey,
+        identityKeyString: preKey.identityKeyString,
+      }
+    }
+
+    window.log.warn('Failed to fetch contact prekey:', pubKey);
+    return undefined;
+  };
+
+  store.loadContactPreKeys = async filters => {
+    const { keyId, identityKeyString } = filters;
+    const keys = await window.Signal.Data.getContactPreKeys(keyId, identityKeyString);
+    if (keys) {
+      return keys.map(preKey => ({
+        id: preKey.id,
+        keyId: preKey.keyId,
+        publicKey: preKey.publicKey,
+        identityKeyString: preKey.identityKeyString,
+      }));
+    }
+
+    window.log.warn(
+      'Failed to fetch signed prekey with filters',
+      filters
+    );
+    return undefined;
+  };
+
+  store.removeContactPreKey = async pubKey => {
+    await window.Signal.Data.removeContactPreKeyByIdentityKey(pubKey);
+  };
+
+  store.clearContactPreKeysStore = async () => {
+    await window.Signal.Data.removeAllContactPreKeys();
+  };
+
+  store.storeContactSignedPreKey = async (pubKey, signedPreKey) => {
+    const key = {
+      // id: (autoincrement)
+      identityKeyString: pubKey,
+      keyId: signedPreKey.keyId,
+      publicKey: signedPreKey.publicKey,
+      signature: signedPreKey.signature,
+      created_at: Date.now(),
+      confirmed: false,
+    };
+    await window.Signal.Data.createOrUpdateContactSignedPreKey(key);
+  };
+
+  store.loadContactSignedPreKey = async pubKey => {
+    const preKey = await window.Signal.Data.getContactSignedPreKeyByIdentityKey(pubKey);
+    if (preKey) {
+      return {
+        id: preKey.id,
+        identityKeyString: preKey.identityKeyString,
+        publicKey: preKey.publicKey,
+        signature: preKey.signature,
+        created_at: preKey.created_at,
+        keyId: preKey.keyId,
+        confirmed: preKey.confirmed,
+      };
+    }
+    window.log.warn('Failed to fetch contact signed prekey:', pubKey);
+    return undefined;
+  };
+
+  store.loadContactSignedPreKeys = async filters => {
+    const { keyId, identityKeyString } = filters;
+    const keys = await window.Signal.Data.getContactSignedPreKeys(keyId, identityKeyString);
+    if (keys) {
+      return keys.map(preKey => ({
+        id: preKey.id,
+        identityKeyString: preKey.identityKeyString,
+        publicKey: preKey.publicKey,
+        signature: preKey.signature,
+        created_at: preKey.created_at,
+        keyId: preKey.keyId,
+        confirmed: preKey.confirmed,
+      }));
+    }
+
+    window.log.warn(
+      'Failed to fetch contact signed prekey with filters',
+      filters
+    );
+    return undefined;
+  };
+
+  store.removeContactSignedPreKey = async pubKey => {
+    await window.Signal.Data.removeContactSignedPreKeyByIdentityKey(pubKey);
+  };
+
+  store.clearContactSignedPreKeysStore = async () => {
+    await window.Signal.Data.removeAllContactSignedPreKeys();
+  };
+
+})();

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -513,7 +513,7 @@
         response: 'declined',
         direction: 'incoming',
       });
-      await window.libloki.removePreKeyBundleForNumber(this.id);
+      await window.libloki.removeContactPreKeyBundle(this.id);
     },
     // We have accepted an incoming friend request
     async onAcceptFriendRequest() {

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -183,11 +183,11 @@
       window.log.error('Failed to fetch prekey:', keyId);
       return undefined;
     },
-    async loadPreKeyForContactIdentityKeyString(contactIdentityKeyString) {
-      const key = await window.Signal.Data.getPreKeyByRecipient(contactIdentityKeyString);
+    async loadPreKeyForContact (contactPubKey) {
+      const key = await window.Signal.Data.getPreKeyByRecipient(contactPubKey);
 
       if (key) {
-        window.log.info('Successfully fetched prekey for recipient:', contactIdentityKeyString);
+        window.log.info('Successfully fetched prekey for recipient:', contactPubKey);
         return {
           pubKey: key.publicKey,
           privKey: key.privateKey,
@@ -198,54 +198,12 @@
 
       return undefined;
     },
-    async loadContactPreKey(pubKey) {
-      const preKey = await window.Signal.Data.getContactPreKeyByIdentityKey(pubKey);
-      if (preKey) {
-        return {
-          id: preKey.id,
-          keyId: preKey.keyId,
-          publicKey: preKey.publicKey,
-          identityKeyString: preKey.identityKeyString,
-        }
-      }
-
-      window.log.warn('Failed to fetch contact prekey:', pubKey);
-      return undefined;
-    },
-    async loadContactPreKeys(filters) {
-      const { keyId, identityKeyString } = filters;
-      const keys = await window.Signal.Data.getContactPreKeys(keyId, identityKeyString);
-      if (keys) {
-        return keys.map(preKey => ({
-          id: preKey.id,
-          keyId: preKey.keyId,
-          publicKey: preKey.publicKey,
-          identityKeyString: preKey.identityKeyString,
-        }));
-      }
-
-      window.log.warn(
-        'Failed to fetch signed prekey with filters',
-        filters
-      );
-      return undefined;
-    },
-    async storeContactPreKey(pubKey, preKey) {
-      const key = {
-        // id: (autoincrement)
-        identityKeyString: pubKey,
-        publicKey: preKey.publicKey,
-        keyId: preKey.keyId,
-      };
-
-      await window.Signal.Data.createOrUpdateContactPreKey(key);
-    },
-    async storePreKey(keyId, keyPair, contactIdentityKeyString) {
+    async storePreKey(keyId, keyPair, contactPubKey) {
       const data = {
         id: keyId,
         publicKey: keyPair.pubKey,
         privateKey: keyPair.privKey,
-        recipient: contactIdentityKeyString,
+        recipient: contactPubKey,
       };
 
       await window.Signal.Data.createOrUpdatePreKey(data);
@@ -265,14 +223,6 @@
     async clearPreKeyStore() {
       await window.Signal.Data.removeAllPreKeys();
     },
-
-    async removeContactPreKey(pubKey) {
-      await window.Signal.Data.removeContactPreKeyByIdentityKey(pubKey);
-    },
-    async clearContactPreKeysStore() {
-      await window.Signal.Data.removeAllContactPreKeys();
-    },
-
     /* Returns a signed keypair object or undefined */
     async loadSignedPreKey(keyId) {
       const key = await window.Signal.Data.getSignedPreKeyById(keyId);
@@ -289,43 +239,6 @@
       }
 
       window.log.error('Failed to fetch signed prekey:', keyId);
-      return undefined;
-    },
-    async loadContactSignedPreKeys(filters) {
-      const { keyId, identityKeyString } = filters;
-      const keys = await window.Signal.Data.getContactSignedPreKeys(keyId, identityKeyString);
-      if (keys) {
-        return keys.map(preKey => ({
-          id: preKey.id,
-          identityKeyString: preKey.identityKeyString,
-          publicKey: preKey.publicKey,
-          signature: preKey.signature,
-          created_at: preKey.created_at,
-          keyId: preKey.keyId,
-          confirmed: preKey.confirmed,
-        }));
-      }
-
-      window.log.warn(
-        'Failed to fetch contact signed prekey with filters',
-        filters
-      );
-      return undefined;
-    },
-    async loadContactSignedPreKey(pubKey) {
-      const preKey = await window.Signal.Data.getContactSignedPreKeyByIdentityKey(pubKey);
-      if (preKey) {
-        return {
-          id: preKey.id,
-          identityKeyString: preKey.identityKeyString,
-          publicKey: preKey.publicKey,
-          signature: preKey.signature,
-          created_at: preKey.created_at,
-          keyId: preKey.keyId,
-          confirmed: preKey.confirmed,
-        };
-      }
-      window.log.warn('Failed to fetch contact signed prekey:', pubKey);
       return undefined;
     },
     async loadSignedPreKeys() {
@@ -354,32 +267,12 @@
       };
       await window.Signal.Data.createOrUpdateSignedPreKey(key);
     },
-    async storeContactSignedPreKey(pubKey, signedPreKey) {
-      const key = {
-        // id: (autoincrement)
-        identityKeyString: pubKey,
-        keyId: signedPreKey.keyId,
-        publicKey: signedPreKey.publicKey,
-        signature: signedPreKey.signature,
-        created_at: Date.now(),
-        confirmed: false,
-      };
-      await window.Signal.Data.createOrUpdateContactSignedPreKey(key);
-    },
     async removeSignedPreKey(keyId) {
       await window.Signal.Data.removeSignedPreKeyById(keyId);
     },
     async clearSignedPreKeysStore() {
       await window.Signal.Data.removeAllSignedPreKeys();
     },
-
-    async removeContactSignedPreKey(pubKey) {
-      await window.Signal.Data.removeContactSignedPreKeyByIdentityKey(pubKey);
-    },
-    async clearContactSignedPreKeysStore() {
-      await window.Signal.Data.removeAllContactSignedPreKeys();
-    },
-
     async loadSession(encodedNumber) {
       if (encodedNumber === null || encodedNumber === undefined) {
         throw new Error('Tried to get session for undefined/null number');

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -183,7 +183,7 @@
       window.log.error('Failed to fetch prekey:', keyId);
       return undefined;
     },
-    async loadPreKeyForContact (contactPubKey) {
+    async loadPreKeyForContact(contactPubKey) {
       const key = await window.Signal.Data.getPreKeyByRecipient(contactPubKey);
 
       if (key) {

--- a/libloki/libloki-protocol.js
+++ b/libloki/libloki-protocol.js
@@ -46,7 +46,7 @@
     }
   }
 
-  async function getPreKeyBundleForNumber(pubKey) {
+  async function getPreKeyBundleForContact(pubKey) {
     const myKeyPair = await textsecure.storage.protocol.getIdentityKeyPair();
     const identityKey = myKeyPair.pubKey;
 
@@ -57,7 +57,7 @@
       textsecure.storage.protocol.loadSignedPreKey(signedKeyId),
       new Promise(async resolve => {
         // retrieve existing prekey if we already generated one for that recipient
-        const storedPreKey = await textsecure.storage.protocol.loadPreKeyForContactIdentityKeyString(
+        const storedPreKey = await textsecure.storage.protocol.loadPreKeyForContact(
           pubKey
         );
         if (storedPreKey) {
@@ -77,7 +77,7 @@
       }),
     ]);
 
-    const preKeyMessage = new textsecure.protobuf.PreKeyBundleMessage({
+    return {
       identityKey: new Uint8Array(identityKey),
       deviceId: 1, // TODO: fetch from somewhere
       preKeyId: preKey.keyId,
@@ -85,12 +85,10 @@
       preKey: new Uint8Array(preKey.pubKey),
       signedKey: new Uint8Array(signedKey.pubKey),
       signature: new Uint8Array(signedKey.signature),
-    });
-
-    return preKeyMessage;
+    };
   }
 
-  async function savePreKeyBundleForNumber({
+  async function saveContactPreKeyBundle({
     pubKey,
     preKeyId,
     preKey,
@@ -122,7 +120,7 @@
     await Promise.all([signedKeyPromise, preKeyPromise]);
   }
 
-  async function removePreKeyBundleForNumber(pubKey) {
+  async function removeContactPreKeyBundle(pubKey) {
     await Promise.all([
       textsecure.storage.protocol.removeContactPreKey(pubKey),
       textsecure.storage.protocol.removeContactSignedPreKey(pubKey),
@@ -156,9 +154,9 @@
   }
 
   window.libloki.FallBackSessionCipher = FallBackSessionCipher;
-  window.libloki.getPreKeyBundleForNumber = getPreKeyBundleForNumber;
+  window.libloki.getPreKeyBundleForContact = getPreKeyBundleForContact;
   window.libloki.FallBackDecryptionError = FallBackDecryptionError;
-  window.libloki.savePreKeyBundleForNumber = savePreKeyBundleForNumber;
-  window.libloki.removePreKeyBundleForNumber = removePreKeyBundleForNumber;
+  window.libloki.saveContactPreKeyBundle = saveContactPreKeyBundle;
+  window.libloki.removeContactPreKeyBundle = removeContactPreKeyBundle;
   window.libloki.sendFriendRequestAccepted = sendFriendRequestAccepted;
 })();

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1235,7 +1235,7 @@ MessageReceiver.prototype.extend({
       );
     }
 
-    await libloki.savePreKeyBundleForNumber({
+    await libloki.saveContactPreKeyBundle({
       pubKey,
       preKeyId,
       signedKeyId,

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -287,7 +287,9 @@ OutgoingMessage.prototype = {
         let sessionCipher;
         if (this.messageType === 'friend-request') {
           // Encrypt them with the fallback
-          this.message.preKeyBundleMessage = await libloki.getPreKeyBundleForNumber(number);
+          const pkb = await libloki.getPreKeyBundleForContact(number);
+          const preKeyBundleMessage = new textsecure.protobuf.PreKeyBundleMessage(pkb);
+          this.message.preKeyBundleMessage = preKeyBundleMessage;
           window.log.info('attaching prekeys to outgoing message');
           sessionCipher = fallBackCipher;
         } else {


### PR DESCRIPTION
More consistent naming of key storage functions, moved some loki messenger only functions into new file
Made getPreKeyBundleForContact return object rather than a proto to be consistent with other functions