### PR TITLE
Use new message json rpc API

### DIFF
--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -131,7 +131,7 @@ class LokiMessageAPI {
       };
       const fetchOptions = {
         method: 'POST',
-        body,
+        body: JSON.stringify(body),
         headers: {
           'X-Loki-EphemKey': 'not implemented yet',
         },
@@ -228,7 +228,7 @@ class LokiMessageAPI {
       };
       const fetchOptions = {
         method: 'POST',
-        body,
+        body: JSON.stringify(body),
         headers,
       };
       try {

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -121,7 +121,7 @@ class LokiMessageAPI {
       const url = `${nodeUrl}${this.messageServerPort}/v1/storage_rpc`;
       const body = {
         method: 'store',
-        args: {
+        params: {
           pubKey,
           ttl: ttl.toString(),
           nonce,
@@ -218,7 +218,7 @@ class LokiMessageAPI {
       const url = `${nodeUrl}${this.messageServerPort}/v1/storage_rpc`;
       const body = {
         method: 'retrieve',
-        args: {
+        params: {
           pubKey: ourKey,
           lastHash: nodeData.lastHash,
         },

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -133,7 +133,7 @@ class LokiMessageAPI {
         method: 'POST',
         body,
         headers: {
-          'X-Loki-EphemKey:': 'not implemented yet',
+          'X-Loki-EphemKey': 'not implemented yet',
         },
       };
 
@@ -224,7 +224,7 @@ class LokiMessageAPI {
         },
       };
       const headers = {
-        'X-Loki-EphemKey:': 'not implemented yet',
+        'X-Loki-EphemKey': 'not implemented yet',
       };
       const fetchOptions = {
         method: 'POST',


### PR DESCRIPTION
Implements #197.

This PR requires the mirror changes in the storage server before merging.

TODO: With these changes, the similitude between `retrieveMessages` and `sendMessage` is now increased and would make them good candidates for refactoring.