### PR TITLE
Suppress friend request notification for session reset

### DIFF
--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -979,6 +979,8 @@ MessageReceiver.prototype.extend({
       if (!plaintext) {
         window.log.warn('handleContentMessage: plaintext was falsey');
         return null;
+      } else if (plaintext instanceof ArrayBuffer && plaintext.byteLength === 0) {
+        return null;
       }
       return this.innerHandleContentMessage(envelope, plaintext);
     });


### PR DESCRIPTION
`plaintext` can be an empty array buffer, in which case there is no point handling it.