### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ cache:
     - node_modules
 node_js:
   - '10.13.0'
-os:
-  - linux
-dist: trusty
 install:
-  - yarn install --frozen-lockfile --network-timeout 1000000
+  - travis_wait 30 yarn install --frozen-lockfile --network-timeout 1000000
 script:
   - yarn generate
   - yarn test
@@ -37,5 +34,3 @@ matrix:
       os: windows
       env:
         - YARN_GPG=no
-      install:
-        - travis_wait 30 yarn install --frozen-lockfile --network-timeout 1000000


### PR DESCRIPTION
The previous travis PR didn't fix the timeouts on windows.

This change makes it so we use `travis_wait` globally.