### PR TITLE
Added local link previews

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1102,6 +1102,17 @@
     "message": "General",
     "description": "Header for general options on the settings screen"
   },
+  "sendLinkPreviews": {
+    "message": "Send Link Previews",
+    "description":
+      "Option to control creation and send of link previews in setting screen"
+  },
+  "linkPreviewsDescription": {
+    "message":
+      "Enable local link previews (Restart for changes to take effect)",
+    "description":
+      "Additional detail provided for Link Previews option in settings screen"
+  },
   "spellCheckDescription": {
     "message": "Enable spell check of text entered in message composition box",
     "description": "Description of the media permission description"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1102,16 +1102,21 @@
     "message": "General",
     "description": "Header for general options on the settings screen"
   },
-  "sendLinkPreviews": {
-    "message": "Send Link Previews",
+  "linkPreviews": {
+    "message": "Link Previews",
     "description":
       "Option to control creation and send of link previews in setting screen"
   },
   "linkPreviewsDescription": {
     "message":
-      "Enable local link previews (Restart for changes to take effect)",
+      "Previews are supported for Imgur, Instagram, Reddit, and YouTube links.",
     "description":
       "Additional detail provided for Link Previews option in settings screen"
+  },
+  "linkPreviewsSettingDescription": {
+    "message":
+      "Enable local link previews (Restart for changes to take effect).",
+    "description": "Description shown for the Link Preview option "
   },
   "spellCheckDescription": {
     "message": "Enable spell check of text entered in message composition box",

--- a/background.html
+++ b/background.html
@@ -730,6 +730,7 @@
   <script type='text/javascript' src='js/expire.js'></script>
   <script type='text/javascript' src='js/conversation_controller.js'></script>
   <script type='text/javascript' src='js/blocked_number_controller.js'></script>
+  <script type='text/javascript' src='js/link_previews_helper.js'></script>
 
   <script type='text/javascript' src='js/views/react_wrapper_view.js'></script>
   <script type='text/javascript' src='js/views/whisper_view.js'></script>

--- a/js/background.js
+++ b/js/background.js
@@ -254,6 +254,11 @@
       getReadReceiptSetting: () => storage.get('read-receipt-setting'),
       setReadReceiptSetting: value =>
         storage.put('read-receipt-setting', value),
+
+      getLinkPreviewSetting: () => storage.get('linkPreviews', false),
+      setLinkPreviewSetting: value =>
+        storage.put('linkPreviews', value),
+
       getNotificationSetting: () =>
         storage.get('notification-setting', 'message'),
       setNotificationSetting: value =>

--- a/js/background.js
+++ b/js/background.js
@@ -256,8 +256,7 @@
         storage.put('read-receipt-setting', value),
 
       getLinkPreviewSetting: () => storage.get('linkPreviews', false),
-      setLinkPreviewSetting: value =>
-        storage.put('linkPreviews', value),
+      setLinkPreviewSetting: value => storage.put('linkPreviews', value),
 
       getNotificationSetting: () =>
         storage.get('notification-setting', 'message'),

--- a/js/link_previews_helper.js
+++ b/js/link_previews_helper.js
@@ -1,8 +1,9 @@
 /* global
   Signal,
   textsecure,
-  dcodeIO,
 */
+
+/* eslint-disable no-bitwise */
 
 // eslint-disable-next-line func-names
 (function() {
@@ -10,29 +11,6 @@
 
   window.Signal = window.Signal || {};
   window.Signal.LinkPreviews = window.Signal.LinkPreviews || {};
-
-  const base64ImageCache = {};
-
-  function getBase64Image(preview) {
-    const { url, image } = preview;
-    if (!url || !image || !image.data) return null;
-
-    // Return the cached value
-    if (base64ImageCache[url]) return base64ImageCache[url];
-
-    // Set the cache and return the value
-    try {
-      const contentType = image.contentType || 'image/jpeg';
-      const base64 = dcodeIO.ByteBuffer.wrap(image.data).toString('base64');
-
-      const data = `data:${contentType};base64, ${base64}`;
-      base64ImageCache[url] = data;
-
-      return data;
-    } catch (e) {
-      return null;
-    }
-  }
 
   async function makeChunkedRequest(url) {
     const PARALLELISM = 3;
@@ -81,6 +59,19 @@
       contentType,
       data,
     };
+  }
+
+  function hashCode(string) {
+    let hash = 0;
+    if (string.length === 0) {
+      return hash;
+    }
+    for (let i = 0; i < string.length; i += 1) {
+      const char = string.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash &= hash; // Convert to 32bit integer
+    }
+    return hash;
   }
 
   async function getPreview(url) {
@@ -145,11 +136,11 @@
       title,
       url,
       image,
+      hash: hashCode(url),
     };
   }
 
   window.Signal.LinkPreviews.helper = {
     getPreview,
-    getBase64Image,
   };
 })();

--- a/js/link_previews_helper.js
+++ b/js/link_previews_helper.js
@@ -21,13 +21,17 @@
     if (base64ImageCache[url]) return base64ImageCache[url];
 
     // Set the cache and return the value
-    const contentType = image.contentType || 'image/jpeg';
-    const base64 = dcodeIO.ByteBuffer.wrap(image.data).toString('base64');
+    try {
+      const contentType = image.contentType || 'image/jpeg';
+      const base64 = dcodeIO.ByteBuffer.wrap(image.data).toString('base64');
 
-    const data = `data:${contentType};base64, ${base64}`;
-    base64ImageCache[url] = data;
+      const data = `data:${contentType};base64, ${base64}`;
+      base64ImageCache[url] = data;
 
-    return data;
+      return data;
+    } catch (e) {
+      return null;
+    }
   }
 
   async function makeChunkedRequest(url) {
@@ -147,5 +151,5 @@
   window.Signal.LinkPreviews.helper = {
     getPreview,
     getBase64Image,
-  }
+  };
 })();

--- a/js/link_previews_helper.js
+++ b/js/link_previews_helper.js
@@ -1,0 +1,151 @@
+/* global
+  Signal,
+  textsecure,
+  dcodeIO,
+*/
+
+// eslint-disable-next-line func-names
+(function() {
+  'use strict';
+
+  window.Signal = window.Signal || {};
+  window.Signal.LinkPreviews = window.Signal.LinkPreviews || {};
+
+  const base64ImageCache = {};
+
+  function getBase64Image(preview) {
+    const { url, image } = preview;
+    if (!url || !image || !image.data) return null;
+
+    // Return the cached value
+    if (base64ImageCache[url]) return base64ImageCache[url];
+
+    // Set the cache and return the value
+    const contentType = image.contentType || 'image/jpeg';
+    const base64 = dcodeIO.ByteBuffer.wrap(image.data).toString('base64');
+
+    const data = `data:${contentType};base64, ${base64}`;
+    base64ImageCache[url] = data;
+
+    return data;
+  }
+
+  async function makeChunkedRequest(url) {
+    const PARALLELISM = 3;
+    const size = await textsecure.messaging.getProxiedSize(url);
+    const chunks = await Signal.LinkPreviews.getChunkPattern(size);
+
+    let results = [];
+    const jobs = chunks.map(chunk => async () => {
+      const { start, end } = chunk;
+
+      const result = await textsecure.messaging.makeProxiedRequest(url, {
+        start,
+        end,
+        returnArrayBuffer: true,
+      });
+
+      return {
+        ...chunk,
+        ...result,
+      };
+    });
+
+    while (jobs.length > 0) {
+      const activeJobs = [];
+      for (let i = 0, max = PARALLELISM; i < max; i += 1) {
+        if (!jobs.length) {
+          break;
+        }
+
+        const job = jobs.shift();
+        activeJobs.push(job());
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      results = results.concat(await Promise.all(activeJobs));
+    }
+
+    if (!results.length) {
+      throw new Error('No responses received');
+    }
+
+    const { contentType } = results[0];
+    const data = Signal.LinkPreviews.assembleChunks(results);
+
+    return {
+      contentType,
+      data,
+    };
+  }
+
+  async function getPreview(url) {
+    let html;
+    try {
+      html = await textsecure.messaging.makeProxiedRequest(url);
+    } catch (error) {
+      if (error.code >= 300) {
+        return null;
+      }
+    }
+
+    const title = window.Signal.LinkPreviews.getTitleMetaTag(html);
+    const imageUrl = window.Signal.LinkPreviews.getImageMetaTag(html);
+
+    let image;
+    let objectUrl;
+    try {
+      if (imageUrl) {
+        if (!Signal.LinkPreviews.isMediaLinkInWhitelist(imageUrl)) {
+          const primaryDomain = Signal.LinkPreviews.getDomain(url);
+          const imageDomain = Signal.LinkPreviews.getDomain(imageUrl);
+          throw new Error(
+            `imageUrl for domain ${primaryDomain} did not match media whitelist. Domain: ${imageDomain}`
+          );
+        }
+
+        const data = await makeChunkedRequest(imageUrl);
+
+        // Calculate dimensions
+        const file = new Blob([data.data], {
+          type: data.contentType,
+        });
+        objectUrl = URL.createObjectURL(file);
+
+        const dimensions = await Signal.Types.VisualAttachment.getImageDimensions(
+          {
+            objectUrl,
+            logger: window.log,
+          }
+        );
+
+        image = {
+          ...data,
+          ...dimensions,
+          contentType: file.type,
+        };
+      }
+    } catch (error) {
+      // We still want to show the preview if we failed to get an image
+      window.log.error(
+        'getPreview failed to get image for link preview:',
+        error.message
+      );
+    } finally {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    }
+
+    return {
+      title,
+      url,
+      image,
+    };
+  }
+
+  window.Signal.LinkPreviews.helper = {
+    getPreview,
+    getBase64Image,
+  }
+})();

--- a/js/link_previews_helper.js
+++ b/js/link_previews_helper.js
@@ -1,6 +1,7 @@
 /* global
   Signal,
   textsecure,
+  StringView
 */
 
 /* eslint-disable no-bitwise */
@@ -61,17 +62,10 @@
     };
   }
 
-  function hashCode(string) {
-    let hash = 0;
-    if (string.length === 0) {
-      return hash;
-    }
-    for (let i = 0; i < string.length; i += 1) {
-      const char = string.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash &= hash; // Convert to 32bit integer
-    }
-    return hash;
+  async function sha256(string) {
+    const arraybuffer = new TextEncoder('utf-8').encode(string);
+    const digest = await window.crypto.subtle.digest('SHA-256', arraybuffer);
+    return StringView.arrayBufferToHex(digest);
   }
 
   async function getPreview(url) {
@@ -132,11 +126,13 @@
       }
     }
 
+    const hash = await sha256(url);
+
     return {
       title,
       url,
       image,
-      hash: hashCode(url),
+      hash,
     };
   }
 

--- a/js/link_previews_helper.js
+++ b/js/link_previews_helper.js
@@ -89,8 +89,8 @@
       }
     }
 
-    const title = window.Signal.LinkPreviews.getTitleMetaTag(html);
-    const imageUrl = window.Signal.LinkPreviews.getImageMetaTag(html);
+    const title = Signal.LinkPreviews.getTitleMetaTag(html);
+    const imageUrl = Signal.LinkPreviews.getImageMetaTag(html);
 
     let image;
     let objectUrl;

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -159,10 +159,11 @@
         const { data } = image;
         const extension = Attachment.getFileExtension(image);
         if (data && extension) {
+          const hash32 = hash.substring(0, 32);
           try {
             const filePath = await writeAttachment({
               data,
-              path: `previews/${hash}.${extension}`,
+              path: `previews/${hash32}.${extension}`,
             });
 
             // return the image without the data

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -140,13 +140,9 @@
 
       try {
         const result = await Signal.LinkPreviews.helper.getPreview(firstLink);
-        if (!result) {
-          this.updatingPreview = false;
-          return;
-        }
 
-        if (!result.image && !result.title) {
-          // A link preview isn't worth showing unless we have either a title or an image
+        // A link preview isn't worth showing unless we have either a title or an image
+        if (!result || !(result.image || result.title)) {
           this.updatingPreview = false;
           return;
         }

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -139,6 +139,8 @@
           return;
         }
 
+        // We don't want to save the base64 url in the message as it will increase the size of it
+        // Rather we fetch the base64 later
         this.set({ preview: [result] });
       } catch (e) {
         window.log.warn(`Failed to load previews for message: ${this.id}`);

--- a/js/modules/signal.js
+++ b/js/modules/signal.js
@@ -169,6 +169,8 @@ function initializeMigrations({
       logger,
     }),
     writeNewAttachmentData: createWriterForNew(attachmentsPath),
+    writeAttachment: ({ data, path }) =>
+      createWriterForExisting(attachmentsPath)({ data, path }),
   };
 }
 

--- a/js/modules/types/attachment.js
+++ b/js/modules/types/attachment.js
@@ -208,6 +208,7 @@ exports.deleteData = deleteOnDisk => {
 
 exports.isVoiceMessage = AttachmentTS.isVoiceMessage;
 exports.save = AttachmentTS.save;
+exports.getFileExtension = AttachmentTS.getFileExtension;
 
 const THUMBNAIL_SIZE = 150;
 const THUMBNAIL_CONTENT_TYPE = 'image/png';

--- a/js/settings_start.js
+++ b/js/settings_start.js
@@ -20,6 +20,7 @@ const getInitialData = async () => ({
 
   messageTTL: await window.getMessageTTL(),
   readReceiptSetting: await window.getReadReceiptSetting(),
+  linkPreviewSetting: await window.getLinkPreviewSetting(),
   notificationSetting: await window.getNotificationSetting(),
   audioNotification: await window.getAudioNotification(),
 

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -155,6 +155,12 @@
         value: window.initialData.hideMenuBar,
         setFn: window.setHideMenuBar,
       });
+      new CheckboxView({
+        el: this.$('.link-preview-setting'),
+        name: 'link-preview-setting',
+        value: window.initialData.linkPreviewSetting,
+        setFn: window.setLinkPreviewSetting,
+      });
       new MediaPermissionsSettingView({
         el: this.$('.media-permissions'),
         value: window.initialData.mediaPermissions,

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -218,8 +218,9 @@
         spellCheckHeader: i18n('spellCheck'),
         spellCheckDescription: i18n('spellCheckDescription'),
         blockedHeader: 'Blocked Users',
-        sendLinkPreviews: i18n('sendLinkPreviews'),
+        linkPreviews: i18n('linkPreviews'),
         linkPreviewsDescription: i18n('linkPreviewsDescription'),
+        linkPreviewsSettingDescription: i18n('linkPreviewsSettingDescription'),
       };
     },
     onClose() {

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -307,6 +307,13 @@ MessageSender.prototype = {
     const message = new Message(attrs);
     const silent = false;
 
+    // Remove this when we add support for attachments
+    message.attachmentPointers = null;
+    message.preview = null;
+    if (message.quote) {
+      message.quote.attachments = null;
+    }
+
     return Promise.all([
       this.uploadAttachments(message),
       this.uploadThumbnails(message),

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -308,10 +308,11 @@ MessageSender.prototype = {
     const silent = false;
 
     // Remove this when we add support for attachments
-    message.attachmentPointers = null;
-    message.preview = null;
+    message.attachments = [];
+    message.attachmentPointers = [];
+    message.preview = [];
     if (message.quote) {
-      message.quote.attachments = null;
+      message.quote.attachments = [];
     }
 
     return Promise.all([

--- a/main.js
+++ b/main.js
@@ -1091,6 +1091,9 @@ installSettingsSetter('notification-setting');
 installSettingsGetter('audio-notification');
 installSettingsSetter('audio-notification');
 
+installSettingsGetter('link-preview-setting');
+installSettingsSetter('link-preview-setting');
+
 installSettingsGetter('spell-check');
 installSettingsSetter('spell-check');
 

--- a/preload.js
+++ b/preload.js
@@ -171,6 +171,9 @@ installSetter('notification-setting', 'setNotificationSetting');
 installGetter('audio-notification', 'getAudioNotification');
 installSetter('audio-notification', 'setAudioNotification');
 
+installGetter('link-preview-setting', 'getLinkPreviewSetting');
+installSetter('link-preview-setting', 'setLinkPreviewSetting');
+
 installGetter('spell-check', 'getSpellCheck');
 installSetter('spell-check', 'setSpellCheck');
 

--- a/settings.html
+++ b/settings.html
@@ -98,11 +98,16 @@
         <input type='checkbox' name='spell-check-setting' id='spell-check-setting' />
         <label for='spell-check-setting'>{{ spellCheckDescription }}</label>
       </div>
-      <div class='link-preview-setting'>
-        <input type='checkbox' name='link-preview-setting' id='link-preview-setting' />
-        <label for='link-preview-setting'>{{ linkPreviewsDescription }}</label>
-      </div>
+
     <hr>
+    <h3>{{ linkPreviews }}</h3>
+    <div>{{ linkPreviewsDescription }}<div>
+    </br>
+    <div class='link-preview-setting'>
+      <input type='checkbox' name='link-preview-setting' id='link-preview-setting' />
+      <label for='link-preview-setting'>{{ linkPreviewsSettingDescription }}</label>
+    </div>
+  <hr>
     <div class='permissions-setting'>
       <h3>{{ permissions }}</h3>
       <div class='media-permissions'>

--- a/settings.html
+++ b/settings.html
@@ -98,6 +98,10 @@
         <input type='checkbox' name='spell-check-setting' id='spell-check-setting' />
         <label for='spell-check-setting'>{{ spellCheckDescription }}</label>
       </div>
+      <div class='link-preview-setting'>
+        <input type='checkbox' name='link-preview-setting' id='link-preview-setting' />
+        <label for='link-preview-setting'>{{ linkPreviewsDescription }}</label>
+      </div>
     <hr>
     <div class='permissions-setting'>
       <h3>{{ permissions }}</h3>

--- a/settings_preload.js
+++ b/settings_preload.js
@@ -52,6 +52,9 @@ window.setNotificationSetting = makeSetter('notification-setting');
 window.getAudioNotification = makeGetter('audio-notification');
 window.setAudioNotification = makeSetter('audio-notification');
 
+window.getLinkPreviewSetting = makeGetter('link-preview-setting');
+window.setLinkPreviewSetting = makeSetter('link-preview-setting');
+
 window.getMediaPermissions = makeGetter('media-permissions');
 window.setMediaPermissions = makeSetter('media-permissions');
 


### PR DESCRIPTION
This PR expands on the Signal preview functionality to make it work with our application.

Resolves #179
Resolves #180 

I ripped some code out into a custom `helper` class, but left the original code untouched (in `conversation_view`)

We save the images locally inside the `attachments` folder and under `previews`

**Changes:**
- Disable sending attachments in messages
- Added local link preview setting
- Added showing link previews of incoming messages

<img width="318" alt="screen shot 2019-02-08 at 2 09 13 pm" src="https://user-images.githubusercontent.com/4365065/52458286-b0174980-2bb2-11e9-8752-e2c40c993134.png">
