### PR TITLE
set build dir to /release on win to align with other platforms

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ windows:
     - call yarn generate
     - call node build\grunt.js
     - call yarn prepare-beta-build
-    - call node_modules\.bin\build --config.extraMetadata.environment=%SIGNAL_ENV% --publish=never
+    - call node_modules\.bin\build --config.extraMetadata.environment=%SIGNAL_ENV% --publish=never --config.directories.output=release
     - call node build\grunt.js test-release:win
   cache:
     paths:


### PR DESCRIPTION
binaries are build under `/dist` by default.
Latest merge from upstream/textsecure changed the test to look under /release.