### PR TITLE
Stop git from defaulting to changing line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,1 @@
-* text=auto
-*.js text eol=lf
-*.ts text eol=lf
-*.tsx text eol=lf
-*.scss text eol=lf
-*.json text eol=lf
-*.css text eol=lf
-*.html text eol=lf
-*.yaml text eol=lf
-*.yml text eol=lf
+* text=false


### PR DESCRIPTION
This change was made to fix travis a while ago breaking from changing line endings, but we have some signal upstream files with combined line endings which get all sorts of messed up when they are modified.
Hopefully travis will be happy with this instead