### PR TITLE
Updated pinging logic.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -17,6 +16,7 @@ Steps to reproduce the behavior:
 If applicable, add screenshots or log files to help explain your problem.
 
 **Other information (please complete the following information):**
- - Device: [e.g. PC, Mac]
- - OS: [e.g. Ubuntu 16.04, Windows 10]
- - Loki messenger Version or Git commit hash:
+
+* Device: [e.g. PC, Mac]
+* OS: [e.g. Ubuntu 16.04, Windows 10]
+* Loki messenger Version or Git commit hash:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,10 +89,10 @@ can public keys. To test the P2P functionality on the same machine, however, req
 that each client binds their message server to a different port.
 
 You can use the following command to start a client bound to a different port.
+
 ```
 yarn start-multi
 ```
-
 
 For more than 2 clients, you can setup additional storage profiles and switch
 between them using the `NODE_APP_INSTANCE` environment variable and specifying a
@@ -149,14 +149,15 @@ So you wanna make a pull request? Please observe the following guidelines.
   the translations in
   [Transifex](https://www.transifex.com/projects/p/signal-desktop).
 -->
+
 * First, make sure that your `yarn ready` run passes - it's very similar to what our
   Continuous Integration servers do to test the app.
 * Never use plain strings right in the source code - pull them from `messages.json`!
   You **only** need to modify the default locale
   [`_locales/en/messages.json`](_locales/en/messages.json).
-<!-- TODO:
-  Other locales are generated automatically based on that file and then periodically
-  uploaded to Transifex for translation. -->
+  <!-- TODO:
+    Other locales are generated automatically based on that file and then periodically
+    uploaded to Transifex for translation. -->
 * [Rebase](https://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/) your
   changes on the latest `development` branch, resolving any conflicts.
   This ensures that your changes will merge cleanly when you open your PR.

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -74,11 +74,6 @@ class LokiP2pAPI extends EventEmitter {
     return { ...this.contactP2pDetails[pubKey] };
   }
 
-  isContactOnline(pubKey) {
-    const contactDetails = this.contactP2pDetails[pubKey];
-    return !!(contactDetails && contactDetails.isOnline);
-  }
-
   setContactOffline(pubKey) {
     this.emit('offline', pubKey);
     if (!this.contactP2pDetails[pubKey]) {

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -39,7 +39,7 @@ class LokiP2pAPI extends EventEmitter {
       isOnline: false,
     };
 
-    const contactExists = isEmpty(baseDetails);
+    const contactExists = !isEmpty(baseDetails);
     const { isOnline } = baseDetails;
     const detailsChanged =
       baseDetails.address !== address || baseDetails.port !== port;
@@ -70,7 +70,8 @@ class LokiP2pAPI extends EventEmitter {
   }
 
   getContactP2pDetails(pubKey) {
-    return this.contactP2pDetails[pubKey] || null;
+    if (!this.contactP2pDetails[pubKey]) return null;
+    return { ...this.contactP2pDetails[pubKey] };
   }
 
   isContactOnline(pubKey) {

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -1,6 +1,7 @@
-/* global setTimeout, clearTimeout, _ */
+/* global setTimeout, clearTimeout */
 
 const EventEmitter = require('events');
+const { isEmpty } = require('lodash')
 
 const offlinePingTime = 2 * 60 * 1000; // 2 minutes
 
@@ -38,7 +39,7 @@ class LokiP2pAPI extends EventEmitter {
      isOnline: false,
    };
 
-    const contactExists = _.isEmpty(baseDetails)
+    const contactExists = isEmpty(baseDetails)
     const { isOnline } = baseDetails;
     const detailsChanged = baseDetails.address !== address || baseDetails.port !== port
 

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -1,7 +1,7 @@
 /* global setTimeout, clearTimeout */
 
 const EventEmitter = require('events');
-const { isEmpty } = require('lodash')
+const { isEmpty } = require('lodash');
 
 const offlinePingTime = 2 * 60 * 1000; // 2 minutes
 
@@ -32,16 +32,17 @@ class LokiP2pAPI extends EventEmitter {
 
     // Always set the new contact details
     this.contactP2pDetails[pubKey] = {
-     address,
-     port,
-     timerDuration,
-     pingTimer: null,
-     isOnline: false,
-   };
+      address,
+      port,
+      timerDuration,
+      pingTimer: null,
+      isOnline: false,
+    };
 
-    const contactExists = isEmpty(baseDetails)
+    const contactExists = isEmpty(baseDetails);
     const { isOnline } = baseDetails;
-    const detailsChanged = baseDetails.address !== address || baseDetails.port !== port
+    const detailsChanged =
+      baseDetails.address !== address || baseDetails.port !== port;
 
     // If we had the contact details
     // And we got a P2P message
@@ -52,7 +53,7 @@ class LokiP2pAPI extends EventEmitter {
       // We also need to set the current contact details to show online
       //  because they get reset to `false` above
       this.setContactOnline(pubKey);
-      return
+      return;
     }
 
     /*

--- a/js/modules/loki_p2p_api.js
+++ b/js/modules/loki_p2p_api.js
@@ -1,4 +1,4 @@
-/* global setTimeout, clearTimeout */
+/* global setTimeout, clearTimeout, _ */
 
 const EventEmitter = require('events');
 
@@ -18,58 +18,52 @@ class LokiP2pAPI extends EventEmitter {
     });
   }
 
-  updateContactP2pDetails(pubKey, address, port, isPing = false) {
+  updateContactP2pDetails(pubKey, address, port, isP2PMessage = false) {
     // Stagger the timers so the friends don't ping each other at the same time
     const timerDuration =
       pubKey < this.ourKey
         ? 60 * 1000 // 1 minute
         : 2 * 60 * 1000; // 2 minutes
 
-    if (!this.contactP2pDetails[pubKey]) {
-      // We didn't have this contact's details
-      this.contactP2pDetails[pubKey] = {
-        address,
-        port,
-        timerDuration,
-        pingTimer: null,
-        isOnline: false,
-      };
-      if (isPing) {
-        this.setContactOnline(pubKey);
-        return;
-      }
-      // Try ping
-      this.pingContact(pubKey);
-      return;
-    }
+    // Get the current contact details
+    // This will be empty if we don't have them
+    const baseDetails = { ...(this.contactP2pDetails[pubKey] || {}) };
 
-    // We already had this contact's details
-    const baseDetails = { ...this.contactP2pDetails[pubKey] };
+    // Always set the new contact details
+    this.contactP2pDetails[pubKey] = {
+     address,
+     port,
+     timerDuration,
+     pingTimer: null,
+     isOnline: false,
+   };
 
-    if (isPing) {
-      // Received a ping
-      // Update details in case they are new and mark online
-      this.contactP2pDetails[pubKey].address = address;
-      this.contactP2pDetails[pubKey].port = port;
+    const contactExists = _.isEmpty(baseDetails)
+    const { isOnline } = baseDetails;
+    const detailsChanged = baseDetails.address !== address || baseDetails.port !== port
+
+    // If we had the contact details
+    // And we got a P2P message
+    // And the contact was online
+    // And the new details that we got matched the old
+    // Then we don't need to bother pinging
+    if (contactExists && isP2PMessage && isOnline && !detailsChanged) {
+      // We also need to set the current contact details to show online
+      //  because they get reset to `false` above
       this.setContactOnline(pubKey);
-      return;
+      return
     }
 
-    // Received a storage broadcast message
-    if (
-      baseDetails.isOnline ||
-      baseDetails.address !== address ||
-      baseDetails.port !== port
-    ) {
-      // Had the contact marked as online and details we had were the same
-      this.pingContact(pubKey);
-      return;
-    }
-
-    // Had the contact marked as offline or got new details
-    this.contactP2pDetails[pubKey].address = address;
-    this.contactP2pDetails[pubKey].port = port;
-    this.setContactOffline(pubKey);
+    /*
+      Ping the contact.
+      This happens in the following scenarios:
+        1. We didn't have the contact, we need to ping them to let them know our details.
+        2. isP2PMessage = false, so we assume the contact doesn't have our details.
+        3. We had the contact marked as offline,
+            we need to make sure that we can reach their server.
+        4. The other contact details have changed,
+            we need to make sure that we can reach their new server.
+    */
     this.pingContact(pubKey);
   }
 

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -106,7 +106,10 @@ const rpc = (address, port, method, params, options = {}) => {
     method: 'POST',
     ...options,
     body: JSON.stringify(body),
-    headers,
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
   };
 
   return fetch(url, fetchOptions);

--- a/libloki/test/node/loki_p2p_api_test.js
+++ b/libloki/test/node/loki_p2p_api_test.js
@@ -70,7 +70,7 @@ describe('LokiP2pAPI', () => {
     it("Should ping a contact if we don't have details for it", done => {
       this.lokiP2pAPI.on('pingContact', pubKey => {
         assert.strictEqual(pubKey, usedKey);
-        assert.isFalse(this.lokiP2pAPI.isContactOnline(usedKey));
+        assert.isFalse(this.lokiP2pAPI.isOnline(usedKey));
         done();
       });
       this.lokiP2pAPI.updateContactP2pDetails(
@@ -87,7 +87,7 @@ describe('LokiP2pAPI', () => {
 
       this.lokiP2pAPI.on('pingContact', pubKey => {
         assert.strictEqual(pubKey, usedKey);
-        assert.isFalse(this.lokiP2pAPI.isContactOnline(usedKey));
+        assert.isFalse(this.lokiP2pAPI.isOnline(usedKey));
         done();
       });
       this.lokiP2pAPI.updateContactP2pDetails(
@@ -105,7 +105,7 @@ describe('LokiP2pAPI', () => {
 
       this.lokiP2pAPI.on('pingContact', pubKey => {
         assert.strictEqual(pubKey, usedKey);
-        assert.isFalse(this.lokiP2pAPI.isContactOnline(usedKey));
+        assert.isFalse(this.lokiP2pAPI.isOnline(usedKey));
         done();
       });
       this.lokiP2pAPI.updateContactP2pDetails(

--- a/libloki/test/node/loki_p2p_api_test.js
+++ b/libloki/test/node/loki_p2p_api_test.js
@@ -26,7 +26,7 @@ describe('LokiP2pAPI', () => {
     it('Should return null if no contact details exist', () => {
       const details = this.lokiP2pAPI.getContactP2pDetails(usedKey);
       assert.isNull(details);
-    })
+    });
 
     it('Should return the exact same object if contact details exist', () => {
       this.lokiP2pAPI.contactP2pDetails[usedKey] = usedDetails;
@@ -60,12 +60,7 @@ describe('LokiP2pAPI', () => {
       const { address, port } = details;
 
       this.lokiP2pAPI.contactP2pDetails[usedKey] = details;
-      this.lokiP2pAPI.updateContactP2pDetails(
-        usedKey,
-        address,
-        port,
-        isP2P
-      );
+      this.lokiP2pAPI.updateContactP2pDetails(usedKey, address, port, isP2P);
 
       // They should also be marked as online
       assert.isTrue(this.lokiP2pAPI.isOnline(usedKey));
@@ -197,7 +192,7 @@ describe('LokiP2pAPI', () => {
           true
         );
         assert.isTrue(this.lokiP2pAPI.isOnline(usedKey));
-        done()
+        done();
       });
 
       // The first message should ping

--- a/libloki/test/node/loki_p2p_api_test.js
+++ b/libloki/test/node/loki_p2p_api_test.js
@@ -6,6 +6,14 @@ describe('LokiP2pAPI', () => {
   const usedAddress = 'anAddress';
   const usedPort = 'aPort';
 
+  const usedDetails = {
+    address: usedAddress,
+    port: usedPort,
+    timerDuration: 100,
+    pingTimer: null,
+    isOnline: false,
+  };
+
   beforeEach(() => {
     this.lokiP2pAPI = new LokiP2pAPI();
   });
@@ -14,79 +22,207 @@ describe('LokiP2pAPI', () => {
     this.lokiP2pAPI.reset();
   });
 
-  it("Should not emit a pingContact event if that contact doesn't exits", () => {
-    this.lokiP2pAPI.on('pingContact', () => {
-      assert.fail();
+  describe('getContactP2pDetails', () => {
+    it('Should return null if no contact details exist', () => {
+      const details = this.lokiP2pAPI.getContactP2pDetails(usedKey);
+      assert.isNull(details);
+    })
+
+    it('Should return the exact same object if contact details exist', () => {
+      this.lokiP2pAPI.contactP2pDetails[usedKey] = usedDetails;
+      const details = this.lokiP2pAPI.getContactP2pDetails(usedKey);
+      assert.deepEqual(details, usedDetails);
     });
-    this.lokiP2pAPI.pingContact('not stored');
   });
 
-  it('Should emit an online event if the contact is online', done => {
-    this.lokiP2pAPI.on('online', pubKey => {
-      assert.strictEqual(pubKey, usedKey);
-      done();
+  describe('pingContact', () => {
+    it("Should not emit a pingContact event if that contact doesn't exits", () => {
+      this.lokiP2pAPI.on('pingContact', () => {
+        assert.fail();
+      });
+      this.lokiP2pAPI.pingContact('not stored');
     });
-    this.lokiP2pAPI.updateContactP2pDetails(
-      usedKey,
-      usedAddress,
-      usedPort,
-      true
-    );
-  }).timeout(1000);
-
-  it("Should send a pingContact event if the contact isn't online", done => {
-    this.lokiP2pAPI.on('pingContact', pubKey => {
-      assert.strictEqual(pubKey, usedKey);
-      done();
-    });
-    this.lokiP2pAPI.updateContactP2pDetails(
-      usedKey,
-      usedAddress,
-      usedPort,
-      false
-    );
-  }).timeout(1000);
-
-  it('Should store a contacts p2p details', () => {
-    this.lokiP2pAPI.updateContactP2pDetails(
-      usedKey,
-      usedAddress,
-      usedPort,
-      true
-    );
-    const p2pDetails = this.lokiP2pAPI.getContactP2pDetails(usedKey);
-    assert.strictEqual(usedAddress, p2pDetails.address);
-    assert.strictEqual(usedPort, p2pDetails.port);
   });
 
-  it('Should say if a contact is online', () => {
-    this.lokiP2pAPI.updateContactP2pDetails(
-      usedKey,
-      usedAddress,
-      usedPort,
-      false
-    );
-    assert.isFalse(this.lokiP2pAPI.isOnline(usedKey));
-    this.lokiP2pAPI.updateContactP2pDetails(
-      usedKey,
-      usedAddress,
-      usedPort,
-      true
-    );
-    assert.isTrue(this.lokiP2pAPI.isOnline(usedKey));
-  });
+  describe('updateContactP2pDetails', () => {
+    it("Shouldn't ping a contact if contact exists, p2p message was sent, contact was online and details didn't change", () => {
+      this.lokiP2pAPI.on('pingContact', () => {
+        assert.fail();
+      });
 
-  it('Should set a contact as offline', () => {
-    this.lokiP2pAPI.updateContactP2pDetails(
-      usedKey,
-      usedAddress,
-      usedPort,
-      true
-    );
-    let p2pDetails = this.lokiP2pAPI.getContactP2pDetails(usedKey);
-    assert.isTrue(p2pDetails.isOnline);
-    p2pDetails = this.lokiP2pAPI.getContactP2pDetails(usedKey);
-    this.lokiP2pAPI.setContactOffline(usedKey);
-    assert.isFalse(p2pDetails.isOnline);
+      // contact exists
+      const details = { ...usedDetails };
+      // P2p message
+      const isP2P = true;
+      // Contact was online
+      details.isOnline = true;
+      // details were the same
+      const { address, port } = details;
+
+      this.lokiP2pAPI.contactP2pDetails[usedKey] = details;
+      this.lokiP2pAPI.updateContactP2pDetails(
+        usedKey,
+        address,
+        port,
+        isP2P
+      );
+
+      // They should also be marked as online
+      assert.isTrue(this.lokiP2pAPI.isOnline(usedKey));
+    });
+
+    it("Should ping a contact if we don't have details for it", done => {
+      this.lokiP2pAPI.on('pingContact', pubKey => {
+        assert.strictEqual(pubKey, usedKey);
+        assert.isFalse(this.lokiP2pAPI.isContactOnline(usedKey));
+        done();
+      });
+      this.lokiP2pAPI.updateContactP2pDetails(
+        usedKey,
+        usedAddress,
+        usedPort,
+        true
+      );
+    });
+
+    it("Should ping a contact if a P2P message wasn't received", done => {
+      // The precondition for this is that we had the contact stored
+      this.lokiP2pAPI.contactP2pDetails[usedKey] = { ...usedDetails };
+
+      this.lokiP2pAPI.on('pingContact', pubKey => {
+        assert.strictEqual(pubKey, usedKey);
+        assert.isFalse(this.lokiP2pAPI.isContactOnline(usedKey));
+        done();
+      });
+      this.lokiP2pAPI.updateContactP2pDetails(
+        usedKey,
+        usedAddress,
+        usedPort,
+        false // We didn't get a p2p message
+      );
+    });
+
+    it('Should ping a contact if they were marked as offline', done => {
+      // The precondition for this is that we had the contact stored
+      // And that p2p message was true
+      this.lokiP2pAPI.contactP2pDetails[usedKey] = { ...usedDetails };
+
+      this.lokiP2pAPI.on('pingContact', pubKey => {
+        assert.strictEqual(pubKey, usedKey);
+        assert.isFalse(this.lokiP2pAPI.isContactOnline(usedKey));
+        done();
+      });
+      this.lokiP2pAPI.updateContactP2pDetails(
+        usedKey,
+        usedAddress,
+        usedPort,
+        true // We got a p2p message
+      );
+    });
+
+    it('Should ping a contact if the address was different', done => {
+      // The precondition for this is that we had the contact stored
+      // And that p2p message was true
+      // And that the user was online
+      this.lokiP2pAPI.contactP2pDetails[usedKey] = { ...usedDetails };
+      this.lokiP2pAPI.contactP2pDetails[usedKey].isOnline = true;
+
+      this.lokiP2pAPI.on('pingContact', pubKey => {
+        assert.strictEqual(pubKey, usedKey);
+        done();
+      });
+      this.lokiP2pAPI.updateContactP2pDetails(
+        usedKey,
+        'different address',
+        usedPort,
+        true // We got a p2p message
+      );
+    });
+
+    it('Should ping a contact if the port was different', done => {
+      // The precondition for this is that we had the contact stored
+      // And that p2p message was true
+      // And that the user was online
+      this.lokiP2pAPI.contactP2pDetails[usedKey] = { ...usedDetails };
+      this.lokiP2pAPI.contactP2pDetails[usedKey].isOnline = true;
+
+      this.lokiP2pAPI.on('pingContact', pubKey => {
+        assert.strictEqual(pubKey, usedKey);
+        done();
+      });
+      this.lokiP2pAPI.updateContactP2pDetails(
+        usedKey,
+        usedAddress,
+        'different port',
+        true // We got a p2p message
+      );
+    });
+
+    it('Should emit an online event if the contact is online', done => {
+      this.lokiP2pAPI.on('online', pubKey => {
+        assert.strictEqual(pubKey, usedKey);
+        done();
+      });
+      this.lokiP2pAPI.contactP2pDetails[usedKey] = { ...usedDetails };
+      this.lokiP2pAPI.setContactOnline(usedKey);
+    }).timeout(1000);
+
+    it('Should store a contacts p2p details', () => {
+      this.lokiP2pAPI.updateContactP2pDetails(
+        usedKey,
+        usedAddress,
+        usedPort,
+        true
+      );
+      const p2pDetails = this.lokiP2pAPI.getContactP2pDetails(usedKey);
+      assert.strictEqual(usedAddress, p2pDetails.address);
+      assert.strictEqual(usedPort, p2pDetails.port);
+    });
+
+    it('Should establish a proper p2p connection', done => {
+      // We assume that when we pinged a contact then it was successful
+      let pingCount = 0;
+
+      this.lokiP2pAPI.on('pingContact', pubKey => {
+        pingCount += 1;
+        assert.strictEqual(pingCount, 1);
+        assert.strictEqual(pubKey, usedKey);
+        this.lokiP2pAPI.setContactOnline(pubKey);
+
+        // The second message should work and the user should be online
+        this.lokiP2pAPI.updateContactP2pDetails(
+          usedKey,
+          usedAddress,
+          usedPort,
+          true
+        );
+        assert.isTrue(this.lokiP2pAPI.isOnline(usedKey));
+        done()
+      });
+
+      // The first message should ping
+      this.lokiP2pAPI.updateContactP2pDetails(
+        usedKey,
+        usedAddress,
+        usedPort,
+        false
+      );
+      assert.isFalse(this.lokiP2pAPI.isOnline(usedKey));
+    }).timeout(2000);
+
+    it('Should set a contact as offline and online', () => {
+      this.lokiP2pAPI.contactP2pDetails[usedKey] = { ...usedDetails };
+      let p2pDetails = this.lokiP2pAPI.getContactP2pDetails(usedKey);
+      assert.isNotNull(p2pDetails);
+      assert.isFalse(p2pDetails.isOnline);
+      this.lokiP2pAPI.setContactOnline(usedKey);
+
+      p2pDetails = this.lokiP2pAPI.getContactP2pDetails(usedKey);
+      assert.isTrue(p2pDetails.isOnline);
+      this.lokiP2pAPI.setContactOffline(usedKey);
+
+      p2pDetails = this.lokiP2pAPI.getContactP2pDetails(usedKey);
+      assert.isFalse(p2pDetails.isOnline);
+    });
   });
 });

--- a/libloki/test/node/loki_p2p_api_test.js
+++ b/libloki/test/node/loki_p2p_api_test.js
@@ -19,6 +19,7 @@ describe('LokiP2pAPI', () => {
   });
 
   afterEach(() => {
+    this.lokiP2pAPI.removeAllListeners();
     this.lokiP2pAPI.reset();
   });
 
@@ -173,37 +174,6 @@ describe('LokiP2pAPI', () => {
       assert.strictEqual(usedAddress, p2pDetails.address);
       assert.strictEqual(usedPort, p2pDetails.port);
     });
-
-    it('Should establish a proper p2p connection', done => {
-      // We assume that when we pinged a contact then it was successful
-      let pingCount = 0;
-
-      this.lokiP2pAPI.on('pingContact', pubKey => {
-        pingCount += 1;
-        assert.strictEqual(pingCount, 1);
-        assert.strictEqual(pubKey, usedKey);
-        this.lokiP2pAPI.setContactOnline(pubKey);
-
-        // The second message should work and the user should be online
-        this.lokiP2pAPI.updateContactP2pDetails(
-          usedKey,
-          usedAddress,
-          usedPort,
-          true
-        );
-        assert.isTrue(this.lokiP2pAPI.isOnline(usedKey));
-        done();
-      });
-
-      // The first message should ping
-      this.lokiP2pAPI.updateContactP2pDetails(
-        usedKey,
-        usedAddress,
-        usedPort,
-        false
-      );
-      assert.isFalse(this.lokiP2pAPI.isOnline(usedKey));
-    }).timeout(2000);
 
     it('Should set a contact as offline and online', () => {
       this.lokiP2pAPI.contactP2pDetails[usedKey] = { ...usedDetails };


### PR DESCRIPTION
There were a few minor cases that we were missing when checking whether we should ping or just mark the user as online.

This PR simplifies that logic down according to the following diagram:
![Screen Shot 2019-05-24 at 11 41 07 am](https://user-images.githubusercontent.com/4365065/58296867-da66dd00-7e18-11e9-83fa-c2dc69aac694.png)

**EDIT: The image is missing a connection between `Was a user marked as online before?` and `Ping contact`**

Here we assume:
1. When pinging, if it succeeds then we set contact to `online`
2. When we mark the contact as online then we reset their ping timers
3. We always save the latest details