### PR TITLE
Added p2p message styling

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -652,6 +652,15 @@
       }
     });
 
+    Whisper.events.on('p2pMessageSent', ({ pubKey, timestamp }) => {
+      try {
+        const conversation = ConversationController.get(pubKey);
+        conversation.onP2pMessageSent(pubKey, timestamp);
+      } catch (e) {
+        window.log.error('Error setting p2p on message');
+      }
+    });
+
     Whisper.events.on('password-updated', () => {
       if (appView && appView.inboxView) {
         appView.inboxView.trigger('password-updated');
@@ -1386,6 +1395,7 @@
       unidentifiedDeliveryReceived: data.unidentifiedDeliveryReceived,
       type: 'incoming',
       unread: 1,
+      isP2p: data.isP2p,
     };
 
     if (data.friendRequest) {

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -321,14 +321,24 @@
       removeMessage();
     },
 
-    async onCalculatingPoW(pubKey, timestamp) {
-      if (this.id !== pubKey) return;
+    // Get messages with the given timestamp
+    _getMessagesWithTimestamp(pubKey, timestamp) {
+      if (this.id !== pubKey) return [];
 
       // Go through our messages and find the one that we need to update
-      const messages = this.messageCollection.models.filter(
+      return this.messageCollection.models.filter(
         m => m.get('sent_at') === timestamp
       );
+    },
+
+    async onCalculatingPoW(pubKey, timestamp) {
+      const messages = this._getMessagesWithTimestamp(pubKey, timestamp);
       await Promise.all(messages.map(m => m.setCalculatingPoW()));
+    },
+
+    async onP2pMessageSent(pubKey, timestamp) {
+      const messages = this._getMessagesWithTimestamp(pubKey, timestamp);
+      await Promise.all(messages.map(m => m.setIsP2p(true)));
     },
 
     async onNewMessage(message) {

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -591,6 +591,8 @@
         isExpired: this.hasExpired,
         expirationLength,
         expirationTimestamp,
+        isP2p: !!this.get('isP2p'),
+
         onReply: () => this.trigger('reply', this),
         onRetrySend: () => this.retrySend(),
         onShowDetail: () => this.trigger('show-message-detail', this),
@@ -1088,6 +1090,17 @@
 
       this.set({
         calculatingPoW: true,
+      });
+
+      await window.Signal.Data.saveMessage(this.attributes, {
+        Message: Whisper.Message,
+      });
+    },
+    async setIsP2p(isP2p) {
+      if (_.isEqual(this.get('isP2p'), isP2p)) return;
+
+      this.set({
+        isP2p: !!isP2p,
       });
 
       await window.Signal.Data.saveMessage(this.attributes, {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1027,6 +1027,7 @@ MessageReceiver.prototype.extend({
             timestamp: envelope.timestamp.toNumber(),
             receivedAt: envelope.receivedAt,
             unidentifiedDeliveryReceived: envelope.unidentifiedDeliveryReceived,
+            isP2p: envelope.isP2p,
             message,
           };
           return this.dispatchAndWait(ev);

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -506,18 +506,22 @@
   padding-right: 24px;
 }
 
-.module-message__metadata__date {
+.module-message__metadata__date, .module-message__metadata__p2p {
   font-size: 11px;
   line-height: 16px;
   letter-spacing: 0.3px;
   color: $color-gray-60;
   text-transform: uppercase;
 }
-.module-message__metadata__date--incoming {
+.module-message__metadata__date--incoming, .module-message__metadata__p2p--incoming {
   color: $color-white-08;
 }
 .module-message__metadata__date--with-image-no-caption {
   color: $color-white;
+}
+
+.module-message__metadata__p2p {
+  font-weight: bold;
 }
 
 .module-message__metadata__spacer {

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -506,14 +506,16 @@
   padding-right: 24px;
 }
 
-.module-message__metadata__date, .module-message__metadata__p2p {
+.module-message__metadata__date,
+.module-message__metadata__p2p {
   font-size: 11px;
   line-height: 16px;
   letter-spacing: 0.3px;
   color: $color-gray-60;
   text-transform: uppercase;
 }
-.module-message__metadata__date--incoming, .module-message__metadata__p2p--incoming {
+.module-message__metadata__date--incoming,
+.module-message__metadata__p2p--incoming {
   color: $color-white-08;
 }
 .module-message__metadata__date--with-image-no-caption {

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -241,10 +241,12 @@ export class Message extends React.Component<Props, State> {
           />
         )}
         {isP2p ? (
-          <span className={classNames(
-            'module-message__metadata__p2p',
-            `module-message__metadata__p2p--${direction}`,
-          )}>
+          <span
+            className={classNames(
+              'module-message__metadata__p2p',
+              `module-message__metadata__p2p--${direction}`
+            )}
+          >
             &nbsp;•&nbsp;P2P
           </span>
         ) : null}
@@ -955,7 +957,7 @@ export class Message extends React.Component<Props, State> {
             `module-message__container--${direction}`,
             direction === 'incoming'
               ? `module-message__container--incoming-${authorColor}`
-              : null,
+              : null
           )}
           style={{
             width: isShowingImage ? width : undefined,

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -79,6 +79,8 @@ export interface Props {
   isExpired: boolean;
   expirationLength?: number;
   expirationTimestamp?: number;
+  isP2p?: boolean;
+
   onClickAttachment?: (attachment: AttachmentType) => void;
   onClickLinkPreview?: (url: string) => void;
   onReply?: () => void;
@@ -196,6 +198,7 @@ export class Message extends React.Component<Props, State> {
       status,
       text,
       timestamp,
+      isP2p,
     } = this.props;
 
     if (collapseMetadata) {
@@ -237,6 +240,14 @@ export class Message extends React.Component<Props, State> {
             module="module-message__metadata__date"
           />
         )}
+        {isP2p ? (
+          <span className={classNames(
+            'module-message__metadata__p2p',
+            `module-message__metadata__p2p--${direction}`,
+          )}>
+            &nbsp;•&nbsp;P2P
+          </span>
+        ) : null}
         {expirationLength && expirationTimestamp ? (
           <ExpireTimer
             direction={direction}
@@ -944,7 +955,7 @@ export class Message extends React.Component<Props, State> {
             `module-message__container--${direction}`,
             direction === 'incoming'
               ? `module-message__container--incoming-${authorColor}`
-              : null
+              : null,
           )}
           style={{
             width: isShowingImage ? width : undefined,


### PR DESCRIPTION
Resolves #190 

Rather than changing the message colour, we just add a `p2p` message in the meta data.

<img width="135" alt="screen shot 2019-02-18 at 12 20 11 pm" src="https://user-images.githubusercontent.com/4365065/52922740-8eb71a00-3377-11e9-80ef-8458fae9b265.png">

