### PR TITLE
Added travis_wait on windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,5 @@ matrix:
       os: windows
       env:
         - YARN_GPG=no
+      install:
+        - travis_wait 30 yarn install --frozen-lockfile --network-timeout 1000000


### PR DESCRIPTION
resolves #118.

We won't be able to see the travis output until the job has been completed with this change.