### PR TITLE
Refactor long polling for better concurrent requests

### DIFF
--- a/js/modules/.eslintrc
+++ b/js/modules/.eslintrc
@@ -5,7 +5,8 @@
     "node": false
   },
   "globals": {
-    "console": true
+    "console": true,
+    "setTimeout": true
   },
   "parserOptions": {
     "sourceType": "module"

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -209,7 +209,7 @@ class LokiMessageAPI {
 
   async openConnection(callback) {
     const ourKey = window.textsecure.storage.user.getNumber();
-    while (this.ourSwarmNodes.length > 0) {
+    while (!_.isEmpty(this.ourSwarmNodes)) {
       const url = Object.keys(this.ourSwarmNodes)[0];
       const nodeData = this.ourSwarmNodes[url];
       delete this.ourSwarmNodes[url];

--- a/libtextsecure/http-resources.js
+++ b/libtextsecure/http-resources.js
@@ -3,8 +3,8 @@
 // eslint-disable-next-line func-names
 (function() {
   let server;
-  const SUCCESS_POLL_TIME = 100;
-  const FAIL_POLL_TIME = 2000;
+  const EXHAUSTED_SNODES_RETRY_DELAY = 5000;
+  const NUM_CONCURRENT_CONNECTIONS = 3;
 
   function stringToArrayBufferBase64(string) {
     return dcodeIO.ByteBuffer.wrap(string, 'base64').toArrayBuffer();
@@ -78,24 +78,31 @@
       }
     };
 
+    // Note: calling callback(false) is currently not necessary
     this.pollServer = async callback => {
+      // This blocking call will return only when all attempts
+      // at reaching snodes are exhausted or a DNS error occured
       try {
-        await server.retrieveMessages(messages => {
-          messages.forEach(message => {
-            const { data } = message;
-            this.handleMessage(data);
-          });
-        });
-        connected = true;
-      } catch (err) {
-        window.log.error('Polling error: ', err);
-        connected = false;
+        await server.startLongPolling(
+          NUM_CONCURRENT_CONNECTIONS,
+          messages => {
+            connected = true;
+            callback(connected);
+            messages.forEach(message => {
+              const { data } = message;
+              this.handleMessage(data);
+            });
+          }
+        );
+      } catch(e) {
+        // we'll try again anyway
       }
-      const pollTime = connected ? SUCCESS_POLL_TIME : FAIL_POLL_TIME;
-      callback(connected);
+
+      connected = false;
+      // Exhausted all our snodes urls, trying again later from scratch
       setTimeout(() => {
         this.pollServer(callback);
-      }, pollTime);
+      }, EXHAUSTED_SNODES_RETRY_DELAY);
     };
 
     this.isConnected = function isConnected() {

--- a/libtextsecure/http-resources.js
+++ b/libtextsecure/http-resources.js
@@ -83,18 +83,15 @@
       // This blocking call will return only when all attempts
       // at reaching snodes are exhausted or a DNS error occured
       try {
-        await server.startLongPolling(
-          NUM_CONCURRENT_CONNECTIONS,
-          messages => {
-            connected = true;
-            callback(connected);
-            messages.forEach(message => {
-              const { data } = message;
-              this.handleMessage(data);
-            });
-          }
-        );
-      } catch(e) {
+        await server.startLongPolling(NUM_CONCURRENT_CONNECTIONS, messages => {
+          connected = true;
+          callback(connected);
+          messages.forEach(message => {
+            const { data } = message;
+            this.handleMessage(data);
+          });
+        });
+      } catch (e) {
         // we'll try again anyway
       }
 


### PR DESCRIPTION
*Disclaimer: untested at this stage, until further notice this PR is just for feedback on the new code flow brought by the refactoring.*

Currently the concurrent connections are always started together, meaning that the fastest request needs to wait for the slowest request to return before it can start over.

This PR basically makes all concurrent connection loop independently of the others.
From top to bottom,
* In `pollServer()` we do a blocking call `await server.startLongPolling(...)` which encapsulates everything. This call never returns as long as everything works fine, but does return or throw if something is wrong (like lokinet/DNS issues) which requires to restart from scratch. In that case, we catch any exception and call `pollServer()` again after some time.

* in `startLongPolling()` we basically fetch our own swarm addresses, then create the (3) concurrent loops with `openConnection()` and await them all. Again, those promises don't resolve or reject unless something went wrong.

* in `openConnection()` we pop snode addresses when necessary, we call `retrieveNextMessage` in an infinite `for...of` loop (see note below),  we handle errors and failure counts 

~~Note: Hopefully, the logic has been simplified/made more readable by using an (exotic) asynchronous generator function `async * retrieveNextMessage ()`, which allows to query messages asynchronously as if they were just read from an array.~~ EDIT: ditched generator function