### PR TITLE
Fix windows database crash

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -679,13 +679,21 @@ async function initialize({ configDir, key }) {
   //   console._log(`EXPLAIN QUERY PLAN ${statement}\n`, data && data.detail);
   // });
 
-  await setupSQLCipher(promisified, { key });
-  await updateSchema(promisified);
+  try {
+    await setupSQLCipher(promisified, { key });
+    await updateSchema(promisified);
+  } catch (e) {
+    await promisified.close();
+    throw e;
+  }
 
   db = promisified;
 }
 
 async function close() {
+  if (!db) {
+    return;
+  }
   const dbRef = db;
   db = null;
   await dbRef.close();

--- a/main.js
+++ b/main.js
@@ -755,7 +755,7 @@ function getDefaultSQLKey() {
 
 async function removeDB() {
   const userDir = await getRealPath(app.getPath('userData'));
-  sql.removeDB(userDir);
+  await sql.removeDB(userDir);
 
   try {
     userConfig.remove();


### PR DESCRIPTION
Even though the `db` variable was null (never assigned), there was a database instance being created when a password attempt was made
For some reason windows really didn't like this while other OS's thought it was chill
Also added an await and a null check for just in case
Fixes #216 