### PR TITLE
Loki address broadcast

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,6 +102,7 @@ module.exports = grunt => {
       libloki: {
         src: [
           'libloki/api.js',
+          'libloki/friends.js',
           'libloki/crypto.js',
           'libloki/service_nodes.js',
           'libloki/storage.js',

--- a/app/sql.js
+++ b/app/sql.js
@@ -90,6 +90,7 @@ module.exports = {
   updateConversation,
   removeConversation,
   getAllConversations,
+  getAllFriendIds,
   getAllConversationIds,
   getAllPrivateConversations,
   getAllGroupsInvolvingId,
@@ -1278,6 +1279,14 @@ async function getConversationById(id) {
 async function getAllConversations() {
   const rows = await db.all('SELECT json FROM conversations ORDER BY id ASC;');
   return map(rows, row => jsonToObject(row.json));
+}
+
+async function getAllFriendIds() {
+  // TODO: Maybe don't have this hardcoded to 4 (friends status in the enum)
+  const rows = await db.all(
+    'SELECT id FROM conversations WHERE friendRequestStatus = 4 ORDER BY id ASC;'
+  );
+  return map(rows, row => row.id);
 }
 
 async function getAllConversationIds() {

--- a/app/sql.js
+++ b/app/sql.js
@@ -90,7 +90,7 @@ module.exports = {
   updateConversation,
   removeConversation,
   getAllConversations,
-  getAllFriendIds,
+  getPubKeysWithFriendStatus,
   getAllConversationIds,
   getAllPrivateConversations,
   getAllGroupsInvolvingId,
@@ -1281,10 +1281,15 @@ async function getAllConversations() {
   return map(rows, row => jsonToObject(row.json));
 }
 
-async function getAllFriendIds() {
+async function getPubKeysWithFriendStatus(status) {
   // TODO: Maybe don't have this hardcoded to 4 (friends status in the enum)
   const rows = await db.all(
-    'SELECT id FROM conversations WHERE friendRequestStatus = 4 ORDER BY id ASC;'
+    `SELECT id FROM conversations WHERE
+      friendRequestStatus = $status
+    ORDER BY id ASC;`,
+    {
+      $status: status,
+    }
   );
   return map(rows, row => row.id);
 }

--- a/app/sql.js
+++ b/app/sql.js
@@ -1128,7 +1128,7 @@ async function getSwarmNodesByPubkey(pubkey) {
   });
 
   if (!row) {
-    return null;
+    return [];
   }
 
   return jsonToObject(row.json).swarmNodes;

--- a/app/sql.js
+++ b/app/sql.js
@@ -1282,7 +1282,6 @@ async function getAllConversations() {
 }
 
 async function getPubKeysWithFriendStatus(status) {
-  // TODO: Maybe don't have this hardcoded to 4 (friends status in the enum)
   const rows = await db.all(
     `SELECT id FROM conversations WHERE
       friendRequestStatus = $status

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "serverUrl": "random.snode",
   "cdnUrl": "random.snode",
+  "localServerPort": "8081",
   "messageServerPort": "8080",
   "swarmServerPort": "8079",
   "disableAutoUpdate": false,

--- a/config/development-1.json
+++ b/config/development-1.json
@@ -1,5 +1,6 @@
 {
   "storageProfile": "development1",
+  "localServerPort": "8082",
   "disableAutoUpdate": true,
   "openDevTools": true
 }

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -182,11 +182,10 @@
         }
 
         try {
-          const swarmNodes = await window.LokiSnodeAPI.getFreshSwarmNodes(id);
-          conversation.set({ swarmNodes });
           await window.Signal.Data.saveConversation(conversation.attributes, {
             Conversation: Whisper.Conversation,
           });
+          window.LokiSnodeAPI.refreshSwarmNodesForPubKey(id);
         } catch (error) {
           window.log.error(
             'Conversation save failed! ',

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -182,8 +182,8 @@
         }
 
         try {
-          const swarmNodes =  await window.LokiSnodeAPI.getFreshSwarmNodes(id);
-          conversation.set({ swarmNodes});
+          const swarmNodes = await window.LokiSnodeAPI.getFreshSwarmNodes(id);
+          conversation.set({ swarmNodes });
           await window.Signal.Data.saveConversation(conversation.attributes, {
             Conversation: Whisper.Conversation,
           });

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -41,8 +41,7 @@
   } = window.Signal.Migrations;
 
   // Possible conversation friend states
-  const FriendRequestStatusEnum =
-    window.libloki.friends.friendRequestStatusEnum;
+  const FriendRequestStatusEnum = window.friends.friendRequestStatusEnum;
 
   // Possible session reset states
   const SessionResetEnum = Object.freeze({

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -41,18 +41,8 @@
   } = window.Signal.Migrations;
 
   // Possible conversation friend states
-  const FriendRequestStatusEnum = Object.freeze({
-    // New conversation, no messages sent or received
-    none: 0,
-    // This state is used to lock the input early while sending
-    pendingSend: 1,
-    // Friend request sent, awaiting response
-    requestSent: 2,
-    // Friend request received, awaiting user input
-    requestReceived: 3,
-    // We did it!
-    friends: 4,
-  });
+  const FriendRequestStatusEnum =
+    window.libloki.friends.friendRequestStatusEnum;
 
   // Possible session reset states
   const SessionResetEnum = Object.freeze({

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -678,11 +678,9 @@ async function getSwarmNodesByPubkey(pubkey) {
 async function saveSwarmNodesForPubKey(pubKey, swarmNodes, { Conversation }) {
   const conversation = await getConversationById(pubKey, { Conversation });
   conversation.set({ swarmNodes });
-  await updateConversation(
-    conversation.id,
-    conversation.attributes,
-    { Conversation }
-  );
+  await updateConversation(conversation.id, conversation.attributes, {
+    Conversation,
+  });
 }
 
 async function getConversationCount() {

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -120,7 +120,7 @@ module.exports = {
   _removeConversations,
 
   getAllConversations,
-  getAllFriendIds,
+  getPubKeysWithFriendStatus,
   getAllConversationIds,
   getAllPrivateConversations,
   getAllGroupsInvolvingId,
@@ -722,12 +722,8 @@ async function _removeConversations(ids) {
   await channels.removeConversation(ids);
 }
 
-async function getAllFriendIds() {
-  const ids = (await channels.getAllFriendIds()).map(c =>
-    setifyProperty(c, 'swarmNodes')
-  );
-
-  return ids;
+async function getPubKeysWithFriendStatus(status) {
+  return channels.getPubKeysWithFriendStatus(status);
 }
 
 async function getAllConversations({ ConversationCollection }) {

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -120,6 +120,7 @@ module.exports = {
   _removeConversations,
 
   getAllConversations,
+  getAllFriendIds,
   getAllConversationIds,
   getAllPrivateConversations,
   getAllGroupsInvolvingId,
@@ -719,6 +720,14 @@ async function removeConversation(id, { Conversation }) {
 // Note: this method will not clean up external files, just delete from SQL
 async function _removeConversations(ids) {
   await channels.removeConversation(ids);
+}
+
+async function getAllFriendIds() {
+  const ids = (await channels.getAllFriendIds()).map(c =>
+    setifyProperty(c, 'swarmNodes')
+  );
+
+  return ids;
 }
 
 async function getAllConversations({ ConversationCollection }) {

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -110,6 +110,7 @@ module.exports = {
   removeAllSessions,
 
   getSwarmNodesByPubkey,
+  saveSwarmNodesForPubKey,
 
   getConversationCount,
   saveConversation,
@@ -672,6 +673,16 @@ function setifyProperty(data, propertyName) {
 
 async function getSwarmNodesByPubkey(pubkey) {
   return channels.getSwarmNodesByPubkey(pubkey);
+}
+
+async function saveSwarmNodesForPubKey(pubKey, swarmNodes, { Conversation }) {
+  const conversation = await getConversationById(pubKey, { Conversation });
+  conversation.set({ swarmNodes });
+  await updateConversation(
+    conversation.id,
+    conversation.attributes,
+    { Conversation }
+  );
 }
 
 async function getConversationCount() {

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -105,20 +105,15 @@ class LokiMessageAPI {
       throw HTTPError('sendMessage: error response', response.status, result);
     };
 
-    let swarmNodes;
-    try {
-      swarmNodes = await window.LokiSnodeAPI.getSwarmNodesByPubkey(pubKey);
-    } catch (e) {
-      throw new window.textsecure.EmptySwarmError(pubKey, e);
-    }
+    let swarmNodes = await window.LokiSnodeAPI.getSwarmNodesByPubkey(pubKey);
     while (successfulRequests < MINIMUM_SUCCESSFUL_REQUESTS) {
       if (!canResolve) {
         throw new window.textsecure.DNSResolutionError('Sending messages');
       }
-      if (!swarmNodes || swarmNodes.length === 0) {
+      if (swarmNodes.length === 0) {
         swarmNodes = await window.LokiSnodeAPI.getFreshSwarmNodes(pubKey);
         swarmNodes = _.difference(swarmNodes, completedNodes);
-        if (!swarmNodes || swarmNodes.length === 0) {
+        if (swarmNodes.length === 0) {
           if (successfulRequests !== 0) {
             // TODO: Decide how to handle some completed requests but not enough
             return;

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -123,11 +123,9 @@ class LokiMessageAPI {
             new Error('Ran out of swarm nodes to query')
           );
         }
-        await window.Signal.Data.saveSwarmNodesForPubkey(
-          pubKey,
-          swarmNodes,
-          { Conversation: Whisper.Conversation }
-        );
+        await window.Signal.Data.saveSwarmNodesForPubKey(pubKey, swarmNodes, {
+          Conversation: Whisper.Conversation,
+        });
       }
       const remainingRequests =
         MINIMUM_SUCCESSFUL_REQUESTS - completedNodes.length;

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-loop-func */
-/* global log, dcodeIO, window, callWorker */
+/* global log, dcodeIO, window, callWorker, Whisper */
 
 const fetch = require('node-fetch');
 const _ = require('lodash');
@@ -105,7 +105,7 @@ class LokiMessageAPI {
       throw HTTPError('sendMessage: error response', response.status, result);
     };
 
-    let swarmNodes = await window.LokiSnodeAPI.getSwarmNodesByPubkey(pubKey);
+    let swarmNodes = await window.Signal.Data.getSwarmNodesByPubkey(pubKey);
     while (successfulRequests < MINIMUM_SUCCESSFUL_REQUESTS) {
       if (!canResolve) {
         throw new window.textsecure.DNSResolutionError('Sending messages');
@@ -123,7 +123,11 @@ class LokiMessageAPI {
             new Error('Ran out of swarm nodes to query')
           );
         }
-        await window.LokiSnodeAPI.saveSwarmNodes(pubKey, swarmNodes);
+        await window.Signal.Data.saveSwarmNodesForPubkey(
+          pubKey,
+          swarmNodes,
+          { Conversation: Whisper.Conversation }
+        );
       }
       const remainingRequests =
         MINIMUM_SUCCESSFUL_REQUESTS - completedNodes.length;

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -1,5 +1,3 @@
-// const fetch = require('node-fetch');
-
 class LokiP2pAPI {
   constructor() {
     this.contactP2pDetails = {};

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -13,17 +13,11 @@ class LokiP2pAPI {
   }
 
   getContactP2pDetails(pubKey) {
-    if (this.contactP2pDetails[pubKey]) {
-      return this.contactP2pDetails[pubKey];
-    }
-    return null;
+    return this.contactP2pDetails[pubKey] || null;
   }
 
-  removeContactP2pDetails(pubKey, address, port) {
-    this.contactP2pDetails[pubKey] = {
-      address,
-      port,
-    };
+  removeContactP2pDetails(pubKey) {
+    delete this.contactP2pDetails[pubKey];
   }
 }
 

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -1,0 +1,32 @@
+// const fetch = require('node-fetch');
+
+class LokiP2pAPI {
+  constructor() {
+    this.contactP2pDetails = {};
+  }
+
+  addContactP2pDetails(pubKey, address, port) {
+    this.contactP2pDetails[pubKey] = {
+      address,
+      port,
+    };
+  }
+
+  getContactP2pDetails(pubKey) {
+    if (this.contactP2pDetails[pubKey]) {
+      return this.contactP2pDetails[pubKey];
+    }
+    return null;
+  }
+
+  removeContactP2pDetails(pubKey, address, port) {
+    this.contactP2pDetails[pubKey] = {
+      address,
+      port,
+    };
+  }
+}
+
+module.exports = {
+  LokiP2pAPI,
+};

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -108,10 +108,7 @@ class LokiSnodeAPI {
 
   async getSwarmNodesByPubkey(pubKey) {
     const swarmNodes = await window.Signal.Data.getSwarmNodesByPubkey(pubKey);
-    if (swarmNodes) {
-      return swarmNodes;
-    }
-    return [];
+    return swarmNodes;
   }
 
   async saveSwarmNodes(pubKey, swarmNodes) {

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -106,6 +106,13 @@ class LokiSnodeAPI {
     return this.ourSwarmNodes;
   }
 
+  async refreshSwarmNodesForPubKey(pubKey) {
+    const newNodes = await this.getFreshSwarmNodes(pubKey);
+    await window.Signal.Data.saveSwarmNodesForPubKey(pubKey, newNodes, {
+      Conversation: Whisper.Conversation,
+    });
+  }
+
   async getFreshSwarmNodes(pubKey) {
     if (!(pubKey in this.swarmsPendingReplenish)) {
       this.swarmsPendingReplenish[pubKey] = new Promise(async resolve => {

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -106,23 +106,6 @@ class LokiSnodeAPI {
     return this.ourSwarmNodes;
   }
 
-  async getSwarmNodesByPubkey(pubKey) {
-    const swarmNodes = await window.Signal.Data.getSwarmNodesByPubkey(pubKey);
-    return swarmNodes;
-  }
-
-  async saveSwarmNodes(pubKey, swarmNodes) {
-    const conversation = window.ConversationController.get(pubKey);
-    conversation.set({ swarmNodes });
-    await window.Signal.Data.updateConversation(
-      conversation.id,
-      conversation.attributes,
-      {
-        Conversation: Whisper.Conversation,
-      }
-    );
-  }
-
   async getFreshSwarmNodes(pubKey) {
     if (!(pubKey in this.swarmsPendingReplenish)) {
       this.swarmsPendingReplenish[pubKey] = new Promise(async resolve => {

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -12,9 +12,13 @@
     const friendKeys = await window.Signal.Data.getPubKeysWithFriendStatus(
       window.friends.friendRequestStatusEnum.friends
     );
-    friendKeys.forEach(pubKey => {
-      sendOnlineBroadcastMessage(pubKey);
-    });
+    await Promise.all(friendKeys.map(async pubKey => {
+      try {
+        await sendOnlineBroadcastMessage(pubKey);
+      } catch(e) {
+        log.warn(`Failed to send online broadcast message to ${pubKey}`);
+      }
+    }));
   }
 
   async function sendOnlineBroadcastMessage(pubKey) {

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -12,13 +12,15 @@
     const friendKeys = await window.Signal.Data.getPubKeysWithFriendStatus(
       window.friends.friendRequestStatusEnum.friends
     );
-    await Promise.all(friendKeys.map(async pubKey => {
-      try {
-        await sendOnlineBroadcastMessage(pubKey);
-      } catch(e) {
-        log.warn(`Failed to send online broadcast message to ${pubKey}`);
-      }
-    }));
+    await Promise.all(
+      friendKeys.map(async pubKey => {
+        try {
+          await sendOnlineBroadcastMessage(pubKey);
+        } catch (e) {
+          log.warn(`Failed to send online broadcast message to ${pubKey}`);
+        }
+      })
+    );
   }
 
   async function sendOnlineBroadcastMessage(pubKey) {

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -9,18 +9,21 @@
   }
 
   async function broadcastOnlineStatus() {
-    const friendKeys = await window.Signal.Data.getAllFriendIds();
+    const friendKeys = await window.Signal.Data.getPubKeysWithFriendStatus(
+      friendRequestStatusEnum.friends
+    );
     friendKeys.forEach(pubKey => {
-      sendOnlineBroadcastMessage(pubKey)
+      sendOnlineBroadcastMessage(pubKey);
     });
   }
 
   async function sendOnlineBroadcastMessage(pubKey) {
-    const onlineBroadcastMessage = new textsecure.protobuf.OnlineBroadcastMessage({
-      snappAddress: 'testAddress',
-      port: parseInt(window.localServerPort, 10),
-      timestamp: Date.now(),
-    });
+    const onlineBroadcastMessage = new textsecure.protobuf.OnlineBroadcastMessage(
+      {
+        p2pAddress: 'testAddress',
+        p2pPort: parseInt(window.localServerPort, 10),
+      }
+    );
     const content = new textsecure.protobuf.Content({
       onlineBroadcastMessage,
     });
@@ -88,10 +91,28 @@
     }
   }
 
+  // Possible conversation friend states
+  const friendRequestStatusEnum = Object.freeze({
+    // New conversation, no messages sent or received
+    none: 0,
+    // This state is used to lock the input early while sending
+    pendingSend: 1,
+    // Friend request sent, awaiting response
+    requestSent: 2,
+    // Friend request received, awaiting user input
+    requestReceived: 3,
+    // We did it!
+    friends: 4,
+  });
+
   window.libloki.api = {
     sendFriendRequestAccepted,
     sendEmptyMessage,
     sendOnlineBroadcastMessage,
     broadcastOnlineStatus,
+  };
+
+  window.libloki.friends = {
+    friendRequestStatusEnum,
   };
 })();

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -18,14 +18,12 @@
   }
 
   async function sendOnlineBroadcastMessage(pubKey) {
-    const onlineBroadcastMessage = new textsecure.protobuf.OnlineBroadcastMessage(
-      {
-        p2pAddress: 'testAddress',
-        p2pPort: parseInt(window.localServerPort, 10),
-      }
-    );
+    const lokiAddressMessage = new textsecure.protobuf.LokiAddressMessage({
+      p2pAddress: 'testAddress',
+      p2pPort: parseInt(window.localServerPort, 10),
+    });
     const content = new textsecure.protobuf.Content({
-      onlineBroadcastMessage,
+      lokiAddressMessage,
     });
 
     // will be called once the transmission succeeded or failed

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -18,6 +18,7 @@
   }
 
   async function sendOnlineBroadcastMessage(pubKey) {
+    // TODO: Make this actually get a loki address rather than junk string
     const lokiAddressMessage = new textsecure.protobuf.LokiAddressMessage({
       p2pAddress: 'testAddress',
       p2pPort: parseInt(window.localServerPort, 10),

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -10,7 +10,7 @@
 
   async function broadcastOnlineStatus() {
     const friendKeys = await window.Signal.Data.getPubKeysWithFriendStatus(
-      friendRequestStatusEnum.friends
+      window.friends.friendRequestStatusEnum.friends
     );
     friendKeys.forEach(pubKey => {
       sendOnlineBroadcastMessage(pubKey);
@@ -90,28 +90,10 @@
     }
   }
 
-  // Possible conversation friend states
-  const friendRequestStatusEnum = Object.freeze({
-    // New conversation, no messages sent or received
-    none: 0,
-    // This state is used to lock the input early while sending
-    pendingSend: 1,
-    // Friend request sent, awaiting response
-    requestSent: 2,
-    // Friend request received, awaiting user input
-    requestReceived: 3,
-    // We did it!
-    friends: 4,
-  });
-
   window.libloki.api = {
     sendFriendRequestAccepted,
     sendEmptyMessage,
     sendOnlineBroadcastMessage,
     broadcastOnlineStatus,
-  };
-
-  window.libloki.friends = {
-    friendRequestStatusEnum,
   };
 })();

--- a/libloki/friends.js
+++ b/libloki/friends.js
@@ -1,0 +1,22 @@
+/* global window */
+
+// eslint-disable-next-line func-names
+(function() {
+  // Possible conversation friend states
+  const friendRequestStatusEnum = Object.freeze({
+    // New conversation, no messages sent or received
+    none: 0,
+    // This state is used to lock the input early while sending
+    pendingSend: 1,
+    // Friend request sent, awaiting response
+    requestSent: 2,
+    // Friend request received, awaiting user input
+    requestReceived: 3,
+    // We did it!
+    friends: 4,
+  });
+
+  window.friends = {
+    friendRequestStatusEnum,
+  };
+})();

--- a/libloki/local_loki_server.js
+++ b/libloki/local_loki_server.js
@@ -68,6 +68,7 @@ class LocalLokiServer extends EventEmitter {
 
   // Async wrapper for http server close
   close() {
+    this.removeAllListeners();
     if (this.server) {
       return new Promise(res => {
         this.server.close(() => res());

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -712,16 +712,6 @@ MessageReceiver.prototype.extend({
           .then(this.unpad)
           .then(handleSessionReset);
         break;
-      case textsecure.protobuf.Envelope.Type.ONLINE_BROADCAST:
-        window.log.info(
-          'Online broadcast message from',
-          this.getEnvelopeId(envelope)
-        );
-        promise = captureActiveSession()
-          .then(() => sessionCipher.decryptWhisperMessage(ciphertext))
-          .then(this.unpad)
-          .then(handleSessionReset);
-        break;
       case textsecure.protobuf.Envelope.Type.FRIEND_REQUEST: {
         window.log.info('friend-request message from ', envelope.source);
         promise = fallBackSessionCipher
@@ -908,8 +898,8 @@ MessageReceiver.prototype.extend({
       })
     );
   },
-  async handleOnlineBroadcastMessage(envelope, onlineBroadcastMessage) {
-    const { p2pAddress, p2pPort } = onlineBroadcastMessage;
+  async handleLokiAddressMessage(envelope, lokiAddressMessage) {
+    const { p2pAddress, p2pPort } = lokiAddressMessage;
     window.LokiP2pAPI.addContactP2pDetails(
       envelope.source,
       p2pAddress,
@@ -1031,10 +1021,10 @@ MessageReceiver.prototype.extend({
         envelope.source,
         content.preKeyBundleMessage
       );
-    if (content.onlineBroadcastMessage)
-      return this.handleOnlineBroadcastMessage(
+    if (content.lokiAddressMessage)
+      return this.handleLokiAddressMessage(
         envelope,
-        content.onlineBroadcastMessage
+        content.lokiAddressMessage
       );
     if (content.syncMessage)
       return this.handleSyncMessage(envelope, content.syncMessage);

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -336,8 +336,13 @@ OutgoingMessage.prototype = {
             dcodeIO.ByteBuffer.wrap(ciphertext.body, 'binary').toArrayBuffer()
           );
         }
+        const outgoingObjectType =
+          this.messageType === 'onlineBroadcast'
+            ? textsecure.protobuf.Envelope.Type.ONLINE_BROADCAST
+            : ciphertext.type; // FallBackSessionCipher sets this to FRIEND_REQUEST
+
         return {
-          type: ciphertext.type, // FallBackSessionCipher sets this to FRIEND_REQUEST
+          type: outgoingObjectType,
           ourKey,
           sourceDevice: 1,
           destinationRegistrationId: ciphertext.registrationId,
@@ -350,14 +355,18 @@ OutgoingMessage.prototype = {
         const outgoingObject = outgoingObjects[0];
         const socketMessage = await this.wrapInWebsocketMessage(outgoingObject);
         let ttl;
-        if (
-          outgoingObject.type ===
-          textsecure.protobuf.Envelope.Type.FRIEND_REQUEST
-        ) {
-          ttl = 4 * 24 * 60 * 60; // 4 days for friend request message
-        } else {
-          const hours = window.getMessageTTL() || 24; // 1 day default for any other message
-          ttl = hours * 60 * 60;
+        switch (outgoingObject.type) {
+          case textsecure.protobuf.Envelope.Type.FRIEND_REQUEST:
+            ttl = 4 * 24 * 60 * 60; // 4 days for friend request message
+            break;
+          case textsecure.protobuf.Envelope.Type.ONLINE_BROADCAST:
+            ttl = 10 * 60; // 10 minutes for online broadcast message
+            break;
+          default: {
+            const hours = window.getMessageTTL() || 24; // 1 day default for any other message
+            ttl = hours * 60 * 60;
+            break;
+          }
         }
         await this.transmitMessage(number, socketMessage, this.timestamp, ttl);
         this.successfulNumbers[this.successfulNumbers.length] = number;

--- a/main.js
+++ b/main.js
@@ -146,6 +146,7 @@ function prepareURL(pathSegments, moreKeys) {
       cdnUrl: config.get('cdnUrl'),
       messageServerPort: config.get('messageServerPort'),
       swarmServerPort: config.get('swarmServerPort'),
+      localServerPort: config.get('localServerPort'),
       certificateAuthority: config.get('certificateAuthority'),
       environment: config.environment,
       node_version: process.versions.node,

--- a/preload.js
+++ b/preload.js
@@ -285,7 +285,8 @@ window.LokiMessageAPI = new LokiMessageAPI({
 
 const { LocalLokiServer } = require('./libloki/local_loki_server');
 
-window.LocalLokiServer = LocalLokiServer;
+window.localServerPort = config.localServerPort;
+window.LocalLokiServer = new LocalLokiServer();
 
 window.mnemonic = require('./libloki/mnemonic');
 const { WorkerInterface } = require('./js/modules/util_worker_interface');

--- a/preload.js
+++ b/preload.js
@@ -276,6 +276,10 @@ window.LokiSnodeAPI = new LokiSnodeAPI({
   swarmServerPort: config.swarmServerPort,
 });
 
+const { LokiP2pAPI } = require('./js/modules/loki_p2p_api');
+
+window.LokiP2pAPI = new LokiP2pAPI();
+
 const { LokiMessageAPI } = require('./js/modules/loki_message_api');
 
 window.LokiMessageAPI = new LokiMessageAPI({

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -13,7 +13,6 @@ message Envelope {
     RECEIPT       = 5;
     UNIDENTIFIED_SENDER = 6;
     FRIEND_REQUEST = 101; // contains prekeys + message and is using simple encryption
-    ONLINE_BROADCAST = 102; // Contains address and port information for p2p messaging
   }
 
   optional Type   type            = 1;
@@ -36,10 +35,10 @@ message Content {
   optional ReceiptMessage receiptMessage = 5;
   optional TypingMessage  typingMessage  = 6;
   optional PreKeyBundleMessage preKeyBundleMessage = 101;
-  optional OnlineBroadcastMessage onlineBroadcastMessage = 102;
+  optional LokiAddressMessage lokiAddressMessage = 102;
 }
 
-message OnlineBroadcastMessage {
+message LokiAddressMessage {
   optional string p2pAddress    = 1;
   optional uint32 p2pPort       = 2;
 }

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -40,8 +40,8 @@ message Content {
 }
 
 message OnlineBroadcastMessage {
-  optional string snappAddress    = 1;
-  optional uint32 port            = 2;
+  optional string p2pAddress    = 1;
+  optional uint32 p2pPort       = 2;
 }
 
 message PreKeyBundleMessage {

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -13,6 +13,7 @@ message Envelope {
     RECEIPT       = 5;
     UNIDENTIFIED_SENDER = 6;
     FRIEND_REQUEST = 101; // contains prekeys + message and is using simple encryption
+    ONLINE_BROADCAST = 102; // Contains address and port information for p2p messaging
   }
 
   optional Type   type            = 1;
@@ -35,6 +36,12 @@ message Content {
   optional ReceiptMessage receiptMessage = 5;
   optional TypingMessage  typingMessage  = 6;
   optional PreKeyBundleMessage preKeyBundleMessage = 101;
+  optional OnlineBroadcastMessage onlineBroadcastMessage = 102;
+}
+
+message OnlineBroadcastMessage {
+  optional string snappAddress    = 1;
+  optional uint32 port            = 2;
 }
 
 message PreKeyBundleMessage {

--- a/test/index.html
+++ b/test/index.html
@@ -360,6 +360,7 @@
   <script type="text/javascript" src="../js/storage.js" data-cover></script>
   <script type="text/javascript" src="../js/signal_protocol_store.js" data-cover></script>
   <script type="text/javascript" src="../js/libtextsecure.js" data-cover></script>
+  <script type="text/javascript" src="../js/libloki.js" data-cover></script>
 
   <script type="text/javascript" src="../js/libphonenumber-util.js"></script>
   <script type='text/javascript' src='../js/models/profile.js' data-cover></script>


### PR DESCRIPTION
Start of P2P stuff, added a new message proto type for a loki address message
When you launch the app you "broadcast" a message to all of your friends with your P2P address info (currently just dummy data because we don't have a way to get our loki address yet) and then the recipient stores this in memory
Next up is the logic for pinging, i.e. the timers etc and then hooking in the message sending to use these addresses if the other user is "online"
Also allowing the user to manually select the port they want to use for their http server (and fall back to the node port finding thing if it doesn't work)

Fixes #154 