### PR TITLE
Long polling

### DIFF
--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -7,6 +7,7 @@ const { rpc } = require('./loki_rpc');
 
 // Will be raised (to 3?) when we get more nodes
 const MINIMUM_SUCCESSFUL_REQUESTS = 2;
+const LOKI_LONGPOLL_HEADER = 'X-Loki-Long-Poll';
 
 class LokiMessageAPI {
   constructor({ snodeServerPort }) {
@@ -171,13 +172,20 @@ class LokiMessageAPI {
         pubKey: ourKey,
         lastHash: nodeData.lastHash || '',
       };
+      const options = {
+        timeout: 40000,
+        headers: {
+          [LOKI_LONGPOLL_HEADER]: true,
+        },
+      };
 
       try {
         const result = await rpc(
           `http://${nodeUrl}`,
           this.snodeServerPort,
           'retrieve',
-          params
+          params,
+          options
         );
 
         nodeComplete(nodeUrl);

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -8,7 +8,7 @@ const endpointBase = '/v1/storage_rpc';
 
 // A small wrapper around node-fetch which deserializes response
 const fetch = async (url, options = {}) => {
-  const timeout = options.timeout || 10000;
+  const timeout = options.timeout || 5000;
   const method = options.method || 'GET';
 
   const address = parse(url).hostname;

--- a/libtextsecure/http-resources.js
+++ b/libtextsecure/http-resources.js
@@ -3,8 +3,7 @@
 // eslint-disable-next-line func-names
 (function() {
   let server;
-  const development = window.getEnvironment() !== 'production';
-  const pollTime = development ? 100 : 5000;
+  const POLL_TIME = 100;
 
   function stringToArrayBufferBase64(string) {
     return dcodeIO.ByteBuffer.wrap(string, 'base64').toArrayBuffer();
@@ -115,7 +114,7 @@
       callback(connected);
       setTimeout(() => {
         pollServer(callback);
-      }, pollTime);
+      }, POLL_TIME);
     };
 
     this.isConnected = function isConnected() {


### PR DESCRIPTION
Include long polling header for retrieve messages
Extend retrieveMessages timeout to 40 seconds, reduce default tmeout to 5 seconds
Remove dev/prod poll time difference now that we want to start new requests quickly since we aren't polling constantly

TODO: Now that we are not polling constantly, it would be nice if we just had 3 (or whatever) poll calls that all independently started a new request any time they got a response rather than the current system where they are all made in the same call which only returns once they are all complete
Thought about this for a bit and a nice way to modify the current implementation to do so didn't seem straight forward, especially with the online/connected stuff :thinking: 