### PR TITLE
Optimise pinging

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -223,8 +223,8 @@
       textsecure.storage.user.getNumber()
     );
     window.lokiP2pAPI.on('pingContact', pubKey => {
-      const forceP2p = true;
-      window.libloki.api.sendOnlineBroadcastMessage(pubKey, forceP2p);
+      const isPing = true;
+      window.libloki.api.sendOnlineBroadcastMessage(pubKey, isPing);
     });
 
     // These make key operations available to IPC handlers created in preload.js

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -82,6 +82,10 @@ class LokiMessageAPI {
       } catch (e) {
         log.warn('Failed to send P2P message, falling back to storage', e);
         lokiP2pAPI.setContactOffline(pubKey);
+        if (isPing) {
+          // If this was just a ping, we don't bother sending to storage server
+          return;
+        }
       }
     }
 

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -63,11 +63,11 @@ class LokiMessageAPI {
     this.messageServerPort = messageServerPort ? `:${messageServerPort}` : '';
   }
 
-  async sendMessage(pubKey, data, messageTimeStamp, ttl, forceP2p = false) {
+  async sendMessage(pubKey, data, messageTimeStamp, ttl, isPing = false) {
     const data64 = dcodeIO.ByteBuffer.wrap(data).toString('base64');
     const timestamp = Math.floor(Date.now() / 1000);
     const p2pDetails = lokiP2pAPI.getContactP2pDetails(pubKey);
-    if (p2pDetails && (forceP2p || p2pDetails.isOnline)) {
+    if (p2pDetails && (isPing || p2pDetails.isOnline)) {
       try {
         const port = p2pDetails.port ? `:${p2pDetails.port}` : '';
         const url = `${p2pDetails.address}${port}/store`;

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -143,6 +143,7 @@ class LokiMessageAPI {
         nodeComplete(nodeUrl);
         successfulRequests += 1;
       } catch (e) {
+        log.warn('Send message error:', e);
         if (e instanceof NotFoundError) {
           canResolve = false;
         } else if (e instanceof HTTPError) {
@@ -155,8 +156,12 @@ class LokiMessageAPI {
           // We mark the node as complete as we could still reach it
           nodeComplete(nodeUrl);
         } else {
-          log.error('Loki SendMessages:', e);
-          if (lokiSnodeAPI.unreachableNode(pubKey, nodeUrl)) {
+          const removeNode = await lokiSnodeAPI.unreachableNode(
+            pubKey,
+            nodeUrl
+          );
+          if (removeNode) {
+            log.error('Loki SendMessages:', e);
             nodeComplete(nodeUrl);
             failedNodes.push(nodeUrl);
           }
@@ -242,6 +247,7 @@ class LokiMessageAPI {
         }
         successfulRequests += 1;
       } catch (e) {
+        log.warn('Retrieve message error:', e);
         if (e instanceof NotFoundError) {
           canResolve = false;
         } else if (e instanceof HTTPError) {
@@ -254,8 +260,12 @@ class LokiMessageAPI {
           // We mark the node as complete as we could still reach it
           nodeComplete(nodeUrl);
         } else {
-          log.error('Loki RetrieveMessages:', e);
-          if (lokiSnodeAPI.unreachableNode(ourKey, nodeUrl)) {
+          const removeNode = await lokiSnodeAPI.unreachableNode(
+            ourKey,
+            nodeUrl
+          );
+          if (removeNode) {
+            log.error('Loki RetrieveMessages:', e);
             nodeComplete(nodeUrl);
           }
         }

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -56,7 +56,7 @@ class LokiP2pAPI extends EventEmitter {
       baseDetails.port !== port
     ) {
       // Had the contact marked as online and details we had were the same
-      // Do nothing
+      this.pingContact(pubKey);
       return;
     }
 
@@ -69,6 +69,14 @@ class LokiP2pAPI extends EventEmitter {
 
   getContactP2pDetails(pubKey) {
     return this.contactP2pDetails[pubKey] || null;
+  }
+
+  isContactOnline(pubKey) {
+    const contactDetails = this.contactP2pDetails[pubKey];
+    if (!contactDetails || !contactDetails.isOnline) {
+      return false;
+    }
+    return contactDetails.isOnline;
   }
 
   setContactOffline(pubKey) {
@@ -101,11 +109,8 @@ class LokiP2pAPI extends EventEmitter {
   }
 
   pingContact(pubKey) {
-    if (
-      !this.contactP2pDetails[pubKey] ||
-      this.contactP2pDetails[pubKey].isOnline
-    ) {
-      // Don't ping if we don't have their details or they are already online
+    if (!this.contactP2pDetails[pubKey]) {
+      // Don't ping if we don't have their details
       return;
     }
     this.emit('pingContact', pubKey);

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -16,7 +16,7 @@ class LokiP2pAPI extends EventEmitter {
     });
   }
 
-  updateContactP2pDetails(pubKey, address, port, isOnline = false) {
+  updateContactP2pDetails(pubKey, address, port, isPing = false) {
     // Stagger the timers so the friends don't ping each other at the same time
     const timerDuration =
       pubKey < this.ourKey
@@ -35,7 +35,7 @@ class LokiP2pAPI extends EventEmitter {
       pingTimer: null,
     };
 
-    if (isOnline) {
+    if (isPing) {
       this.setContactOnline(pubKey);
       return;
     }

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -79,10 +79,7 @@ class LokiP2pAPI extends EventEmitter {
 
   isContactOnline(pubKey) {
     const contactDetails = this.contactP2pDetails[pubKey];
-    if (!contactDetails || !contactDetails.isOnline) {
-      return false;
-    }
-    return contactDetails.isOnline;
+    return !!(contactDetails && contactDetails.isOnline);
   }
 
   setContactOffline(pubKey) {

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -34,6 +34,10 @@ class LokiP2pAPI extends EventEmitter {
         pingTimer: null,
         isOnline: false,
       };
+      if (isPing) {
+        this.setContactOnline(pubKey);
+        return;
+      }
       // Try ping
       this.pingContact(pubKey);
       return;

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -2,6 +2,8 @@
 
 const EventEmitter = require('events');
 
+const offlinePingTime = 2 * 60 * 1000; // 2 minutes
+
 class LokiP2pAPI extends EventEmitter {
   constructor(ourKey) {
     super();
@@ -85,6 +87,11 @@ class LokiP2pAPI extends EventEmitter {
       return;
     }
     clearTimeout(this.contactP2pDetails[pubKey].pingTimer);
+    this.contactP2pDetails[pubKey].pingTimer = setTimeout(
+      this.pingContact.bind(this),
+      offlinePingTime,
+      pubKey
+    );
     this.contactP2pDetails[pubKey].isOnline = false;
   }
 

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -23,7 +23,7 @@
     );
   }
 
-  async function sendOnlineBroadcastMessage(pubKey, forceP2p = false) {
+  async function sendOnlineBroadcastMessage(pubKey, isPing = false) {
     const myLokiAddress = await window.lokiSnodeAPI.getMyLokiAddress();
     const lokiAddressMessage = new textsecure.protobuf.LokiAddressMessage({
       p2pAddress: `http://${myLokiAddress}`,
@@ -41,7 +41,7 @@
         log.info('Online broadcast message sent successfully');
       }
     };
-    const options = { messageType: 'onlineBroadcast', forceP2p };
+    const options = { messageType: 'onlineBroadcast', isPing };
     // Send a empty message with information about how to contact us directly
     const outgoingMessage = new textsecure.OutgoingMessage(
       null, // server

--- a/libloki/test/node/loki_p2p_api_test.js
+++ b/libloki/test/node/loki_p2p_api_test.js
@@ -1,7 +1,7 @@
 const { assert } = require('chai');
 const LokiP2pAPI = require('../../../js/modules/loki_p2p_api');
 
-describe('LocalLokiServer', () => {
+describe('LokiP2pAPI', () => {
   const usedKey = 'aPubKey';
   const usedAddress = 'anAddress';
   const usedPort = 'aPort';
@@ -64,16 +64,16 @@ describe('LocalLokiServer', () => {
       usedKey,
       usedAddress,
       usedPort,
-      true
+      false
     );
-    assert.isTrue(this.lokiP2pAPI.isOnline(usedKey));
+    assert.isFalse(this.lokiP2pAPI.isOnline(usedKey));
     this.lokiP2pAPI.updateContactP2pDetails(
       usedKey,
       usedAddress,
       usedPort,
-      false
+      true
     );
-    assert.isFalse(this.lokiP2pAPI.isOnline(usedKey));
+    assert.isTrue(this.lokiP2pAPI.isOnline(usedKey));
   });
 
   it('Should set a contact as offline', () => {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -218,6 +218,9 @@ MessageReceiver.prototype.extend({
     const promise = Promise.resolve(request.body.toArrayBuffer()) // textsecure.crypto
       .then(plaintext => {
         const envelope = textsecure.protobuf.Envelope.decode(plaintext);
+        if (isP2p) {
+          lokiP2pAPI.setContactOnline(envelope.source);
+        }
         // After this point, decoding errors are not the server's
         //   fault, and we should handle them gracefully and tell the
         //   user they received an invalid message
@@ -945,9 +948,7 @@ MessageReceiver.prototype.extend({
     return this.removeFromCache(envelope);
   },
   handleDataMessage(envelope, msg) {
-    if (envelope.isP2p) {
-      lokiP2pAPI.setContactOnline(envelope.source);
-    } else {
+    if (!envelope.isP2p) {
       const timestamp = envelope.timestamp.toNumber();
       const now = Date.now();
       const ageInSeconds = (now - timestamp) / 1000;

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -218,9 +218,6 @@ MessageReceiver.prototype.extend({
     const promise = Promise.resolve(request.body.toArrayBuffer()) // textsecure.crypto
       .then(plaintext => {
         const envelope = textsecure.protobuf.Envelope.decode(plaintext);
-        if (isP2p) {
-          lokiP2pAPI.setContactOnline(envelope.source);
-        }
         // After this point, decoding errors are not the server's
         //   fault, and we should handle them gracefully and tell the
         //   user they received an invalid message

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -945,6 +945,16 @@ MessageReceiver.prototype.extend({
     return this.removeFromCache(envelope);
   },
   handleDataMessage(envelope, msg) {
+    if (envelope.isP2p) {
+      lokiP2pAPI.setContactOnline(envelope.source);
+    } else {
+      const timestamp = envelope.timestamp.toNumber();
+      const now = Date.now();
+      const ageInSeconds = (now - timestamp) / 1000;
+      if (ageInSeconds <= 120) {
+        lokiP2pAPI.pingContact(envelope.source);
+      }
+    }
     window.log.info('data message from', this.getEnvelopeId(envelope));
     let p = Promise.resolve();
     // eslint-disable-next-line no-bitwise

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -42,13 +42,13 @@ function OutgoingMessage(
   this.failoverNumbers = [];
   this.unidentifiedDeliveries = [];
 
-  const { numberInfo, senderCertificate, online, messageType, forceP2p } =
+  const { numberInfo, senderCertificate, online, messageType, isPing } =
     options || {};
   this.numberInfo = numberInfo;
   this.senderCertificate = senderCertificate;
   this.online = online;
   this.messageType = messageType || 'outgoing';
-  this.forceP2p = forceP2p || false;
+  this.isPing = isPing || false;
 }
 
 OutgoingMessage.prototype = {
@@ -192,7 +192,7 @@ OutgoingMessage.prototype = {
         data,
         timestamp,
         ttl,
-        this.forceP2p
+        this.isPing
       );
     } catch (e) {
       if (e.name === 'HTTPError' && (e.code !== 409 && e.code !== 410)) {
@@ -347,7 +347,7 @@ OutgoingMessage.prototype = {
         if (this.messageType === 'friend-request') {
           ttl = 4 * 24 * 60 * 60; // 4 days for friend request message
         } else if (this.messageType === 'onlineBroadcast') {
-          ttl = 10 * 60; // 10 minutes for online broadcast message
+          ttl = 60; // 1 minute for online broadcast message
         } else {
           const hours = window.getMessageTTL() || 24; // 1 day default for any other message
           ttl = hours * 60 * 60;


### PR DESCRIPTION
Refactored the pinging logic to handle a couple edge cases better
Ttl for online broadcast messages is now only 1 min
More sensible variable names for ping related things
Now ping our contacts that go offline every 2 mins to check if they are back online
Ping our contacts if they sent us a storage server message in the last 2 mins

Along the way I stumbled across a couple bugs in the snode logic that would cause the nodes to always be removed on the first error rather than trying 3 times, and changed the logging to print a warning for the first 2 failures of a snode and then an error when it is removed from memory

Although I didn't end up actually doing a debounce for the pings (because it would have made the system less reliable), this resolves #191 
Also fixes #192 

Tried a bunch and considered heaps of different stuff during this PR, still not happy with the pinging but I think the nature of the architecture means we are just going to have to accept that the online indicator won't always be very accurate