### PR TITLE
P2P messaging

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -642,6 +642,7 @@
         await this.respondToAllPendingFriendRequests({
           response: 'accepted',
         });
+        window.libloki.api.sendOnlineBroadcastMessage(this.id);
         return true;
       }
       return false;

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -16,34 +16,16 @@ class LokiP2pAPI extends EventEmitter {
         ? 60 * 1000 // 1 minute
         : 2 * 60 * 1000; // 2 minutes
 
-    if (!this.contactP2pDetails[pubKey]) {
-      // If this is the first time we are getting this contacts details
-      // then we try to ping them straight away
-      this.contactP2pDetails[pubKey] = {
-        address,
-        port,
-        timerDuration,
-        isOnline: false,
-        pingTimer: null,
-      };
-      this.pingContact(pubKey);
-      return;
+    if (this.contactP2pDetails[pubKey] && this.contactP2pDetails[pubKey].pingTimer) {
+      clearTimeout(this.contactP2pDetails[pubKey].pingTimer);
     }
-
-    clearTimeout(this.contactP2pDetails[pubKey].pingTimer);
-    if (
-      this.contactP2pDetails[pubKey].address !== address ||
-      this.contactP2pDetails[pubKey].port !== port
-    ) {
-      // If this contact has changed their details
-      // then we try to ping them straight away
-      this.contactP2pDetails[pubKey].address = address;
-      this.contactP2pDetails[pubKey].port = port;
-      this.contactP2pDetails[pubKey].isOnline = false;
-      this.pingContact(pubKey);
-      return;
-    }
-
+    this.contactP2pDetails[pubKey] = {
+      address,
+      port,
+      timerDuration,
+      isOnline: false,
+      pingTimer: null,
+    };
     if (resetTimer) {
       // If this contact is simply sharing the same details with us
       // then we just reset our timer

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -1,21 +1,94 @@
-class LokiP2pAPI {
+/* global setTimeout, clearTimeout, window */
+
+const EventEmitter = require('events');
+
+class LokiP2pAPI extends EventEmitter {
   constructor() {
+    super();
     this.contactP2pDetails = {};
   }
 
-  addContactP2pDetails(pubKey, address, port) {
-    this.contactP2pDetails[pubKey] = {
-      address,
-      port,
-    };
+  addContactP2pDetails(pubKey, address, port, resetTimer = false) {
+    // Stagger the timers so the friends don't ping each other at the same time
+    this.ourKey = this.ourKey || window.textsecure.storage.user.getNumber();
+    const timerDuration =
+      pubKey < this.ourKey
+        ? 60 * 1000 // 1 minute
+        : 2 * 60 * 1000; // 2 minutes
+
+    if (!this.contactP2pDetails[pubKey]) {
+      // If this is the first time we are getting this contacts details
+      // then we try to ping them straight away
+      this.contactP2pDetails[pubKey] = {
+        address,
+        port,
+        timerDuration,
+        isOnline: false,
+        pingTimer: null,
+      };
+      this.pingContact(pubKey);
+      return;
+    }
+
+    clearTimeout(this.contactP2pDetails[pubKey].pingTimer);
+    if (
+      this.contactP2pDetails[pubKey].address !== address ||
+      this.contactP2pDetails[pubKey].port !== port
+    ) {
+      // If this contact has changed their details
+      // then we try to ping them straight away
+      this.contactP2pDetails[pubKey].address = address;
+      this.contactP2pDetails[pubKey].port = port;
+      this.contactP2pDetails[pubKey].isOnline = false;
+      this.pingContact(pubKey);
+      return;
+    }
+
+    if (resetTimer) {
+      // If this contact is simply sharing the same details with us
+      // then we just reset our timer
+      this.contactP2pDetails[pubKey].pingTimer = setTimeout(
+        this.pingContact.bind(this),
+        this.contactP2pDetails[pubKey].timerDuration,
+        pubKey
+      );
+      return;
+    }
+    this.pingContact(pubKey);
   }
 
   getContactP2pDetails(pubKey) {
     return this.contactP2pDetails[pubKey] || null;
   }
 
-  removeContactP2pDetails(pubKey) {
-    delete this.contactP2pDetails[pubKey];
+  setContactOffline(pubKey) {
+    this.emit('offline', pubKey);
+    if (!this.contactP2pDetails[pubKey]) {
+      return;
+    }
+    clearTimeout(this.contactP2pDetails[pubKey].pingTimer);
+    this.contactP2pDetails[pubKey].isOnline = false;
+  }
+
+  setContactOnline(pubKey) {
+    if (!this.contactP2pDetails[pubKey]) {
+      return;
+    }
+    this.emit('online', pubKey);
+    clearTimeout(this.contactP2pDetails[pubKey].pingTimer);
+    this.contactP2pDetails[pubKey].isOnline = true;
+    this.contactP2pDetails[pubKey].pingTimer = setTimeout(
+      this.pingContact.bind(this),
+      this.contactP2pDetails[pubKey].timerDuration,
+      pubKey
+    );
+  }
+
+  pingContact(pubKey) {
+    if (!this.contactP2pDetails[pubKey]) {
+      return;
+    }
+    window.libloki.api.sendOnlineBroadcastMessage(pubKey, true);
   }
 }
 

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -23,10 +23,9 @@
     );
   }
 
-  async function sendOnlineBroadcastMessage(pubKey) {
-    // TODO: Make this actually get a loki address rather than junk string
+  async function sendOnlineBroadcastMessage(pubKey, forceP2p = false) {
     const lokiAddressMessage = new textsecure.protobuf.LokiAddressMessage({
-      p2pAddress: 'testAddress',
+      p2pAddress: 'http://localhost',
       p2pPort: parseInt(window.localServerPort, 10),
     });
     const content = new textsecure.protobuf.Content({
@@ -41,7 +40,7 @@
         log.info('Online broadcast message sent successfully');
       }
     };
-    const options = { messageType: 'onlineBroadcast' };
+    const options = { messageType: 'onlineBroadcast', forceP2p };
     // Send a empty message with information about how to contact us directly
     const outgoingMessage = new textsecure.OutgoingMessage(
       null, // server

--- a/libtextsecure/http-resources.js
+++ b/libtextsecure/http-resources.js
@@ -74,7 +74,7 @@
       });
     };
 
-    this.handleMessage = message => {
+    this.handleMessage = (message, isP2p = false) => {
       try {
         const dataPlaintext = stringToArrayBufferBase64(message);
         const messageBuf = textsecure.protobuf.WebSocketMessage.decode(
@@ -89,7 +89,8 @@
               path: messageBuf.request.path,
               body: messageBuf.request.body,
               id: messageBuf.request.id,
-            })
+            }),
+            isP2p
           );
         }
       } catch (error) {

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -42,11 +42,13 @@ function OutgoingMessage(
   this.failoverNumbers = [];
   this.unidentifiedDeliveries = [];
 
-  const { numberInfo, senderCertificate, online, messageType } = options || {};
+  const { numberInfo, senderCertificate, online, messageType, forceP2p } =
+    options || {};
   this.numberInfo = numberInfo;
   this.senderCertificate = senderCertificate;
   this.online = online;
   this.messageType = messageType || 'outgoing';
+  this.forceP2p = forceP2p || false;
 }
 
 OutgoingMessage.prototype = {
@@ -185,7 +187,13 @@ OutgoingMessage.prototype = {
   async transmitMessage(number, data, timestamp, ttl = 24 * 60 * 60) {
     const pubKey = number;
     try {
-      await lokiMessageAPI.sendMessage(pubKey, data, timestamp, ttl);
+      await lokiMessageAPI.sendMessage(
+        pubKey,
+        data,
+        timestamp,
+        ttl,
+        this.forceP2p
+      );
     } catch (e) {
       if (e.name === 'HTTPError' && (e.code !== 409 && e.code !== 410)) {
         // 409 and 410 should bubble and be handled by doSendMessage


### PR DESCRIPTION
Lots of logic for establishing a p2p connection, managing when the other user is online vs offline etc. Will always try to use P2P messaging when it can and fall back to storage server otherwise
Pinging system to determine whether a user is online or offline, staggered so one user always pings the other until one of them goes offline
Failing to send a P2P message will result in a contact being marked as offline

Next up is the UI for online/offline contacts (Mik)
I feel like there might be some redundant logic in here somewhere (as in I think I am doing more back and forth than totally necessary but can't wrap my head around it yet)
I have tested this over lokinet (hardcoded .loki address) and it works like a charm ;)
Once the localhost.loki is working (and they fix it for Macs) then we can go completely over lokinet ayy

Also I need to write tests for this stuff in another PR, especially the P2pAPI stuff should be easy to test

MVP of #140 