### PR TITLE
PoW statistical measurements

### DIFF
--- a/js/util_worker_tasks.js
+++ b/js/util_worker_tasks.js
@@ -41,6 +41,6 @@ function stringToArrayBufferBase64(string) {
 function arrayBufferToStringBase64(arrayBuffer) {
   return dcodeIO.ByteBuffer.wrap(arrayBuffer).toString('base64');
 }
-function calcPoW(timestamp, ttl, pubKey, data, development) {
-  return pow.calcPoW(timestamp, ttl, pubKey, data, development);
+function calcPoW(timestamp, ttl, pubKey, data, development, nonceTrial = undefined, increment = 1, nonceStartValue = 0) {
+  return pow.calcPoW(timestamp, ttl, pubKey, data, development, nonceTrial, increment, nonceStartValue);
 }

--- a/js/util_worker_tasks.js
+++ b/js/util_worker_tasks.js
@@ -41,6 +41,6 @@ function stringToArrayBufferBase64(string) {
 function arrayBufferToStringBase64(arrayBuffer) {
   return dcodeIO.ByteBuffer.wrap(arrayBuffer).toString('base64');
 }
-function calcPoW(timestamp, ttl, pubKey, data, development, nonceTrial = undefined, increment = 1, nonceStartValue = 0) {
-  return pow.calcPoW(timestamp, ttl, pubKey, data, development, nonceTrial, increment, nonceStartValue);
+function calcPoW(timestamp, ttl, pubKey, data, development, nonceTrials = undefined, increment = 1, startNonce = 0) {
+  return pow.calcPoW(timestamp, ttl, pubKey, data, development, nonceTrials, increment, startNonce);
 }

--- a/libloki/proof-of-work.js
+++ b/libloki/proof-of-work.js
@@ -80,7 +80,6 @@ const pow = {
       await crypto.subtle.digest('SHA-512', payload)
     );
     const innerPayload = new Uint8Array(initialHash.length + NONCE_LEN);
-    innerPayload.set(nonce);
     innerPayload.set(initialHash, NONCE_LEN);
     let resultHash;
     let nextNonce = nonce;

--- a/libloki/test/metrics.js
+++ b/libloki/test/metrics.js
@@ -1,0 +1,124 @@
+/* global dcodeIO, Plotly */
+let jobId = 0;
+let currentTrace = 0
+let plotlyDiv;
+const workers = [];
+async function run(messageLength, numWorkers = 1, nonceTrials=100) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const ttl = 4 * 24 * 60 * 60;
+  const pubKey = '05ec8635a07a13743516c7c9b3412f3e8252efb7fcaf67eb1615ffba62bebc6802';
+  const message = randomString(messageLength);
+  const messageBuffer = dcodeIO.ByteBuffer.wrap(message, 'utf8').toArrayBuffer();
+  const data = dcodeIO.ByteBuffer.wrap(messageBuffer).toString('base64');
+  const promises = [];
+  const t0 = performance.now();
+  for (let w = 0; w < numWorkers; w += 1) {
+    const worker = new Worker('../../js/util_worker.js');
+    workers.push(worker);
+    jobId += 1;
+    const increment = numWorkers;
+    const index = w;
+    worker.postMessage([jobId, 'calcPoW', timestamp, ttl, pubKey, data, false, nonceTrials, increment, index]);
+    const p = new Promise(resolve => {
+      worker.onmessage = (nonce) => {
+        resolve(nonce);
+      };
+    });
+    promises.push(p);
+  }
+  await Promise.race(promises);
+  const t1 = performance.now();
+  const duration = (t1 - t0) / 1000;
+  addPoint(duration);
+  // clean up
+  workers.forEach(worker => worker.terminate());
+}
+
+async function runPoW({ iteration, nonceTrials, numWorkers, messageLength = 50 }) {
+  const name = `W:${numWorkers} - NT: ${nonceTrials} - L:${messageLength}`;
+  Plotly.addTraces(plotlyDiv ,{
+    y: [],
+    type: 'box',
+    boxpoints: 'all',
+    name,
+  });
+  for (let i = 0; i < iteration; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await run(messageLength, numWorkers, nonceTrials);
+  }
+  currentTrace += 1;
+  console.log(`done for ${name}`);
+}
+
+
+function randomString(length) {
+  let text = '';
+  const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < length; i += 1)
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  return text;
+}
+
+function addPoint(duration) {
+  Plotly.extendTraces(plotlyDiv, {y: [[duration]]}, [currentTrace]);
+}
+async function startMessageLengthRun() {
+  const iteration0 = parseFloat(document.getElementById('iteration0').value);
+  const nonceTrials0 = parseFloat(document.getElementById('nonceTrials0').value);
+  const numWorkers0 = parseFloat(document.getElementById('numWorkers0').value);
+  const messageLengthStart0 = parseFloat(document.getElementById('messageLengthStart0').value);
+  const messageLengthStop0 = parseFloat(document.getElementById('messageLengthStop0').value);
+  const messageLengthStep0 = parseFloat(document.getElementById('messageLengthStep0').value);
+  for (let l = messageLengthStart0; l < messageLengthStop0; l += messageLengthStep0) {
+    // eslint-disable-next-line no-await-in-loop
+    await runPoW({ iteration: iteration0, nonceTrials: nonceTrials0, numWorkers: numWorkers0, messageLength: l });
+  }
+}
+async function startNumWorkerRun() {
+  const iteration1 = parseFloat(document.getElementById('iteration1').value);
+  const nonceTrials1 = parseFloat(document.getElementById('nonceTrials1').value);
+  const numWorkersStart1 = parseFloat(document.getElementById('numWorkersStart1').value);
+  const numWorkersEnd1 = parseFloat(document.getElementById('numWorkersEnd1').value);
+  const messageLength1 = parseFloat(document.getElementById('messageLength1').value);
+  for (let numWorkers = numWorkersStart1; numWorkers <= numWorkersEnd1; numWorkers +=1) {
+    // eslint-disable-next-line no-await-in-loop
+    await runPoW({ iteration: iteration1, nonceTrials: nonceTrials1, numWorkers, messageLength: messageLength1 });
+  }
+}
+async function startNonceTrialsRun() {
+  const iteration2 = parseFloat(document.getElementById('iteration2').value);
+  const messageLength2 = parseFloat(document.getElementById('messageLength2').value);
+  const numWorkers2 = parseFloat(document.getElementById('numWorkers2').value);
+  const nonceTrialsStart2 = parseFloat(document.getElementById('nonceTrialsStart2').value);
+  const nonceTrialsStop2 = parseFloat(document.getElementById('nonceTrialsStop2').value);
+  const nonceTrialsStep2 = parseFloat(document.getElementById('nonceTrialsStep2').value);
+  for (let n = nonceTrialsStart2; n < nonceTrialsStop2; n += nonceTrialsStep2) {
+    // eslint-disable-next-line no-await-in-loop
+    await runPoW({ iteration: iteration2, nonceTrials: n, numWorkers: numWorkers2, messageLength: messageLength2 });
+  }
+}
+async function start(index) {
+  const data = [];
+  const layout = {};
+  const options = {
+    responsive: true,
+  };
+  plotlyDiv =`plotly${index}`;
+  currentTrace = 0;
+  window.chart = Plotly.newPlot(plotlyDiv, data, layout, options);
+  workers.forEach(worker => worker.terminate());
+
+  switch(index) {
+    case 0:
+      await startMessageLengthRun();
+      break;
+    case 1:
+      await startNumWorkerRun();
+      break;
+    case 2:
+      await startNonceTrialsRun();
+      break;
+    default:
+      break;
+  }
+}

--- a/metrics.html
+++ b/metrics.html
@@ -1,0 +1,51 @@
+<html>
+
+<head>
+  <meta charset='utf-8'>
+  <title>pow calculations</title>
+  <style>
+    input[type=number] {
+      width: 50px;
+    }
+  </style>
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+</head>
+<body>
+  <h2>Influence of message length</h2>
+  <label for="iteration0">Iterations:</label><input name="iteration0" id ="iteration0" type="number" value="20"/>
+  <label for="nonceTrials0">Nonce Trials:</label><input name="nonceTrials0" id ="nonceTrials0" type="number" value="100"/>
+  <label for="numWorkers0">Number of workers:</label><input name="numWorkers0" id ="numWorkers0" type="number" value="1"/>
+  <label for="messageLengthStart0">Message length start:</label><input name="messageLengthStart0" id ="messageLengthStart0" type="number" value="50"/>
+  <label for="messageLengthStop0">Message length stop:</label><input name="messageLengthStop0" id ="messageLengthStop0" type="number" value="1000"/>
+  <label for="messageLengthStep0">Message length step:</label><input name="messageLengthStep0" id ="messageLengthStep0" type="number" value="100"/>
+  <br>
+  <button onclick="start(0)">Run</button>
+  <div id="plotly0"></div>
+
+  <h2>Influence of workers</h2>
+  <label for="iteration1">Iterations:</label><input name="iteration1" id ="iteration1" type="number" value="20"/>
+  <label for="nonceTrials1">Nonce Trials:</label><input name="nonceTrials1" id ="nonceTrials1" type="number" value="100"/>
+  <label for="numWorkersStart1">Number of workers start:</label><input name="numWorkersStart1" id ="numWorkersStart1" type="number" value="1"/>
+  <label for="numWorkersEnd1">Number of workers end:</label><input name="numWorkersEnd1" id ="numWorkersEnd1" type="number" value="4"/>
+  <label for="messageLength1">Message length stop:</label><input name="messageLength1" id ="messageLength1" type="number" value="100"/>
+  <br>
+  <button onclick="start(1)">Run</button>
+  <div id="plotly1"></div>
+
+  <h2>Influence of NonceTrials</h2>
+  <label for="iteration2">Iterations:</label><input name="iteration2" id ="iteration2" type="number" value="20"/>
+  <label for="messageLength2">Message length:</label><input name="messageLength2" id ="messageLength2" type="number" value="100"/>
+  <label for="numWorkers2">Number of workers:</label><input name="numWorkers2" id ="numWorkers2" type="number" value="1"/>
+  <label for="nonceTrialsStart2">Nonce Trials start:</label><input name="nonceTrialsStart2" id ="nonceTrialsStart2" type="number" value="10"/>
+  <label for="nonceTrialsStop2">Nonce Trials stop:</label><input name="nonceTrialsStop2" id ="nonceTrialsStop2" type="number" value="100"/>
+  <label for="nonceTrialsStep2">Nonce Trials step:</label><input name="nonceTrialsStep2" id ="nonceTrialsStep2" type="number" value="10"/>
+  <br>
+  <button onclick="start(2)">Run</button>
+  <div id="plotly2"></div>
+
+  <script type="text/javascript" src="libloki/test/components.js"></script>
+  <script type="text/javascript" src="libloki/proof-of-work.js"></script>
+
+  <script type="text/javascript" src="libloki/test/metrics.js"></script>
+</body>
+</html>

--- a/metrics_app.js
+++ b/metrics_app.js
@@ -1,0 +1,61 @@
+const http = require('http');
+const url = require('url');
+const fs = require('fs');
+const path = require('path');
+// you can pass the parameter in the command line. e.g. node static_server.js 3000
+const port = process.argv[3] || 9000;
+const hostname = process.argv[2] || 'localhost';
+// maps file extention to MIME types
+const mimeType = {
+  '.ico': 'image/x-icon',
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.css': 'text/css',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.wav': 'audio/wav',
+  '.mp3': 'audio/mpeg',
+  '.svg': 'image/svg+xml',
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.eot': 'appliaction/vnd.ms-fontobject',
+  '.ttf': 'aplication/font-sfnt'
+};
+http.createServer(function (req, res) {
+//   console.log(`${req.method} ${req.url}`);
+  // parse URL
+  const parsedUrl = url.parse(req.url);
+  // extract URL path
+  // Avoid https://en.wikipedia.org/wiki/Directory_traversal_attack
+  // e.g curl --path-as-is http://localhost:9000/../fileInDanger.txt
+  // by limiting the path to current directory only
+  const sanitizePath = path.normalize(parsedUrl.pathname).replace(/^(\.\.[\/\\])+/, '');
+  let pathname = path.join(__dirname, sanitizePath);
+  fs.exists(pathname, function (exist) {
+    if(!exist) {
+      // if the file is not found, return 404
+      res.statusCode = 404;
+      res.end(`File ${pathname} not found!`);
+      return;
+    }
+    // if is a directory, then look for index.html
+    if (fs.statSync(pathname).isDirectory()) {
+      pathname += '/index.html';
+    }
+    // read file from file system
+    fs.readFile(pathname, function(err, data){
+      if(err){
+        res.statusCode = 500;
+        res.end(`Error getting the file: ${err}.`);
+      } else {
+        // based on the URL path, extract the file extention. e.g. .js, .doc, ...
+        const ext = path.parse(pathname).ext;
+        // if the file is found, set Content-type and send data
+        res.setHeader('Content-type', mimeType[ext] || 'text/plain' );
+        res.end(data);
+      }
+    });
+  });
+}).listen(parseInt(port), hostname);
+console.log(`metrics running on http://${hostname}:${port}/metrics.html`);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "transpile": "tsc",
     "clean-transpile": "rimraf ts/**/*.js ts/*.js",
     "open-coverage": "open coverage/lcov-report/index.html",
-    "styleguide": "styleguidist server"
+    "styleguide": "styleguidist server",
+    "pow-metrics": "node metrics_app.js localhost 9000"
   },
   "dependencies": {
     "@journeyapps/sqlcipher": "https://github.com/scottnonnenberg-signal/node-sqlcipher.git#ed4f4d179ac010c6347b291cbd4c2ebe5c773741",


### PR DESCRIPTION
As PoW might become a recurrent issue (too long - not long enough - too dependent on the computer) it might be nice to gather and display some data locally:
run `yarn pow-metrics` and go to `http://localhost:9000/metrics.html` to see the dashboard (fancy name *cough* *cough*).

You can customise the different settings for each test.
The idea is to isolate the influence of one parameter at a time, by keeping everything else constant.
<img width="557" alt="screen shot 2018-12-20 at 3 51 53 pm" src="https://user-images.githubusercontent.com/40749766/50264550-5080a580-046f-11e9-8448-cbbae74524ef.png">

I made some changes to the pow logic:
- ability to specify a nounceTrials, an nonce increment and start value (for multi-workers)
- ability to increment a uint8array by any integer, not just by 1.
- actually calculate the hash for the initial value of the nonce (we were incrementing the nonce before actually trying anything)