### PR TITLE
Swarm fixes

### DIFF
--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -199,9 +199,10 @@
         return conversation;
       };
 
-      conversation.initialPromise = create().then(async () => {
-        window.lokiSnodeAPI.refreshSwarmNodesForPubKey(id);
-        conversation.updateProfileAvatar();
+      conversation.initialPromise = create();
+      conversation.initialPromise.then(async () => {
+        await window.lokiSnodeAPI.refreshSwarmNodesForPubKey(id);
+        await conversation.updateProfileAvatar();
       });
 
       return conversation;

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -185,7 +185,6 @@
           await window.Signal.Data.saveConversation(conversation.attributes, {
             Conversation: Whisper.Conversation,
           });
-          window.LokiSnodeAPI.refreshSwarmNodesForPubKey(id);
         } catch (error) {
           window.log.error(
             'Conversation save failed! ',
@@ -200,9 +199,10 @@
         return conversation;
       };
 
-      conversation.initialPromise = create().then(() =>
-        conversation.updateProfileAvatar()
-      );
+      conversation.initialPromise = create().then(async () => {
+        window.lokiSnodeAPI.refreshSwarmNodesForPubKey(id);
+        conversation.updateProfileAvatar();
+      });
 
       return conversation;
     },

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -78,7 +78,7 @@
         friendRequestStatus: FriendRequestStatusEnum.none,
         unlockTimestamp: null, // Timestamp used for expiring friend requests.
         sessionResetStatus: SessionResetEnum.none,
-        swarmNodes: new Set([]),
+        swarmNodes: [],
         isOnline: false,
       };
     },
@@ -1405,6 +1405,12 @@
                 ),
         },
       };
+    },
+    async updateSwarmNodes(swarmNodes) {
+      this.set({ swarmNodes });
+      await window.Signal.Data.updateConversation(this.id, this.attributes, {
+        Conversation: Whisper.Conversation,
+      });
     },
     async updateLastMessage() {
       if (!this.id) {

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -111,7 +111,6 @@ module.exports = {
   removeAllSessions,
 
   getSwarmNodesByPubkey,
-  saveSwarmNodesForPubKey,
 
   getConversationCount,
   saveConversation,
@@ -674,14 +673,6 @@ function setifyProperty(data, propertyName) {
 
 async function getSwarmNodesByPubkey(pubkey) {
   return channels.getSwarmNodesByPubkey(pubkey);
-}
-
-async function saveSwarmNodesForPubKey(pubKey, swarmNodes, { Conversation }) {
-  const conversation = await getConversationById(pubKey, { Conversation });
-  conversation.set({ swarmNodes });
-  await updateConversation(conversation.id, conversation.attributes, {
-    Conversation,
-  });
 }
 
 async function getConversationCount() {

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -79,29 +79,26 @@ class LokiSnodeAPI {
   }
 
   async getSwarmNodesForPubKey(pubKey) {
-    let conversation;
-    let swarmNodes;
     try {
-      conversation = ConversationController.get(pubKey);
-      swarmNodes = [...conversation.get('swarmNodes')];
+      const conversation = ConversationController.get(pubKey);
+      const swarmNodes = [...conversation.get('swarmNodes')];
+      return swarmNodes;
     } catch (e) {
       throw new window.textsecure.ReplayableError({
         message: 'Could not get conversation',
       });
     }
-    return swarmNodes;
   }
 
   async updateSwarmNodes(pubKey, newNodes) {
-    let conversation;
     try {
-      conversation = ConversationController.get(pubKey);
+      const conversation = ConversationController.get(pubKey);
+      await conversation.updateSwarmNodes(newNodes);
     } catch (e) {
       throw new window.textsecure.ReplayableError({
         message: 'Could not get conversation',
       });
     }
-    await conversation.updateSwarmNodes(newNodes);
   }
 
   async getOurSwarmNodes() {
@@ -128,12 +125,7 @@ class LokiSnodeAPI {
 
   async refreshSwarmNodesForPubKey(pubKey) {
     const newNodes = await this.getFreshSwarmNodes(pubKey);
-    try {
-      const conversation = ConversationController.get(pubKey);
-      await conversation.updateSwarmNodes(newNodes);
-    } catch (e) {
-      throw e;
-    }
+    this.updateSwarmNodes(pubKey, newNodes);
   }
 
   async getFreshSwarmNodes(pubKey) {

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -59,9 +59,10 @@ class LokiSnodeAPI {
       return false;
     }
     const conversation = ConversationController.get(pubKey);
-    const swarmNodes = conversation.get('swarmNodes');
-    if (swarmNodes.delete(nodeUrl)) {
-      await conversation.updateSwarmNodes(swarmNodes);
+    const swarmNodes = [...conversation.get('swarmNodes')];
+    if (nodeUrl in swarmNodes) {
+      const filteredNodes = swarmNodes.filter(node => node !== nodeUrl);
+      await conversation.updateSwarmNodes(filteredNodes);
       delete this.contactSwarmNodes[nodeUrl];
     }
     return true;
@@ -82,7 +83,7 @@ class LokiSnodeAPI {
     let swarmNodes;
     try {
       conversation = ConversationController.get(pubKey);
-      swarmNodes = conversation.get('swarmNodes');
+      swarmNodes = [...conversation.get('swarmNodes')];
     } catch (e) {
       throw new window.textsecure.ReplayableError({
         message: 'Could not get conversation',
@@ -143,6 +144,7 @@ class LokiSnodeAPI {
           newSwarmNodes = await this.getSwarmNodes(pubKey);
         } catch (e) {
           // TODO: Handle these errors sensibly
+          log.error('Failed to get new swarm nodes');
           newSwarmNodes = [];
         }
         resolve(newSwarmNodes);

--- a/preload.js
+++ b/preload.js
@@ -288,7 +288,7 @@ window.WebAPI = initializeWebAPI({
 
 const LokiSnodeAPI = require('./js/modules/loki_snode_api');
 
-window.LokiSnodeAPI = new LokiSnodeAPI({
+window.lokiSnodeAPI = new LokiSnodeAPI({
   url: config.serverUrl,
   swarmServerPort: config.swarmServerPort,
 });


### PR DESCRIPTION
Fixed a nasty 'returning a reference' bug I introduced a while back which made us check for new swarm nodes before sending every message
Found another couple dumb things left around from the transition from using sets for swarm nodes to using arrays
Also found a nice little infinite loop bug that I had bumped into a couple times from using `completedNodes.length` instead of `successfulNodes`
Overall slightly less disgusted by all this swarm stuff