### PR TITLE
Localhost loki

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,6 @@
 {
   "serverUrl": "random.snode",
+  "localUrl": "localhost.loki",
   "cdnUrl": "random.snode",
   "localServerPort": "8081",
   "messageServerPort": "8080",

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -9,6 +9,17 @@ const dns = require('dns');
 const MINIMUM_SWARM_NODES = 1;
 const FAILURE_THRESHOLD = 3;
 
+const resolve4 = url =>
+  new Promise((resolve, reject) => {
+    dns.resolve4(url, (err, ip) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(ip);
+      }
+    });
+  });
+
 const resolveCname = url =>
   new Promise((resolve, reject) => {
     dns.resolveCname(url, (err, address) => {
@@ -33,7 +44,12 @@ class LokiSnodeAPI {
     this.contactSwarmNodes = {};
   }
 
-  async getMySnodeAddress() {
+  async getMyLokiIp() {
+    const address = await resolveCname(this.localUrl);
+    return resolve4(address);
+  }
+
+  async getMyLokiAddress() {
     /* resolve our local loki address */
     return resolveCname(this.localUrl);
   }

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -24,8 +24,9 @@
   }
 
   async function sendOnlineBroadcastMessage(pubKey, forceP2p = false) {
+    const myLokiAddress = await window.lokiSnodeAPI.getMySnodeAddress();
     const lokiAddressMessage = new textsecure.protobuf.LokiAddressMessage({
-      p2pAddress: 'http://localhost',
+      p2pAddress: `http://${myLokiAddress}`,
       p2pPort: parseInt(window.localServerPort, 10),
     });
     const content = new textsecure.protobuf.Content({

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -24,7 +24,7 @@
   }
 
   async function sendOnlineBroadcastMessage(pubKey, forceP2p = false) {
-    const myLokiAddress = await window.lokiSnodeAPI.getMySnodeAddress();
+    const myLokiAddress = await window.lokiSnodeAPI.getMyLokiAddress();
     const lokiAddressMessage = new textsecure.protobuf.LokiAddressMessage({
       p2pAddress: `http://${myLokiAddress}`,
       p2pPort: parseInt(window.localServerPort, 10),

--- a/libloki/local_loki_server.js
+++ b/libloki/local_loki_server.js
@@ -50,13 +50,13 @@ class LocalLokiServer extends EventEmitter {
     });
   }
 
-  async start(port) {
+  async start(port, ip) {
     // Close the old server
     await this.close();
 
     // Start a listening on new server
     return new Promise((res, rej) => {
-      this.server.listen(port, err => {
+      this.server.listen(port, ip, err => {
         if (err) {
           rej(err);
         } else {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -83,11 +83,12 @@ MessageReceiver.prototype.extend({
         this.onEmpty();
       }
     });
-
-    localLokiServer.start(localServerPort).then(port => {
-      window.log.info(`Local Server started at localhost:${port}`);
-      libloki.api.broadcastOnlineStatus();
-      localLokiServer.on('message', this.handleP2pMessage.bind(this));
+    window.lokiSnodeAPI.getMyLokiIp().then(myLokiIp => {
+      localLokiServer.start(localServerPort, myLokiIp).then(port => {
+        window.log.info(`Local Server started at localhost:${port}`);
+        libloki.api.broadcastOnlineStatus();
+        localLokiServer.on('message', this.handleP2pMessage.bind(this));
+      });
     });
 
     // TODO: Rework this socket stuff to work with online messaging

--- a/main.js
+++ b/main.js
@@ -144,6 +144,7 @@ function prepareURL(pathSegments, moreKeys) {
       version: app.getVersion(),
       buildExpiration: config.get('buildExpiration'),
       serverUrl: config.get('serverUrl'),
+      localUrl: config.get('localUrl'),
       cdnUrl: config.get('cdnUrl'),
       messageServerPort: config.get('messageServerPort'),
       swarmServerPort: config.get('swarmServerPort'),

--- a/preload.js
+++ b/preload.js
@@ -289,7 +289,8 @@ window.WebAPI = initializeWebAPI({
 const LokiSnodeAPI = require('./js/modules/loki_snode_api');
 
 window.lokiSnodeAPI = new LokiSnodeAPI({
-  url: config.serverUrl,
+  serverUrl: config.serverUrl,
+  localUrl: config.localUrl,
   swarmServerPort: config.swarmServerPort,
 });
 


### PR DESCRIPTION
Use the newly added localhost.loki lookup to get our .loki address to send to our contacts for P2P messaging
Also do a reverse lookup on this .loki address to get the private ip our hidden service is using so we can bind our P2P server to it, this allows us to receive messages P2P without having to forward ports