### PR TITLE
Convert profile field in DataMessage to use LokiProfile

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -620,7 +620,7 @@
     Whisper.events.on('onEditProfile', () => {
       const ourNumber = textsecure.storage.user.getNumber();
       const profile = storage.getLocalProfile();
-      const displayName = profile && profile.name && profile.name.displayName;
+      const displayName = profile && profile.displayName;
       if (appView) {
         appView.showNicknameDialog({
           title: window.i18n('editProfileTitle'),

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1978,7 +1978,7 @@
       // Prioritise nickname over the profile display name
       const nickname = this.getNickname();
       const profile = this.getLocalProfile();
-      const displayName = profile && profile.name && profile.name.displayName;
+      const displayName = profile && profile.displayName;
 
       const profileName = nickname || displayName || null;
       await this.setProfileName(profileName);

--- a/js/models/profile.js
+++ b/js/models/profile.js
@@ -29,11 +29,9 @@
     const profile = storage.getLocalProfile();
     const newProfile = profile || {};
     if (_.isEmpty(trimmed)) {
-      delete newProfile.name;
+      delete newProfile.displayName;
     } else {
-      newProfile.name = {
-        displayName: trimmed,
-      };
+      newProfile.displayName = trimmed;
     }
 
     await storage.saveLocalProfile(newProfile);

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -143,10 +143,12 @@ Message.prototype = {
       proto.profileKey = this.profileKey;
     }
 
-    if (this.profile && this.profile.name) {
-      const contact = new textsecure.protobuf.DataMessage.Contact();
-      contact.name = this.profile.name;
-      proto.profile = contact;
+    // Only send the display name for now.
+    // In the future we might want to extend this to send other things.
+    if (this.profile && this.profile.displayName) {
+      const profile = new textsecure.protobuf.DataMessage.LokiProfile();
+      profile.displayName = this.profile.displayName;
+      proto.profile = profile;
     }
 
     this.dataMessage = proto;

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -180,6 +180,11 @@ message DataMessage {
     optional AttachmentPointer image = 3;
   }
 
+  // Loki: A custom message for our profile
+  message LokiProfile {
+    optional string displayName = 1;
+  }
+
   optional string             body        = 1;
   repeated AttachmentPointer  attachments = 2;
   optional GroupContext       group       = 3;
@@ -190,7 +195,7 @@ message DataMessage {
   optional Quote              quote       = 8;
   repeated Contact            contact     = 9;
   repeated Preview            preview     = 10;
-  optional Contact            profile     = 101; // Loki: The profile of the current user
+  optional LokiProfile        profile     = 101; // Loki: The profile of the current user
 }
 
 message NullMessage {

--- a/test/models/profile_test.js
+++ b/test/models/profile_test.js
@@ -72,13 +72,8 @@ describe('Profile', () => {
 
     it('saves the display name', async () => {
       await storage.setProfileName('hi there!');
-
-      const expected = {
-        displayName: 'hi there!',
-      };
       const profile = storage.getLocalProfile();
-      assert.exists(profile.name);
-      assert.deepEqual(expected, profile.name);
+      assert.deepEqual(profile.displayName, 'hi there!');
     });
 
     it('saves the display name without overwriting the other profile properties', async () => {
@@ -88,9 +83,7 @@ describe('Profile', () => {
 
       const expected = {
         ...profile,
-        name: {
-          displayName: 'hi there!',
-        },
+        displayName: 'hi there!',
       };
       assert.deepEqual(expected, storage.getLocalProfile());
     });
@@ -98,23 +91,18 @@ describe('Profile', () => {
     it('trims the display name', async () => {
       await storage.setProfileName('  in    middle  ');
       const profile = storage.getLocalProfile();
-      const name = {
-        displayName: 'in    middle',
-      };
-      assert.deepEqual(name, profile.name);
+      assert.deepEqual('in    middle', profile.displayName);
     });
 
-    it('unsets the name property if it is empty', async () => {
+    it('unsets the display name property if it is empty', async () => {
       const profile = {
-        name: {
-          displayName: 'HI THERE!',
-        },
+        displayName: 'HI THERE!',
       };
       await storage.put(PROFILE_ID, profile);
-      assert.exists(storage.getLocalProfile().name);
+      assert.exists(storage.getLocalProfile().displayName);
 
       await storage.setProfileName('');
-      assert.notExists(storage.getLocalProfile().name);
+      assert.notExists(storage.getLocalProfile().displayName);
     });
   });
 });


### PR DESCRIPTION
We were using signal `Contact` before but we didn't really need any other unnecessary fields.
Also if in the future we want to add a custom field (E.g loki wallet address) then we only modify the proto that we made and not the one signal has, which may stop conflicts occurring (though the chances are low)