### PR TITLE
Upgrade react-contextmenu to 2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "protobufjs": "~6.8.6",
     "proxy-agent": "3.0.3",
     "react": "16.2.0",
-    "react-contextmenu": "2.9.2",
+    "react-contextmenu": "2.10.0",
     "react-dom": "16.2.0",
     "read-last-lines": "1.3.0",
     "rimraf": "2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7206,10 +7206,10 @@ react-codemirror2@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-4.2.1.tgz#4ad3c5c60ebbcb34880f961721b51527324ec021"
 
-react-contextmenu@2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/react-contextmenu/-/react-contextmenu-2.9.2.tgz#7076075f09e4cad023a1252da347d9e6782d003a"
-  integrity sha512-DdcO6iLBIJuDVsRpJLG/9N6ine0OVZhuQvnSPCEihfcyJFz+SHU9pQo+w9LWi2PdUxFbFV52BwAuutQkAYJxaA==
+react-contextmenu@2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/react-contextmenu/-/react-contextmenu-2.10.0.tgz#3a5338a552964db85c300072f719bc1f6b969838"
+  integrity sha512-neiZGpfxfYFjqbcIExi69qruqhB7l0LKEguHDXeizgyTGbJHTwbq1GplXCHIafUAkbGZH8FfD9PBeUcSRG78+Q==
   dependencies:
     classnames "^2.2.5"
     object-assign "^4.1.0"


### PR DESCRIPTION
The new version seems to fix #218.
When clicking on "disappearing messages" the submenu now stays open.
But the whole thing is highlighted in blue, apparently this is a chrome thing to improve accessibility.