### PR TITLE
Fix node tests

### DIFF
--- a/ts/test/types/Attachment_test.ts
+++ b/ts/test/types/Attachment_test.ts
@@ -45,10 +45,7 @@ describe('Attachment', () => {
           data: stringToArrayBuffer('foo'),
           contentType: MIME.VIDEO_QUICKTIME,
         };
-        // Unix timestamp of start of year 2000 to fix odd sudo timezone bug
-        const timestamp = new Date(
-          946684800000 - moment().utcOffset() * 60 * 1000
-        );
+        const timestamp = moment('2000-01-01').toDate();
         const actual = Attachment.getSuggestedFilename({
           attachment,
           timestamp,


### PR DESCRIPTION
Node tests were breaking locally (but not on travis surprisingly).

~The white list tests were broken because `URL` is not defined globally when running mocha, but it is in nodejs (URL is a global in nodejs > v10.0)~
EDIT: The whitelist issue only occurs when running node < 10.0. Turns out I was running node 8.10 and we also fount out that running the tests as sudo might pick a different node version! So reverted the change since we target node 10.13 in the nvmrc.

Hopefully this is the last attempt at fixing the timestamp/filename test.