### PR TITLE
Send profile along with friend request accept message

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -653,7 +653,9 @@
         await this.respondToAllPendingFriendRequests({
           response: 'accepted',
         });
+        return true;
       }
+      return false;
     },
     async onFriendRequestTimeout() {
       // Unset the timer

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -1,27 +1,52 @@
-/* global window, textsecure */
+/* global window, textsecure, log */
 
 // eslint-disable-next-line func-names
 (function() {
   window.libloki = window.libloki || {};
 
   async function sendFriendRequestAccepted(pubKey) {
-    return sendEmptyMessage(pubKey);
+    return sendEmptyMessage(pubKey, true);
   }
 
-  async function sendEmptyMessage(pubKey) {
+  async function sendEmptyMessage(pubKey, sendContentMessage = false) {
     const options = {};
     // send an empty message.
-    // The logic downstream will attach the prekeys and our profile.
-    await textsecure.messaging.sendMessageToNumber(
-      pubKey, // number
-      null, // messageText
-      [], // attachments
-      null, // quote
-      Date.now(), // timestamp
-      null, // expireTimer
-      null, // profileKey
-      options
-    );
+    if (sendContentMessage) {
+      // The logic downstream will attach the prekeys and our profile.
+      await textsecure.messaging.sendMessageToNumber(
+        pubKey, // number
+        null, // messageText
+        [], // attachments
+        null, // quote
+        Date.now(), // timestamp
+        null, // expireTimer
+        null, // profileKey
+        options
+      );
+    } else {
+      // empty content message
+      const content = new textsecure.protobuf.Content();
+
+      // will be called once the transmission succeeded or failed
+      const callback = res => {
+        if (res.errors.length > 0) {
+          res.errors.forEach(error => log.error(error));
+        } else {
+          log.info('empty message sent successfully');
+        }
+      };
+      // send an empty message. The logic in ougoing_message will attach the prekeys.
+      const outgoingMessage = new textsecure.OutgoingMessage(
+        null, // server
+        Date.now(), // timestamp,
+        [pubKey], // numbers
+        content, // message
+        true, // silent
+        callback, // callback
+        options
+      );
+      await outgoingMessage.sendToNumber(pubKey);
+    }
   }
 
   window.libloki.api = {

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -1,4 +1,4 @@
-/* global window, textsecure, log */
+/* global window, textsecure */
 
 // eslint-disable-next-line func-names
 (function() {
@@ -9,29 +9,19 @@
   }
 
   async function sendEmptyMessage(pubKey) {
-    // empty content message
-    const content = new textsecure.protobuf.Content();
-
-    // will be called once the transmission succeeded or failed
-    const callback = res => {
-      if (res.errors.length > 0) {
-        res.errors.forEach(error => log.error(error));
-      } else {
-        log.info('empty message sent successfully');
-      }
-    };
     const options = {};
-    // send an empty message. The logic in ougoing_message will attach the prekeys.
-    const outgoingMessage = new textsecure.OutgoingMessage(
-      null, // server
-      Date.now(), // timestamp,
-      [pubKey], // numbers
-      content, // message
-      true, // silent
-      callback, // callback
+    // send an empty message.
+    // The logic downstream will attach the prekeys and our profile.
+    await textsecure.messaging.sendMessageToNumber(
+      pubKey, // number
+      null, // messageText
+      [], // attachments
+      null, // quote
+      Date.now(), // timestamp
+      null, // expireTimer
+      null, // profileKey
       options
     );
-    await outgoingMessage.sendToNumber(pubKey);
   }
 
   window.libloki.api = {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -954,11 +954,14 @@ MessageReceiver.prototype.extend({
             if (conversation && !message.flags) {
               const isFriendRequestAccept = await conversation.onFriendRequestAccepted();
               if (isFriendRequestAccept) {
-                await conversation.notifyFriendRequest(envelope.source, 'accepted');
-                this.removeFromCache(envelope);
-                return null;
+                await conversation.notifyFriendRequest(
+                  envelope.source,
+                  'accepted'
+                );
               }
             }
+            this.removeFromCache(envelope);
+            return null;
           }
 
           const ev = new Event('message');

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -909,56 +909,63 @@ MessageReceiver.prototype.extend({
       p = this.handleEndSession(envelope.source);
     }
     return p.then(() =>
-      this.processDecrypted(envelope, msg, envelope.source).then(message => {
-        const groupId = message.group && message.group.id;
-        const isBlocked = this.isGroupBlocked(groupId);
-        const isMe = envelope.source === textsecure.storage.user.getNumber();
-        const conversation = window.ConversationController.get(envelope.source);
-        const isLeavingGroup = Boolean(
-          message.group &&
-            message.group.type === textsecure.protobuf.GroupContext.Type.QUIT
-        );
-        const friendRequest =
-          envelope.type === textsecure.protobuf.Envelope.Type.FRIEND_REQUEST;
+      this.processDecrypted(envelope, msg, envelope.source).then(
+        async message => {
+          const groupId = message.group && message.group.id;
+          const isBlocked = this.isGroupBlocked(groupId);
+          const isMe = envelope.source === textsecure.storage.user.getNumber();
+          const conversation = window.ConversationController.get(
+            envelope.source
+          );
+          const isLeavingGroup = Boolean(
+            message.group &&
+              message.group.type === textsecure.protobuf.GroupContext.Type.QUIT
+          );
+          const friendRequest =
+            envelope.type === textsecure.protobuf.Envelope.Type.FRIEND_REQUEST;
 
-        // Check if we need to update any profile names
-        if (!isMe && conversation) {
-          let profile = null;
-          if (message.profile) {
-            profile = JSON.parse(message.profile.encodeJSON());
+          // Check if we need to update any profile names
+          if (!isMe && conversation) {
+            let profile = null;
+            if (message.profile) {
+              profile = JSON.parse(message.profile.encodeJSON());
+            }
+
+            // Update the conversation
+            await conversation.setProfile(profile);
           }
 
-          // Update the conversation
-          conversation.setProfile(profile);
-        }
+          if (friendRequest && isMe) {
+            window.log.info('refusing to add a friend request to ourselves');
+            throw new Error('Cannot add a friend request for ourselves!');
+          }
 
-        if (friendRequest && isMe) {
-          window.log.info('refusing to add a friend request to ourselves');
-          throw new Error('Cannot add a friend request for ourselves!');
-        }
+          if (groupId && isBlocked && !(isMe && isLeavingGroup)) {
+            window.log.warn(
+              `Message ${this.getEnvelopeId(
+                envelope
+              )} ignored; destined for blocked group`
+            );
+            return this.removeFromCache(envelope);
+          }
+          if (!message.body) {
+            return null;
+          }
 
-        if (groupId && isBlocked && !(isMe && isLeavingGroup)) {
-          window.log.warn(
-            `Message ${this.getEnvelopeId(
-              envelope
-            )} ignored; destined for blocked group`
-          );
-          return this.removeFromCache(envelope);
+          const ev = new Event('message');
+          ev.confirm = this.removeFromCache.bind(this, envelope);
+          ev.data = {
+            friendRequest,
+            source: envelope.source,
+            sourceDevice: envelope.sourceDevice,
+            timestamp: envelope.timestamp.toNumber(),
+            receivedAt: envelope.receivedAt,
+            unidentifiedDeliveryReceived: envelope.unidentifiedDeliveryReceived,
+            message,
+          };
+          return this.dispatchAndWait(ev);
         }
-
-        const ev = new Event('message');
-        ev.confirm = this.removeFromCache.bind(this, envelope);
-        ev.data = {
-          friendRequest,
-          source: envelope.source,
-          sourceDevice: envelope.sourceDevice,
-          timestamp: envelope.timestamp.toNumber(),
-          receivedAt: envelope.receivedAt,
-          unidentifiedDeliveryReceived: envelope.unidentifiedDeliveryReceived,
-          message,
-        };
-        return this.dispatchAndWait(ev);
-      })
+      )
     );
   },
   handleLegacyMessage(envelope) {
@@ -994,7 +1001,7 @@ MessageReceiver.prototype.extend({
     if (content.syncMessage)
       return this.handleSyncMessage(envelope, content.syncMessage);
     if (content.dataMessage)
-      return this.handleDataMessage(envelope, content.dataMessage);
+      await this.handleDataMessage(envelope, content.dataMessage);
     if (content.nullMessage)
       return this.handleNullMessage(envelope, content.nullMessage);
     if (content.callMessage)
@@ -1004,13 +1011,19 @@ MessageReceiver.prototype.extend({
     if (content.typingMessage)
       return this.handleTypingMessage(envelope, content.typingMessage);
 
-    // Trigger conversation friend request event for empty message
-    const conversation = window.ConversationController.get(envelope.source);
-    if (conversation) {
-      conversation.onFriendRequestAccepted();
-      conversation.notifyFriendRequest(envelope.source, 'accepted');
+    // Trigger conversation friend request event
+    if (
+      envelope.type === textsecure.protobuf.Envelope.Type.PREKEY_BUNDLE &&
+      (content.dataMessage === null || content.dataMessage.flags === null)
+    ) {
+      const conversation = window.ConversationController.get(envelope.source);
+      if (conversation) {
+        conversation.onFriendRequestAccepted();
+        conversation.notifyFriendRequest(envelope.source, 'accepted');
+      }
+      this.removeFromCache(envelope);
     }
-    this.removeFromCache(envelope);
+
     return null;
   },
   handleCallMessage(envelope) {


### PR DESCRIPTION
Fixes #145 
Basically in libloki/api.js we want to use `textsecure.messaging.sendMessageToNumber` which is a higher-level function that attaches the profile to the message proto.

Then when receiving messages, we allow having a `DataMessage` even for friend request messages.
To do so, we need to bail early if the message body is falsey.

(The linter has changes some indentation in message_receiver.js so best ignore whitespace changes in github: Diff settings => Hide whitespace changes)