### PR TITLE
Fix resolution for windows

### DIFF
--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -4,6 +4,7 @@
 const fetch = require('node-fetch');
 const is = require('@sindresorhus/is');
 const dns = require('dns');
+const process = require('process');
 
 // Will be raised (to 3?) when we get more nodes
 const MINIMUM_SWARM_NODES = 1;
@@ -42,6 +43,10 @@ class LokiSnodeAPI {
     this.swarmsPendingReplenish = {};
     this.ourSwarmNodes = {};
     this.contactSwarmNodes = {};
+    // When we package lokinet with messenger we can ensure this ip is correct
+    if (process.platform === 'win32') {
+      dns.setServers(['127.0.0.1']);
+    }
   }
 
   async getMyLokiIp() {


### PR DESCRIPTION
After a lot of poking around I think this is all we need
This is a bit of a bandaid solution for now because we are just hard coding the dns server to localhost, while in reality lokinet could be configured to bind to a different address

Had some chats with Ryan and hopefully we will be able to reuse some of his node stuff he is doing for the launcher which bundles lokinet in and then we could always ensure that lokinet is installed with the messenger and could run our own instance with whatever config we want