### PR TITLE
Fix multiple friend request timers instantiated

### DIFF
--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -277,6 +277,7 @@
               conversation.updateProfile(),
               conversation.updateProfileAvatar(),
               conversation.resetPendingSend(),
+              conversation.setFriendRequestExpiryTimeout(),
             ]);
           });
           await Promise.all(promises);

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -155,7 +155,6 @@
       this.unset('lastMessage');
       this.unset('lastMessageStatus');
 
-      this.setFriendRequestExpiryTimeout();
       this.typingRefreshTimer = null;
       this.typingPauseTimer = null;
 
@@ -722,6 +721,9 @@
         const ms = 60 * 60 * 1000 * hourLockDuration;
 
         this.set({ unlockTimestamp: Date.now() + ms });
+        await window.Signal.Data.updateConversation(this.id, this.attributes, {
+          Conversation: Whisper.Conversation,
+        });
         this.setFriendRequestExpiryTimeout();
       }
       await this.setFriendRequestStatus(FriendRequestStatusEnum.requestSent);


### PR DESCRIPTION
The `initialize` function is called for every instance of a conversation created, which happens _a lot_, so starting a timer for those temporary conversation instances/copies doesn't make sense.
Also, I'm guessing we should save to database right after setting the `unlockTimestamp`?