### PR TITLE
P2p using rpc endpoint

### DIFF
--- a/libloki/local_loki_server.js
+++ b/libloki/local_loki_server.js
@@ -32,9 +32,14 @@ class LocalLokiServer extends EventEmitter {
             }
 
             // Check endpoints here
-            if (req.url === '/store') {
-              // body is a base64 encoded string
-              this.emit('message', body);
+            if (req.url === '/v1/storage_rpc') {
+              const bodyObject = JSON.parse(body);
+              if (bodyObject.method !== 'store') {
+                res.writeHead(404, { 'Content-Type': 'text/plain' });
+                res.end('Invalid endpoint!');
+                return;
+              }
+              this.emit('message', bodyObject.params.data);
               res.statusCode = 200;
               res.end();
             } else {

--- a/libloki/test/node/local_loki_server_test.js
+++ b/libloki/test/node/local_loki_server_test.js
@@ -56,6 +56,12 @@ describe('LocalLokiServer', () => {
     it('should pass the POSTed data to the callback', async () => {
       const server = new LocalLokiServer();
       await server.start(8001);
+      const messageData = {
+        method: 'store',
+        params: {
+          data: 'This is data',
+        },
+      };
 
       const promise = new Promise(res => {
         server.on('message', message => {
@@ -66,7 +72,7 @@ describe('LocalLokiServer', () => {
       });
 
       try {
-        await axios.post('http://localhost:8001/store', 'This is data');
+        await axios.post('http://localhost:8001/v1/storage_rpc', messageData);
       } catch (error) {
         assert.isNotOk(error, 'Error occured');
       }


### PR DESCRIPTION
Update p2p messages to follow the same endpoint format as storage server. Clean up message_api a lil bit and updated tests
Implements #206 (And sets up for #174)