### PR TITLE
Swarm error handling

### DIFF
--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -181,8 +181,10 @@
           return conversation;
         }
 
-        window.LokiSnodeAPI.replenishSwarm(id);
         try {
+          conversation.attributes.swarmNodes = await window.LokiSnodeAPI.getFreshSwarmNodes(
+            id
+          );
           await window.Signal.Data.saveConversation(conversation.attributes, {
             Conversation: Whisper.Conversation,
           });

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -182,9 +182,8 @@
         }
 
         try {
-          conversation.attributes.swarmNodes = await window.LokiSnodeAPI.getFreshSwarmNodes(
-            id
-          );
+          const swarmNodes =  await window.LokiSnodeAPI.getFreshSwarmNodes(id);
+          conversation.set({ swarmNodes});
           await window.Signal.Data.saveConversation(conversation.attributes, {
             Conversation: Whisper.Conversation,
           });

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -847,6 +847,8 @@
         e.name === 'SendMessageNetworkError' ||
         e.name === 'SignedPreKeyRotationError' ||
         e.name === 'OutgoingIdentityKeyError' ||
+        e.name === 'DNSResolutionError' ||
+        e.name === 'EmptySwarmError' ||
         e.name === 'PoWError'
       );
     },

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -662,8 +662,8 @@ async function removeAllSessions(id) {
 
 function setifyProperty(data, propertyName) {
   if (!data) return data;
-  const returnData = data;
-  if (returnData[propertyName] && Array.isArray(returnData[propertyName])) {
+  const returnData = { ...data };
+  if (Array.isArray(returnData[propertyName])) {
     returnData[propertyName] = new Set(returnData[propertyName]);
   }
   return returnData;

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -106,21 +106,11 @@ class LokiMessageAPI {
       }
       try {
         swarmNodes = await window.LokiSnodeAPI.getSwarmNodesByPubkey(pubKey);
-        // Filter out the nodes we have already got responses from
-        swarmNodes = Object.keys(swarmNodes)
-          .filter(node => !(node in completedNodes))
-          .reduce(
-            // eslint-disable-next-line no-loop-func
-            (obj, node) => ({
-              ...obj,
-              [node]: swarmNodes[node],
-            }),
-            {}
-          );
+        swarmNodes = swarmNodes.filter(node => !(node in completedNodes));
       } catch (e) {
         throw new window.textsecure.EmptySwarmError(pubKey, e);
       }
-      if (!swarmNodes || swarmNodes.size === 0) {
+      if (!swarmNodes || swarmNodes.length === 0) {
         if (completedNodes.length !== 0) {
           // TODO: Decide how to handle some completed requests but not enough
           return;
@@ -134,7 +124,7 @@ class LokiMessageAPI {
       const remainingRequests =
         MINIMUM_SUCCESSFUL_REQUESTS - completedNodes.length;
       await Promise.all(
-        Array.from(swarmNodes)
+        swarmNodes
           .splice(0, remainingRequests)
           .map(nodeUrl => doRequest(nodeUrl))
       );

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -45,7 +45,7 @@ class LokiSnodeAPI {
       if (this.ourSwarmNodes[nodeUrl].failureCount >= FAILURE_THRESHOLD) {
         delete this.ourSwarmNodes[nodeUrl];
       }
-      return;
+      return false;
     }
     if (!this.contactSwarmNodes[nodeUrl]) {
       this.contactSwarmNodes[nodeUrl] = {
@@ -55,7 +55,7 @@ class LokiSnodeAPI {
       this.contactSwarmNodes[nodeUrl].failureCount += 1;
     }
     if (this.contactSwarmNodes[nodeUrl].failureCount < FAILURE_THRESHOLD) {
-      return;
+      return false;
     }
     const conversation = window.ConversationController.get(pubKey);
     const swarmNodes = conversation.get('swarmNodes');
@@ -70,6 +70,7 @@ class LokiSnodeAPI {
       );
       delete this.contactSwarmNodes[nodeUrl];
     }
+    return true;
   }
 
   updateLastHash(nodeUrl, hash) {

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -108,7 +108,7 @@ class LokiSnodeAPI {
   async getSwarmNodesByPubkey(pubKey) {
     const swarmNodes = await window.Signal.Data.getSwarmNodesByPubkey(pubKey);
     // TODO: Check if swarm list is below a threshold rather than empty
-    if (swarmNodes && swarmNodes.size !== 0) {
+    if (swarmNodes && swarmNodes.length !== 0) {
       return swarmNodes;
     }
     return this.replenishSwarm(pubKey);
@@ -120,10 +120,10 @@ class LokiSnodeAPI {
       this.swarmsPendingReplenish[pubKey] = new Promise(async resolve => {
         let newSwarmNodes;
         try {
-          newSwarmNodes = new Set(await this.getSwarmNodes(pubKey));
+          newSwarmNodes = await this.getSwarmNodes(pubKey);
         } catch (e) {
           // TODO: Handle these errors sensibly
-          newSwarmNodes = new Set([]);
+          newSwarmNodes = [];
         }
         conversation.set({ swarmNodes: newSwarmNodes });
         await window.Signal.Data.updateConversation(

--- a/libtextsecure/errors.js
+++ b/libtextsecure/errors.js
@@ -140,7 +140,7 @@
       appendStack(this, error);
     }
   }
-  inherit(ReplayableError, PoWError);
+  inherit(ReplayableError, EmptySwarmError);
 
   function PoWError(number, error) {
     // eslint-disable-next-line prefer-destructuring

--- a/libtextsecure/errors.js
+++ b/libtextsecure/errors.js
@@ -127,6 +127,21 @@
   }
   inherit(Error, UnregisteredUserError);
 
+  function EmptySwarmError(number, error) {
+    // eslint-disable-next-line prefer-destructuring
+    this.number = number.split('.')[0];
+
+    ReplayableError.call(this, {
+      name: 'EmptySwarmError',
+      message: 'Could not get any swarm nodes to query',
+    });
+
+    if (error) {
+      appendStack(this, error);
+    }
+  }
+  inherit(ReplayableError, PoWError);
+
   function PoWError(number, error) {
     // eslint-disable-next-line prefer-destructuring
     this.number = number.split('.')[0];
@@ -151,4 +166,5 @@
   window.textsecure.MessageError = MessageError;
   window.textsecure.SignedPreKeyRotationError = SignedPreKeyRotationError;
   window.textsecure.PoWError = PoWError;
+  window.textsecure.EmptySwarmError = EmptySwarmError;
 })();

--- a/libtextsecure/errors.js
+++ b/libtextsecure/errors.js
@@ -157,6 +157,16 @@
   }
   inherit(ReplayableError, PoWError);
 
+  function DNSResolutionError(message) {
+    // eslint-disable-next-line prefer-destructuring
+
+    ReplayableError.call(this, {
+      name: 'DNSResolutionError',
+      message: `Error resolving url: ${message}`,
+    });
+  }
+  inherit(ReplayableError, DNSResolutionError);
+
   window.textsecure.UnregisteredUserError = UnregisteredUserError;
   window.textsecure.SendMessageNetworkError = SendMessageNetworkError;
   window.textsecure.IncomingIdentityKeyError = IncomingIdentityKeyError;
@@ -167,4 +177,5 @@
   window.textsecure.SignedPreKeyRotationError = SignedPreKeyRotationError;
   window.textsecure.PoWError = PoWError;
   window.textsecure.EmptySwarmError = EmptySwarmError;
+  window.textsecure.DNSResolutionError = DNSResolutionError;
 })();

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -186,13 +186,7 @@ OutgoingMessage.prototype = {
   async transmitMessage(number, data, timestamp, ttl = 24 * 60 * 60) {
     const pubKey = number;
     try {
-      const result = await this.lokiMessageAPI.sendMessage(
-        pubKey,
-        data,
-        timestamp,
-        ttl
-      );
-      return result;
+      await this.lokiMessageAPI.sendMessage(pubKey, data, timestamp, ttl);
     } catch (e) {
       if (e.name === 'HTTPError' && (e.code !== 409 && e.code !== 410)) {
         // 409 and 410 should bubble and be handled by doSendMessage


### PR DESCRIPTION
More robust handling of swarm requests and how failures and edge cases are handled
Now don't just wait for a single successful send message request but continue trying until we run out of nodes or we get enough responses, the same way we do retrieving messages
Added a failure threshold for the nodes we are querying so we aren't deleting them from memory until they have failed 3 times
Make sure we don't just make 3 successful queries to the same node 3 times
Added some more specific errors for the different ways sending a message can fail

Feel like this logic is getting a bit messy, especially the stuff for sending and receiving messages seems mostly duplicated with only a few differences, not really sure how to go about simplifying/generalising it
Also feel like the responsibilities of the different files/modules and getting a bit blurred and I'm not confident about the places I have done some of this stuff, interested in input