### PR TITLE
Swarm requests

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -81,6 +81,8 @@ module.exports = {
   removeSessionsByNumber,
   removeAllSessions,
 
+  getSwarmNodesByPubkey,
+
   getConversationCount,
   saveConversation,
   saveConversations,
@@ -385,6 +387,7 @@ async function updateToSchemaVersion4(currentVersion, instance) {
       type STRING,
       members TEXT,
       name TEXT,
+      swarmNodes TEXT,
       profileName TEXT
     );`
   );
@@ -1025,6 +1028,18 @@ async function removeAllFromTable(table) {
 
 // Conversations
 
+async function getSwarmNodesByPubkey(pubkey) {
+  const row = await db.get('SELECT * FROM conversations WHERE id = $pubkey;', {
+    $pubkey: pubkey,
+  });
+
+  if (!row) {
+    return null;
+  }
+
+  return jsonToObject(row.json).swarmNodes;
+}
+
 async function getConversationCount() {
   const row = await db.get('SELECT count(*) from conversations;');
 
@@ -1037,7 +1052,7 @@ async function getConversationCount() {
 
 async function saveConversation(data) {
   // eslint-disable-next-line camelcase
-  const { id, active_at, type, members, name, friendRequestStatus, profileName } = data;
+  const { id, active_at, type, members, name, friendRequestStatus, swarmNodes, profileName } = data;
 
   await db.run(
     `INSERT INTO conversations (
@@ -1049,6 +1064,7 @@ async function saveConversation(data) {
     members,
     name,
     friendRequestStatus,
+    swarmNodes,
     profileName
   ) values (
     $id,
@@ -1059,6 +1075,7 @@ async function saveConversation(data) {
     $members,
     $name,
     $friendRequestStatus,
+    $swarmNodes,
     $profileName
   );`,
     {
@@ -1070,6 +1087,7 @@ async function saveConversation(data) {
       $members: members ? members.join(' ') : null,
       $name: name,
       $friendRequestStatus: friendRequestStatus,
+      $swarmNodes: swarmNodes ? swarmNodes.join(' ') : null,
       $profileName: profileName,
     }
   );
@@ -1093,7 +1111,7 @@ async function saveConversations(arrayOfConversations) {
 
 async function updateConversation(data) {
   // eslint-disable-next-line camelcase
-  const { id, active_at, type, members, name, friendRequestStatus, profileName } = data;
+  const { id, active_at, type, members, name, friendRequestStatus, swarmNodes, profileName } = data;
 
   await db.run(
     `UPDATE conversations SET
@@ -1104,6 +1122,7 @@ async function updateConversation(data) {
     members = $members,
     name = $name,
     friendRequestStatus = $friendRequestStatus,
+    swarmNodes = $swarmNodes,
     profileName = $profileName
   WHERE id = $id;`,
     {
@@ -1115,6 +1134,7 @@ async function updateConversation(data) {
       $members: members ? members.join(' ') : null,
       $name: name,
       $friendRequestStatus: friendRequestStatus,
+      $swarmNodes: swarmNodes ? swarmNodes.join(' ') : null,
       $profileName: profileName,
     }
   );

--- a/app/sql.js
+++ b/app/sql.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');

--- a/app/sql.js
+++ b/app/sql.js
@@ -387,7 +387,6 @@ async function updateToSchemaVersion4(currentVersion, instance) {
       type STRING,
       members TEXT,
       name TEXT,
-      swarmNodes TEXT,
       profileName TEXT
     );`
   );
@@ -1052,7 +1051,7 @@ async function getConversationCount() {
 
 async function saveConversation(data) {
   // eslint-disable-next-line camelcase
-  const { id, active_at, type, members, name, friendRequestStatus, swarmNodes, profileName } = data;
+  const { id, active_at, type, members, name, friendRequestStatus, profileName } = data;
 
   await db.run(
     `INSERT INTO conversations (
@@ -1064,7 +1063,6 @@ async function saveConversation(data) {
     members,
     name,
     friendRequestStatus,
-    swarmNodes,
     profileName
   ) values (
     $id,
@@ -1075,7 +1073,6 @@ async function saveConversation(data) {
     $members,
     $name,
     $friendRequestStatus,
-    $swarmNodes,
     $profileName
   );`,
     {
@@ -1087,7 +1084,6 @@ async function saveConversation(data) {
       $members: members ? members.join(' ') : null,
       $name: name,
       $friendRequestStatus: friendRequestStatus,
-      $swarmNodes: swarmNodes ? swarmNodes.join(' ') : null,
       $profileName: profileName,
     }
   );
@@ -1111,7 +1107,7 @@ async function saveConversations(arrayOfConversations) {
 
 async function updateConversation(data) {
   // eslint-disable-next-line camelcase
-  const { id, active_at, type, members, name, friendRequestStatus, swarmNodes, profileName } = data;
+  const { id, active_at, type, members, name, friendRequestStatus, profileName } = data;
 
   await db.run(
     `UPDATE conversations SET
@@ -1122,7 +1118,6 @@ async function updateConversation(data) {
     members = $members,
     name = $name,
     friendRequestStatus = $friendRequestStatus,
-    swarmNodes = $swarmNodes,
     profileName = $profileName
   WHERE id = $id;`,
     {
@@ -1134,7 +1129,6 @@ async function updateConversation(data) {
       $members: members ? members.join(' ') : null,
       $name: name,
       $friendRequestStatus: friendRequestStatus,
-      $swarmNodes: swarmNodes ? swarmNodes.join(' ') : null,
       $profileName: profileName,
     }
   );

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,8 @@
 {
-  "serverUrl": "http://localhost:8080",
-  "cdnUrl": "http://localhost",
+  "serverUrl": "http://qp994mrc8z7fqmsynzdumd35b5918q599gno46br86e537f7qzzy.snode",
+  "cdnUrl": "http://qp994mrc8z7fqmsynzdumd35b5918q599gno46br86e537f7qzzy.snode",
+  "messageServerPort": ":8080",
+  "swarmServerPort": ":8079",
   "disableAutoUpdate": false,
   "openDevTools": false,
   "buildExpiration": 0,

--- a/config/default.json
+++ b/config/default.json
@@ -1,8 +1,8 @@
 {
-  "serverUrl": "http://qp994mrc8z7fqmsynzdumd35b5918q599gno46br86e537f7qzzy.snode",
-  "cdnUrl": "http://qp994mrc8z7fqmsynzdumd35b5918q599gno46br86e537f7qzzy.snode",
-  "messageServerPort": ":8080",
-  "swarmServerPort": ":8079",
+  "serverUrl": "random.snode",
+  "cdnUrl": "random.snode",
+  "messageServerPort": "8080",
+  "swarmServerPort": "8079",
   "disableAutoUpdate": false,
   "openDevTools": false,
   "buildExpiration": 0,

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -174,6 +174,7 @@
           return conversation;
         }
 
+        conversation.refreshSwarmNodes();
         try {
           await window.Signal.Data.saveConversation(conversation.attributes, {
             Conversation: Whisper.Conversation,

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -174,7 +174,7 @@
           return conversation;
         }
 
-        conversation.refreshSwarmNodes();
+        window.libloki.replenishSwarm(id);
         try {
           await window.Signal.Data.saveConversation(conversation.attributes, {
             Conversation: Whisper.Conversation,

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -174,7 +174,7 @@
           return conversation;
         }
 
-        window.libloki.replenishSwarm(id);
+        window.LokiSnodeAPI.replenishSwarm(id);
         try {
           await window.Signal.Data.saveConversation(conversation.attributes, {
             Conversation: Whisper.Conversation,

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -86,7 +86,7 @@
         friendRequestStatus: FriendRequestStatusEnum.none,
         unlockTimestamp: null, // Timestamp used for expiring friend requests.
         sessionResetStatus: SessionResetEnum.none,
-        swarmNodes: [],
+        swarmNodes: new Set([]),
       };
     },
 

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1200,9 +1200,6 @@
 
         // Add the message sending on another queue so that our UI doesn't get blocked
         this.queueMessageSend(async () => {
-          if (this.get('swarmNodes').length === 0) {
-            await window.libloki.replenishSwarm(destination);
-          }
           message.send(
             this.wrapSend(
               sendFunction(

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -86,6 +86,8 @@
         friendRequestStatus: FriendRequestStatusEnum.none,
         unlockTimestamp: null, // Timestamp used for expiring friend requests.
         sessionResetStatus: SessionResetEnum.none,
+        swarmNodes: [],
+        refreshPromise: null,
       };
     },
 
@@ -578,6 +580,22 @@
         default:
           throw new Error('Invalid friend request state');
       }
+    },
+    async refreshSwarmNodes() {
+      // Refresh promise to ensure that we are only doing a single query at a time
+      let refreshPromise = this.get('refreshPromise');
+      if (refreshPromise === null) {
+        refreshPromise = (async () => {
+          const newSwarmNodes = await window.LokiAPI.getSwarmNodes(this.id);
+          this.set({ swarmNodes: _.union(this.get('swarmNodes'), newSwarmNodes) });
+          await window.Signal.Data.updateConversation(this.id, this.attributes, {
+            Conversation: Whisper.Conversation,
+          });
+        })();
+        this.set({ refreshPromise });
+      }
+      await refreshPromise;
+      this.set({ refreshPromise: null });
     },
     async setFriendRequestStatus(newStatus) {
       // Ensure that the new status is a valid FriendStatusEnum value
@@ -1198,7 +1216,10 @@
         options.messageType = message.get('type');
 
         // Add the message sending on another queue so that our UI doesn't get blocked
-        this.queueMessageSend(async () =>
+        this.queueMessageSend(async () => {
+          if (this.get('swarmNodes').length === 0) {
+            await this.refreshSwarmNodes();
+          }
           message.send(
             this.wrapSend(
               sendFunction(
@@ -1213,7 +1234,7 @@
               )
             )
           )
-        );
+        });
 
         return true;
       });

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -656,8 +656,21 @@ async function removeAllSessions(id) {
 
 // Conversation
 
+function setifyProperty(data, propertyName) {
+  if (!data) return data;
+  const returnData = data;
+  if (returnData[propertyName]) {
+    returnData[propertyName] = new Set(returnData[propertyName]);
+  }
+  return returnData;
+}
+
 async function getSwarmNodesByPubkey(pubkey) {
-  return channels.getSwarmNodesByPubkey(pubkey);
+  let swarmNodes = await channels.getSwarmNodesByPubkey(pubkey);
+  if (Array.isArray(swarmNodes)) {
+    swarmNodes = new Set(swarmNodes);
+  }
+  return swarmNodes;
 }
 
 async function getConversationCount() {
@@ -665,7 +678,11 @@ async function getConversationCount() {
 }
 
 async function saveConversation(data) {
-  await channels.saveConversation(data);
+  const storeData = data;
+  if (storeData.swarmNodes) {
+    storeData.swarmNodes = Array.from(storeData.swarmNodes);
+  }
+  await channels.saveConversation(storeData);
 }
 
 async function saveConversations(data) {
@@ -673,7 +690,7 @@ async function saveConversations(data) {
 }
 
 async function getConversationById(id, { Conversation }) {
-  const data = await channels.getConversationById(id);
+  const data = setifyProperty(await channels.getConversationById(id), 'swarmNodes');
   return new Conversation(data);
 }
 
@@ -684,6 +701,9 @@ async function updateConversation(id, data, { Conversation }) {
   }
 
   const merged = merge({}, existing.attributes, data);
+  if (merged.swarmNodes instanceof Set) {
+    merged.swarmNodes = Array.from(merged.swarmNodes);
+  }
   await channels.updateConversation(merged);
 }
 
@@ -704,7 +724,8 @@ async function _removeConversations(ids) {
 }
 
 async function getAllConversations({ ConversationCollection }) {
-  const conversations = await channels.getAllConversations();
+  const conversations = (await channels.getAllConversations())
+    .map(c => setifyProperty(c, 'swarmNodes'));
 
   const collection = new ConversationCollection();
   collection.add(conversations);
@@ -717,7 +738,8 @@ async function getAllConversationIds() {
 }
 
 async function getAllPrivateConversations({ ConversationCollection }) {
-  const conversations = await channels.getAllPrivateConversations();
+  const conversations = (await channels.getAllPrivateConversations())
+    .map(c => setifyProperty(c, 'swarmNodes'));
 
   const collection = new ConversationCollection();
   collection.add(conversations);
@@ -725,7 +747,8 @@ async function getAllPrivateConversations({ ConversationCollection }) {
 }
 
 async function getAllGroupsInvolvingId(id, { ConversationCollection }) {
-  const conversations = await channels.getAllGroupsInvolvingId(id);
+  const conversations = (await channels.getAllGroupsInvolvingId(id))
+    .map(c => setifyProperty(c, 'swarmNodes'));
 
   const collection = new ConversationCollection();
   collection.add(conversations);
@@ -733,7 +756,8 @@ async function getAllGroupsInvolvingId(id, { ConversationCollection }) {
 }
 
 async function searchConversations(query, { ConversationCollection }) {
-  const conversations = await channels.searchConversations(query);
+  const conversations = (await channels.searchConversations(query))
+    .map(c => setifyProperty(c, 'swarmNodes'));
 
   const collection = new ConversationCollection();
   collection.add(conversations);

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -108,6 +108,8 @@ module.exports = {
   removeSessionsByNumber,
   removeAllSessions,
 
+  getSwarmNodesByPubkey,
+
   getConversationCount,
   saveConversation,
   saveConversations,
@@ -653,6 +655,10 @@ async function removeAllSessions(id) {
 }
 
 // Conversation
+
+async function getSwarmNodesByPubkey(pubkey) {
+  return channels.getSwarmNodesByPubkey(pubkey);
+}
 
 async function getConversationCount() {
   return channels.getConversationCount();

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -690,7 +690,8 @@ async function saveConversations(data) {
 }
 
 async function getConversationById(id, { Conversation }) {
-  const data = setifyProperty(await channels.getConversationById(id), 'swarmNodes');
+  const rawData = await channels.getConversationById(id)
+  const data = setifyProperty(rawData, 'swarmNodes');
   return new Conversation(data);
 }
 

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -1,90 +1,25 @@
+/* eslint-disable no-await-in-loop */
 /* global log, dcodeIO, window, callWorker */
 
 const fetch = require('node-fetch');
-const is = require('@sindresorhus/is');
 
-class LokiServer {
+// eslint-disable-next-line
+const invert  = p  => new Promise((res, rej) => p.then(rej, res));
+const firstOf = ps => invert(Promise.all(ps.map(invert)));
 
-  constructor({ urls, messageServerPort, swarmServerPort }) {
-    this.nodes = [];
-    this.messageServerPort = messageServerPort;
-    this.swarmServerPort = swarmServerPort;
-    urls.forEach(url => {
-      if (!is.string(url)) {
-        throw new Error('WebAPI.initialize: Invalid server url');
-      }
-      this.nodes.push({ url });
-    });
-  }
+// Will be raised (to 3?) when we get more nodes
+const MINIMUM_SUCCESSFUL_REQUESTS = 2;
+class LokiMessageAPI {
 
-  async loadOurSwarm() {
-    const ourKey = window.textsecure.storage.user.getNumber();
-    const nodeAddresses = await this.getSwarmNodes(ourKey);
-    this.ourSwarmNodes = [];
-    nodeAddresses.forEach(url => {
-      this.ourSwarmNodes.push({ url });
-    })
-  }
-
-  async getSwarmNodes(pubKey) {
-    const currentNode = this.nodes[0];
-
-    const options = {
-      url: `${currentNode.url}${this.swarmServerPort}/json_rpc`,
-      type: 'POST',
-      responseType: 'json',
-      timeout: undefined,
-    };
-
-    const body = {
-      jsonrpc: '2.0',
-      id: '0',
-      method: 'get_swarm_list_for_messenger_pubkey',
-      params: {
-        pubkey: pubKey,
-      },
-    }
-
-    const fetchOptions = {
-      method: options.type,
-      body: JSON.stringify(body),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      timeout: options.timeout,
-    };
-
-    let response;
-    try {
-      response = await fetch(options.url, fetchOptions);
-    } catch (e) {
-      log.error(options.type, options.url, 0, 'Error');
-      throw HTTPError('fetch error', 0, e.toString());
-    }
-
-    let result;
-    if (
-      options.responseType === 'json' &&
-      response.headers.get('Content-Type') === 'application/json'
-    ) {
-      result = await response.json();
-    } else if (options.responseType === 'arraybuffer') {
-      result = await response.buffer();
-    } else {
-      result = await response.text();
-    }
-
-    if (response.status >= 0 && response.status < 400) {
-      return result.nodes;
-    }
-    log.error(options.type, options.url, response.status, 'Error');
-    throw HTTPError('sendMessage: error response', response.status, result);
+  constructor({ messageServerPort }) {
+    this.messageServerPort = messageServerPort
+      ? `:${messageServerPort}`
+      : '';
   }
 
   async sendMessage(pubKey, data, messageTimeStamp, ttl) {
-    const swarmNodes = await window.Signal.Data.getSwarmNodesByPubkey(pubKey);
+    const swarmNodes = await window.LokiSnodeAPI.getSwarmNodesByPubkey(pubKey)
     if (!swarmNodes || swarmNodes.length === 0) {
-      // TODO: Refresh the swarm nodes list
       throw Error('No swarm nodes to query!');
     }
 
@@ -101,110 +36,143 @@ class LokiServer {
       nonce = await callWorker('calcPoW', timestamp, ttl, pubKey, data64, development);
     } catch (err) {
       // Something went horribly wrong
-      // TODO: Handle gracefully
       throw err;
     }
 
-    const options = {
-      url: `${swarmNodes[0]}${this.messageServerPort}/store`,
-      type: 'POST',
-      responseType: undefined,
-      timeout: undefined,
-    };
+    const requests = swarmNodes.map(async node => {
+      const options = {
+        url: `${node}${this.messageServerPort}/store`,
+        type: 'POST',
+        responseType: undefined,
+        timeout: undefined,
+      };
 
-    const fetchOptions = {
-      method: options.type,
-      body: data64,
-      headers: {
-        'X-Loki-pow-nonce': nonce,
-        'X-Loki-timestamp': timestamp.toString(),
-        'X-Loki-ttl': ttl.toString(),
-        'X-Loki-recipient': pubKey,
-      },
-      timeout: options.timeout,
-    };
+      const fetchOptions = {
+        method: options.type,
+        body: data64,
+        headers: {
+          'X-Loki-pow-nonce': nonce,
+          'X-Loki-timestamp': timestamp.toString(),
+          'X-Loki-ttl': ttl.toString(),
+          'X-Loki-recipient': pubKey,
+        },
+        timeout: options.timeout,
+      };
 
-    let response;
+      let response;
+      try {
+        response = await fetch(options.url, fetchOptions);
+      } catch (e) {
+        log.error(options.type, options.url, 0, 'Error sending message');
+        window.LokiSnodeAPI.unreachableNode(pubKey, node);
+        throw HTTPError('fetch error', 0, e.toString());
+      }
+
+      let result;
+      if (
+        options.responseType === 'json' &&
+        response.headers.get('Content-Type') === 'application/json'
+      ) {
+        result = await response.json();
+      } else if (options.responseType === 'arraybuffer') {
+        result = await response.buffer();
+      } else {
+        result = await response.text();
+      }
+
+      if (response.status >= 0 && response.status < 400) {
+        return result;
+      }
+      log.error(options.type, options.url, response.status, 'Error sending message');
+      throw HTTPError('sendMessage: error response', response.status, result);
+    });
     try {
-      response = await fetch(options.url, fetchOptions);
-    } catch (e) {
-      log.error(options.type, options.url, 0, 'Error');
-      throw HTTPError('fetch error', 0, e.toString());
-    }
-
-    let result;
-    if (
-      options.responseType === 'json' &&
-      response.headers.get('Content-Type') === 'application/json'
-    ) {
-      result = await response.json();
-    } else if (options.responseType === 'arraybuffer') {
-      result = await response.buffer();
-    } else {
-      result = await response.text();
-    }
-
-    if (response.status >= 0 && response.status < 400) {
+      // TODO: Possibly change this to require more than a single response?
+      const result = await firstOf(requests);
       return result;
+    } catch(err) {
+      throw err;
     }
-    log.error(options.type, options.url, response.status, 'Error');
-    throw HTTPError('sendMessage: error response', response.status, result);
   }
 
-  async retrieveMessages(pubKey) {
-    if (!this.ourSwarmNodes || this.ourSwarmNodes.length === 0) {
-      await this.loadOurSwarm();
-    }
-    const currentNode = this.ourSwarmNodes[0];
-    const options = {
-      url: `${currentNode.url}${this.messageServerPort}/retrieve`,
-      type: 'GET',
-      responseType: 'json',
-      timeout: undefined,
-    };
+  async retrieveMessages(callback) {
+    let ourSwarmNodes = await window.LokiSnodeAPI.getOurSwarmNodes();
+    const ourKey = window.textsecure.storage.user.getNumber();
+    let completedRequests = 0;
 
-    const headers = {
-      'X-Loki-recipient': pubKey,
-    };
+    const doRequest = async (nodeUrl, nodeData) => {
+      const options = {
+        url: `${nodeUrl}${this.messageServerPort}/retrieve`,
+        type: 'GET',
+        responseType: 'json',
+        timeout: undefined,
+      };
 
-    if (currentNode.lastHash) {
-      headers['X-Loki-last-hash'] = currentNode.lastHash;
-    }
+      const headers = {
+        'X-Loki-recipient': ourKey,
+      };
 
-    const fetchOptions = {
-      method: options.type,
-      headers,
-      timeout: options.timeout,
-    };
-
-    let response;
-    try {
-      response = await fetch(options.url, fetchOptions);
-    } catch (e) {
-      log.error(options.type, options.url, 0, 'Error');
-      throw HTTPError('fetch error', 0, e.toString());
-    }
-
-    let result;
-    if (
-      options.responseType === 'json' &&
-      response.headers.get('Content-Type') === 'application/json'
-    ) {
-      result = await response.json();
-    } else if (options.responseType === 'arraybuffer') {
-      result = await response.buffer();
-    } else {
-      result = await response.text();
-    }
-
-    if (response.status >= 0 && response.status < 400) {
-      if (result.lastHash) {
-        currentNode.lastHash = result.lastHash;
+      if (nodeData.lastHash) {
+        headers['X-Loki-last-hash'] = nodeData.lastHash;
       }
-      return result;
+
+      const fetchOptions = {
+        method: options.type,
+        headers,
+        timeout: options.timeout,
+      };
+      let response;
+      try {
+        response = await fetch(options.url, fetchOptions);
+      } catch (e) {
+        // TODO: Maybe we shouldn't immediately delete?
+        log.error(options.type, options.url, 0, `Error retrieving messages from ${nodeUrl}`);
+        window.LokiSnodeAPI.unreachableNode(ourKey, nodeUrl);
+        throw HTTPError('fetch error', 0, e.toString());
+      }
+
+      let result;
+      if (
+        options.responseType === 'json' &&
+        response.headers.get('Content-Type') === 'application/json'
+      ) {
+        result = await response.json();
+      } else if (options.responseType === 'arraybuffer') {
+        result = await response.buffer();
+      } else {
+        result = await response.text();
+      }
+      completedRequests += 1;
+
+      if (response.status >= 0 && response.status < 400) {
+        if (result.lastHash) {
+          window.LokiSnodeAPI.updateLastHash(nodeUrl, result.lastHash);
+        }
+        return result;
+      }
+      log.error(options.type, options.url, response.status, 'Error');
+      throw HTTPError('retrieveMessages: error response', response.status, result);
     }
-    log.error(options.type, options.url, response.status, 'Error');
-    throw HTTPError('retrieveMessages: error response', response.status, result);
+
+    while (completedRequests < MINIMUM_SUCCESSFUL_REQUESTS) {
+      const remainingRequests = MINIMUM_SUCCESSFUL_REQUESTS - completedRequests;
+      ourSwarmNodes = await window.LokiSnodeAPI.getOurSwarmNodes();
+      if (Object.keys(ourSwarmNodes).length < remainingRequests) {
+        if (completedRequests !== 0) {
+          // TODO: Decide how to handle some completed requests but not enough
+        }
+        return;
+      }
+
+      const requests = await Promise.all(
+        Object.entries(ourSwarmNodes)
+          .splice(0, remainingRequests)
+          .map(([nodeUrl, lastHash]) => doRequest(nodeUrl, lastHash).catch(() => null))
+      );
+      // Requests is now an array of null for failed requests and the json for success
+      requests.filter(v => v !== null && 'messages' in v)
+        .forEach(v => callback(v.messages));
+    }
   }
 }
 
@@ -223,5 +191,5 @@ function HTTPError(message, providedCode, response, stack) {
 }
 
 module.exports = {
-  LokiServer,
+  LokiMessageAPI,
 };

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -19,7 +19,7 @@ class LokiMessageAPI {
 
   async sendMessage(pubKey, data, messageTimeStamp, ttl) {
     const swarmNodes = await window.LokiSnodeAPI.getSwarmNodesByPubkey(pubKey)
-    if (!swarmNodes || swarmNodes.length === 0) {
+    if (!swarmNodes || swarmNodes.size === 0) {
       throw Error('No swarm nodes to query!');
     }
 
@@ -39,12 +39,13 @@ class LokiMessageAPI {
       throw err;
     }
 
-    const requests = swarmNodes.map(async node => {
+    const requests = Array.from(swarmNodes).map(async node => {
+      // TODO: Confirm sensible timeout
       const options = {
         url: `${node}${this.messageServerPort}/store`,
         type: 'POST',
         responseType: undefined,
-        timeout: undefined,
+        timeout: 5000,
       };
 
       const fetchOptions = {
@@ -100,11 +101,12 @@ class LokiMessageAPI {
     let completedRequests = 0;
 
     const doRequest = async (nodeUrl, nodeData) => {
+      // TODO: Confirm sensible timeout
       const options = {
         url: `${nodeUrl}${this.messageServerPort}/retrieve`,
         type: 'GET',
         responseType: 'json',
-        timeout: undefined,
+        timeout: 5000,
       };
 
       const headers = {
@@ -159,10 +161,10 @@ class LokiMessageAPI {
       const remainingRequests = MINIMUM_SUCCESSFUL_REQUESTS - completedRequests;
       const ourSwarmNodes = await window.LokiSnodeAPI.getOurSwarmNodes();
       if (Object.keys(ourSwarmNodes).length < remainingRequests) {
+        // This means we don't have enough swarm nodes to meet the minimum threshold
         if (completedRequests !== 0) {
           // TODO: Decide how to handle some completed requests but not enough
         }
-        return;
       }
 
       await Promise.all(

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -1,0 +1,170 @@
+/* global log, window, Whisper */
+
+const fetch = require('node-fetch');
+const is = require('@sindresorhus/is');
+const dns = require('dns');
+
+// Will be raised (to 3?) when we get more nodes
+const MINIMUM_SWARM_NODES = 1;
+
+class LokiSnodeAPI {
+
+  constructor({ url, swarmServerPort }) {
+    if (!is.string(url)) {
+      throw new Error('WebAPI.initialize: Invalid server url');
+    }
+    this.url = url;
+    this.swarmServerPort = swarmServerPort
+      ? `:${swarmServerPort}`
+      : '';
+    this.swarmsPendingReplenish = {};
+    this.ourSwarmNodes = {};
+  }
+
+  getRandomSnodeAddress() {
+    /* resolve random snode */
+    return new Promise((resolve, reject) => {
+      dns.resolveCname(this.url, (err, address) => {
+        if(err) {
+          reject(err);
+        } else {
+          resolve(address[0]);
+        }
+      });
+    });
+  }
+
+  unreachableNode(pubKey, nodeUrl) {
+    if (pubKey === window.textsecure.storage.user.getNumber()) {
+      delete this.ourSwarmNodes[nodeUrl];
+    }
+  }
+
+  updateLastHash(nodeUrl, hash) {
+    if (!this.ourSwarmNodes[nodeUrl]) {
+      this.ourSwarmNodes[nodeUrl] = {
+        lastHash: hash,
+      }
+    } else {
+      this.ourSwarmNodes[nodeUrl].lastHash = hash;
+    }
+  }
+
+  async getOurSwarmNodes() {
+    if (
+      !this.ourSwarmNodes ||
+      Object.keys(this.ourSwarmNodes).length < MINIMUM_SWARM_NODES
+    ) {
+      // Try refresh our swarm list once
+      const ourKey = window.textsecure.storage.user.getNumber();
+      const nodeAddresses = await window.LokiSnodeAPI.getSwarmNodes(ourKey);
+
+      this.ourSwarmNodes = {};
+      nodeAddresses.forEach(url => {
+        this.ourSwarmNodes[url] = {};
+      })
+      if (!this.ourSwarmNodes || Object.keys(this.ourSwarmNodes).length === 0) {
+        throw Error('Could not load our swarm')
+      }
+    }
+    return this.ourSwarmNodes;
+  }
+
+  async getSwarmNodesByPubkey(pubKey) {
+    const swarmNodes = await window.Signal.Data.getSwarmNodesByPubkey(pubKey);
+    // TODO: Check if swarm list is below a threshold rather than empty
+    if (swarmNodes && swarmNodes.length !== 0) {
+      return swarmNodes;
+    }
+    return this.replenishSwarm(pubKey);
+  }
+
+  async replenishSwarm(pubKey) {
+    const conversation = window.ConversationController.get(pubKey);
+    if (!(pubKey in this.swarmsPendingReplenish)) {
+      this.swarmsPendingReplenish[pubKey] = new Promise(async (resolve) => {
+        const newSwarmNodes = await this.getSwarmNodes(pubKey);
+        conversation.set({ swarmNodes: newSwarmNodes });
+        await window.Signal.Data.updateConversation(conversation.id, conversation.attributes, {
+          Conversation: Whisper.Conversation,
+        });
+        resolve(newSwarmNodes);
+      });
+    }
+    const newSwarmNodes = await this.swarmsPendingReplenish[pubKey];
+    delete this.swarmsPendingReplenish[pubKey];
+    return newSwarmNodes;
+  }
+
+  async getSwarmNodes(pubKey) {
+    const node = await this.getRandomSnodeAddress();
+    const options = {
+      url: `http://${node}${this.swarmServerPort}/json_rpc`,
+      type: 'POST',
+      responseType: 'json',
+      timeout: undefined,
+    };
+
+    const body = {
+      jsonrpc: '2.0',
+      id: '0',
+      method: 'get_swarm_list_for_messenger_pubkey',
+      params: {
+        pubkey: pubKey,
+      },
+    }
+
+    const fetchOptions = {
+      method: options.type,
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      timeout: options.timeout,
+    };
+
+    let response;
+    try {
+      response = await fetch(options.url, fetchOptions);
+    } catch (e) {
+      log.error(options.type, options.url, 0, `Error getting swarm nodes for ${pubKey}`);
+      throw HTTPError('fetch error', 0, e.toString());
+    }
+
+    let result;
+    if (
+      options.responseType === 'json' &&
+      response.headers.get('Content-Type') === 'application/json'
+    ) {
+      result = await response.json();
+    } else if (options.responseType === 'arraybuffer') {
+      result = await response.buffer();
+    } else {
+      result = await response.text();
+    }
+
+    if (response.status >= 0 && response.status < 400) {
+      return result.nodes;
+    }
+    log.error(options.type, options.url, response.status, `Error getting swarm nodes for ${pubKey}`);
+    throw HTTPError('sendMessage: error response', response.status, result);
+  }
+}
+
+function HTTPError(message, providedCode, response, stack) {
+  const code = providedCode > 999 || providedCode < 100 ? -1 : providedCode;
+  const e = new Error(`${message}; code: ${code}`);
+  e.name = 'HTTPError';
+  e.code = code;
+  if (stack) {
+    e.stack += `\nOriginal stack:\n${stack}`;
+  }
+  if (response) {
+    e.response = response;
+  }
+  return e;
+}
+
+module.exports = {
+  LokiSnodeAPI,
+};

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -92,7 +92,13 @@ class LokiSnodeAPI {
     const conversation = window.ConversationController.get(pubKey);
     if (!(pubKey in this.swarmsPendingReplenish)) {
       this.swarmsPendingReplenish[pubKey] = new Promise(async (resolve) => {
-        const newSwarmNodes = new Set(await this.getSwarmNodes(pubKey));
+        let newSwarmNodes
+        try {
+          newSwarmNodes = new Set(await this.getSwarmNodes(pubKey));
+        } catch (e) {
+          // TODO: Handle these errors sensibly
+          newSwarmNodes = new Set([]);
+        }
         conversation.set({ swarmNodes: newSwarmNodes });
         await window.Signal.Data.updateConversation(conversation.id, conversation.attributes, {
           Conversation: Whisper.Conversation,

--- a/libloki/service_nodes.js
+++ b/libloki/service_nodes.js
@@ -4,30 +4,36 @@
 (function () {
   window.libloki = window.libloki || {};
 
-  function consolidateLists(lists, threshold = 1){
+  function consolidateLists(lists, threshold, selector = (x) => x){
     if (typeof threshold !== 'number') {
       throw Error('Provided threshold is not a number');
+    }
+    if (typeof selector !== 'function') {
+      throw Error('Provided selector is not a function');
     }
 
     // calculate list size manually since `Set`
     // does not have a `length` attribute
     let numLists = 0;
     const occurences = {};
+    const values = {};
     lists.forEach(list => {
       numLists += 1;
       list.forEach(item => {
-        if (!(item in occurences)) {
-          occurences[item] = 1;
+        const key = selector(item);
+        if (!(key in occurences)) {
+          occurences[key] = 1;
+          values[key] = item;
         } else {
-          occurences[item] += 1;
+          occurences[key] += 1;
         }
       });
     });
 
     const scaledThreshold = numLists * threshold;
-    return Object.entries(occurences)
-      .filter(keyValue => keyValue[1] >= scaledThreshold)
-      .map(keyValue => keyValue[0]);
+    return Object.keys(occurences)
+      .filter(key => occurences[key] >= scaledThreshold)
+      .map(key => values[key]);
   }
 
   window.libloki.serviceNodes = {

--- a/libloki/test/service_nodes_test.js
+++ b/libloki/test/service_nodes_test.js
@@ -17,13 +17,22 @@ describe('ServiceNodes', () => {
       );
     });
 
+    it('should throw when provided a non-function selector', () => {
+      [1, 'a', 0xffffffff, { really: 'not a function' }].forEach(x => {
+        assert.throws(() =>
+          libloki.serviceNodes.consolidateLists([], 1, x),
+          'Provided selector is not a function'
+        )
+      });
+    });
+
     it('should return an empty array when the input is an empty array', () => {
-      const result = libloki.serviceNodes.consolidateLists([]);
+      const result = libloki.serviceNodes.consolidateLists([], 1);
       assert.deepEqual(result, []);
     });
 
     it('should return the input when only 1 list is provided', () => {
-      const result = libloki.serviceNodes.consolidateLists([['a', 'b', 'c']]);
+      const result = libloki.serviceNodes.consolidateLists([['a', 'b', 'c']], 1);
       assert.deepEqual(result, ['a', 'b', 'c']);
     });
 
@@ -34,6 +43,25 @@ describe('ServiceNodes', () => {
         ['g', 'h'],
       ], 0);
       assert.deepEqual(result.sort(), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
+    });
+
+    it('should use the selector to identify the elements', () => {
+      const result = libloki.serviceNodes.consolidateLists([
+        [{ id: 1, val: 'a'}, { id: 2, val: 'b'}, { id: 3, val: 'c'}, { id: 8, val: 'h'}],
+        [{ id: 4, val: 'd'}, { id: 5, val: 'e'}, { id: 6, val: 'f'}, { id: 7, val: 'g'}],
+        [{ id: 7, val: 'g'}, { id: 8, val: 'h'}],
+      ], 0, x => x.id);
+      const expected = [
+        { id: 1, val: 'a'},
+        { id: 2, val: 'b'},
+        { id: 3, val: 'c'},
+        { id: 4, val: 'd'},
+        { id: 5, val: 'e'},
+        { id: 6, val: 'f'},
+        { id: 7, val: 'g'},
+        { id: 8, val: 'h'},
+      ];
+      assert.deepEqual(result.sort((a, b) => a.val > b.val), expected);
     });
 
     it('should return the intersection of all lists when threshold is 1', () => {

--- a/libtextsecure/http-resources.js
+++ b/libtextsecure/http-resources.js
@@ -1,4 +1,4 @@
-/* global window, dcodeIO, textsecure, StringView */
+/* global window, dcodeIO, textsecure */
 
 // eslint-disable-next-line func-names
 (function () {
@@ -62,26 +62,8 @@
     };
     let connected = false;
 
-    this.startPolling = async function pollServer(callBack) {
-      const myKeys = await textsecure.storage.protocol.getIdentityKeyPair();
-      const pubKey = StringView.arrayBufferToHex(myKeys.pubKey)
-      let result;
-      try {
-        result = await server.retrieveMessages(pubKey);
-        connected = true;
-      } catch (err) {
-        connected = false;
-        setTimeout(() => { pollServer(callBack); }, pollTime);
-        return;
-      }
-      if (typeof callBack === 'function') {
-        callBack(connected);
-      }
-      if (!result.messages) {
-        setTimeout(() => { pollServer(callBack); }, pollTime);
-        return;
-      }
-      const newMessages = await filterIncomingMessages(result.messages);
+    const processMessages = async messages => {
+      const newMessages = await filterIncomingMessages(messages);
       newMessages.forEach(async message => {
         const { data } = message;
         const dataPlaintext = stringToArrayBufferBase64(data);
@@ -97,7 +79,17 @@
           );
         }
       });
-      setTimeout(() => { pollServer(callBack); }, pollTime);
+    }
+
+    this.startPolling = async function pollServer(callback) {
+      try {
+        await server.retrieveMessages(processMessages);
+        connected = true;
+      } catch (err) {
+        connected = false;
+      }
+      callback(connected);
+      setTimeout(() => { pollServer(callback); }, pollTime);
     };
 
     this.isConnected = function isConnected() {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -22,7 +22,7 @@ function MessageReceiver(username, password, signalingKey, options = {}) {
   this.signalingKey = signalingKey;
   this.username = username;
   this.password = password;
-  this.lokiserver = window.LokiAPI;
+  this.lokiMessageAPI = window.LokiMessageAPI;
 
   if (!options.serverTrustRoot) {
     throw new Error('Server trust root is required!');
@@ -67,7 +67,7 @@ MessageReceiver.prototype.extend({
     }
 
     this.hasConnected = true;
-    this.httpPollingResource = new HttpResource(this.lokiserver, {
+    this.httpPollingResource = new HttpResource(this.lokiMessageAPI, {
       handleRequest: this.handleRequest.bind(this),
     });
     this.httpPollingResource.startPolling((connected) => {

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -34,7 +34,7 @@ function OutgoingMessage(
   this.callback = callback;
   this.silent = silent;
 
-  this.lokiserver = window.LokiAPI;
+  this.lokiMessageAPI = window.LokiMessageAPI;
 
   this.numbersCompleted = 0;
   this.errors = [];
@@ -184,7 +184,7 @@ OutgoingMessage.prototype = {
   async transmitMessage(number, data, timestamp, ttl = 24 * 60 * 60) {
     const pubKey = number;
     try {
-      const result = await this.lokiserver.sendMessage(pubKey, data, timestamp, ttl);
+      const result = await this.lokiMessageAPI.sendMessage(pubKey, data, timestamp, ttl);
       return result;
     } catch (e) {
       if (e.name === 'HTTPError' && (e.code !== 409 && e.code !== 410)) {

--- a/main.js
+++ b/main.js
@@ -144,6 +144,8 @@ function prepareURL(pathSegments, moreKeys) {
       buildExpiration: config.get('buildExpiration'),
       serverUrl: config.get('serverUrl'),
       cdnUrl: config.get('cdnUrl'),
+      messageServerPort: config.get('messageServerPort'),
+      swarmServerPort: config.get('swarmServerPort'),
       certificateAuthority: config.get('certificateAuthority'),
       environment: config.environment,
       node_version: process.versions.node,

--- a/preload.js
+++ b/preload.js
@@ -265,12 +265,18 @@ window.WebAPI = initializeWebAPI({
   proxyUrl: config.proxyUrl,
 });
 
-const { LokiServer } = require('./js/modules/loki_message_api');
+const { LokiSnodeAPI } = require('./js/modules/loki_snode_api');
 
-window.LokiAPI = new LokiServer({
-  urls: [config.serverUrl],
-  messageServerPort: config.messageServerPort,
+window.LokiSnodeAPI = new LokiSnodeAPI({
+  url: config.serverUrl,
   swarmServerPort: config.swarmServerPort,
+});
+
+const { LokiMessageAPI } = require('./js/modules/loki_message_api');
+
+window.LokiMessageAPI = new LokiMessageAPI({
+  url: config.serverUrl,
+  messageServerPort: config.messageServerPort,
 });
 
 window.mnemonic = require('./libloki/mnemonic');

--- a/preload.js
+++ b/preload.js
@@ -269,6 +269,8 @@ const { LokiServer } = require('./js/modules/loki_message_api');
 
 window.LokiAPI = new LokiServer({
   urls: [config.serverUrl],
+  messageServerPort: config.messageServerPort,
+  swarmServerPort: config.swarmServerPort,
 });
 
 window.mnemonic = require('./libloki/mnemonic');


### PR DESCRIPTION
Random.snode is now used to query the network for lists of nodes in the swarm for a specific contact
Sending a retrieving messages now fires off multiple queries to the nodes in these lists and some rudimentary organising of this is in place
Some thinking still needs to be done about how to handle the outcome of all these requests
E.g.

- What should be the minimum successful responses we want when sending a message? (A % of the max # of nodes we have had in list? Hardcoded to 3?
- What should we do if we run out of nodes to try and have received a nonzero # of successful responses that is less than this minimum threshold? (Just approve? (invalidates the idea of threshold) Throw error? (Realistically the request was a success) Small warning? (User shouldn't really need to see))
- How should we handle requests that don't fail to connect to nodes but still respond with non-200

etc

Error handling in general needs to be more thorough, I have silenced the errors that would be thrown by send/retrieveMessages because there are more than a single request for each of these calls now so we can't just rely on one. There's probably a bunch of cases I haven't thought about.

When we get larger sized swarms (currently toynet has 2) we will want to send to a subset of these, this number is in code as a constant but the size needs to be considered

Some other stuff worth mentioning that I have forgot probably

And there's currently an SQL unique constraint exception being thrown when trying to save the hashes of seen messages because we have multiple requests returning the same messages now which will be fixed in another PR