### PR TITLE
Fix windows gitlab cd

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,4 +58,4 @@ windows:
       - node_modules/
   artifacts:
     paths:
-      - dist/
+      - release/


### PR DESCRIPTION
A couple months ago the output folder for the windows builds was set to release, this needs to be reflected in the folder that gitlab uploads after building