### PR TITLE
Skip `lint-deps` on appveyor to prevent build failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ install:
 build_script:
   - yarn generate
   - yarn lint-windows
-  - yarn lint-deps
   - yarn test-node
   - node build\grunt.js
   - type package.json | findstr /v certificateSubjectName > temp.json


### PR DESCRIPTION
That line seems to never have succeeded?