### PR TITLE
Add requestExpired state to Friend Request state machine

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -390,7 +390,7 @@
       // Get the pending friend requests that match the direction
       // If no direction is supplied then return all pending friend requests
       return messages.models.filter(m => {
-        if (status.indexOf(m.get('friendStatus')) < 0) return false;
+        if (!status.includes(m.get('friendStatus')) return false;
         return direction === null || m.get('direction') === direction;
       });
     },

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -668,7 +668,7 @@
       if (this.unlockTimer) clearTimeout(this.unlockTimer);
       if (this.hasReceivedFriendRequest()) {
         this.setFriendRequestStatus(FriendRequestStatusEnum.friends);
-        await this.respondToAllPendingFriendRequests({
+        await this.respondToAllFriendRequests({
           response: 'accepted',
           direction: 'incoming',
           status: ['pending', 'expired'],

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -390,7 +390,7 @@
       // Get the pending friend requests that match the direction
       // If no direction is supplied then return all pending friend requests
       return messages.models.filter(m => {
-        if (!status.includes(m.get('friendStatus')) return false;
+        if (!status.includes(m.get('friendStatus'))) return false;
         return direction === null || m.get('direction') === direction;
       });
     },

--- a/libloki/friends.js
+++ b/libloki/friends.js
@@ -14,6 +14,8 @@
     requestReceived: 3,
     // We did it!
     friends: 4,
+    // Friend Request sent but timed out
+    requestExpired: 5,
   });
 
   window.friends = {


### PR DESCRIPTION
Seems a big convoluted so if you guys think of a more straightforward way to do this please comment ;)

To summarise:
* when friend request expires, set the `friendRequestStatus` to `requestExpired` instead of `None`
* when friend request is accepted, set all friend request messages that are `pending` or `expired` to `accepted`

Still feels weird to have 2 different statuses tho.


Fixes #172 