### PR TITLE
Clearnet seeds

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -5,7 +5,7 @@
   "contentProxyUrl": "random.snode",
   "localServerPort": "8081",
   "defaultPoWDifficulty": "100",
-  "seedNodeUrl": "13.238.53.205",
+  "seedNodeUrl": "3.104.19.14",
   "seedNodePort": "22023",
   "disableAutoUpdate": false,
   "updatesUrl": "https://updates2.signal.org/desktop",

--- a/config/default.json
+++ b/config/default.json
@@ -4,7 +4,6 @@
   "cdnUrl": "random.snode",
   "contentProxyUrl": "random.snode",
   "localServerPort": "8081",
-  "snodeServerPort": "8080",
   "defaultPoWDifficulty": "100",
   "disableAutoUpdate": false,
   "updatesUrl": "https://updates2.signal.org/desktop",

--- a/config/default.json
+++ b/config/default.json
@@ -5,6 +5,8 @@
   "contentProxyUrl": "random.snode",
   "localServerPort": "8081",
   "defaultPoWDifficulty": "100",
+  "seedNodeUrl": "13.238.53.205",
+  "seedNodePort": "22023",
   "disableAutoUpdate": false,
   "updatesUrl": "https://updates2.signal.org/desktop",
   "updatesPublicKey":

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -239,7 +239,8 @@ class LokiMessageAPI {
         await sleepFor(successiveFailures * 1000);
 
         try {
-          let messages = await retrieveNextMessages(address, nodeData, ourKey);
+          // TODO: Revert back to using snode address instead of IP
+          let messages = await retrieveNextMessages(nodeData.ip, nodeData, ourKey);
           successiveFailures = 0;
           if (messages.length) {
             const lastMessage = _.last(messages);

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -170,8 +170,8 @@ class LokiMessageAPI {
 
   async openSendConnection(params) {
     while (!_.isEmpty(this.sendingSwarmNodes[params.timestamp])) {
-      const url = this.sendingSwarmNodes[params.timestamp].shift();
-      const successfulSend = await this.sendToNode(url, params);
+      const snode = this.sendingSwarmNodes[params.timestamp].shift();
+      const successfulSend = await this.sendToNode(snode.address, snode.port, params);
       if (successfulSend) {
         return true;
       }
@@ -179,14 +179,14 @@ class LokiMessageAPI {
     return false;
   }
 
-  async sendToNode(url, params) {
+  async sendToNode(address, port, params) {
     let successiveFailures = 0;
     while (successiveFailures < 3) {
       await sleepFor(successiveFailures * 500);
       try {
         const result = await rpc(
-          `https://${url}`,
-          this.snodeServerPort,
+          `https://${address}`,
+          port,
           'store',
           params
         );
@@ -222,8 +222,8 @@ class LokiMessageAPI {
         }
       }
     }
-    log.error(`Failed to send to node: ${url}`);
-    await lokiSnodeAPI.unreachableNode(params.pubKey, url);
+    log.error(`Failed to send to node: ${address}`);
+    await lokiSnodeAPI.unreachableNode(params.pubKey, address);
     return false;
   }
 

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -171,7 +171,8 @@ class LokiMessageAPI {
   async openSendConnection(params) {
     while (!_.isEmpty(this.sendingSwarmNodes[params.timestamp])) {
       const snode = this.sendingSwarmNodes[params.timestamp].shift();
-      const successfulSend = await this.sendToNode(snode.address, snode.port, params);
+      // TODO: Revert back to using snode address instead of IP
+      const successfulSend = await this.sendToNode(snode.ip, snode.port, params);
       if (successfulSend) {
         return true;
       }

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -86,7 +86,7 @@ const retrieveNextMessages = async (nodeUrl, nodeData, ourKey) => {
     options
   );
   return result.messages || [];
-}
+};
 
 class LokiMessageAPI {
   constructor() {
@@ -172,7 +172,11 @@ class LokiMessageAPI {
     while (!_.isEmpty(this.sendingSwarmNodes[params.timestamp])) {
       const snode = this.sendingSwarmNodes[params.timestamp].shift();
       // TODO: Revert back to using snode address instead of IP
-      const successfulSend = await this.sendToNode(snode.ip, snode.port, params);
+      const successfulSend = await this.sendToNode(
+        snode.ip,
+        snode.port,
+        params
+      );
       if (successfulSend) {
         return true;
       }
@@ -185,12 +189,7 @@ class LokiMessageAPI {
     while (successiveFailures < 3) {
       await sleepFor(successiveFailures * 500);
       try {
-        const result = await rpc(
-          `https://${address}`,
-          port,
-          'store',
-          params
-        );
+        const result = await rpc(`https://${address}`, port, 'store', params);
 
         // Make sure we aren't doing too much PoW
         const currentDifficulty = window.storage.get('PoWDifficulty', null);
@@ -240,7 +239,11 @@ class LokiMessageAPI {
 
         try {
           // TODO: Revert back to using snode address instead of IP
-          let messages = await retrieveNextMessages(nodeData.ip, nodeData, ourKey);
+          let messages = await retrieveNextMessages(
+            nodeData.ip,
+            nodeData,
+            ourKey
+          );
           successiveFailures = 0;
           if (messages.length) {
             const lastMessage = _.last(messages);

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -5,6 +5,7 @@ const { parse } = require('url');
 
 const LOKI_EPHEMKEY_HEADER = 'X-Loki-EphemKey';
 const endpointBase = '/v1/storage_rpc';
+const seedEndpointBase = '/json_rpc';
 
 const decryptResponse = async (response, address) => {
   try {
@@ -101,11 +102,15 @@ const fetch = async (url, options = {}) => {
 };
 
 // Wrapper for a JSON RPC request
-const rpc = (address, port, method, params, options = {}) => {
+const rpc = (address, port, method, params, options = {}, seedRequest = false) => {
   const headers = options.headers || {};
   const portString = port ? `:${port}` : '';
-  const url = `${address}${portString}${endpointBase}`;
+  const endpoint = seedRequest ? seedEndpointBase : endpointBase;
+  const url = `${address}${portString}${endpoint}`;
+  // TODO: The jsonrpc and body field will be ignored on storage server
   const body = {
+    jsonrpc: '2.0',
+    id: '0',
     method,
     params,
   };
@@ -122,6 +127,7 @@ const rpc = (address, port, method, params, options = {}) => {
 
   return fetch(url, fetchOptions);
 };
+
 
 module.exports = {
   rpc,

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -102,7 +102,14 @@ const fetch = async (url, options = {}) => {
 };
 
 // Wrapper for a JSON RPC request
-const rpc = (address, port, method, params, options = {}, seedRequest = false) => {
+const rpc = (
+  address,
+  port,
+  method,
+  params,
+  options = {},
+  seedRequest = false
+) => {
   const headers = options.headers || {};
   const portString = port ? `:${port}` : '';
   const endpoint = seedRequest ? seedEndpointBase : endpointBase;
@@ -127,7 +134,6 @@ const rpc = (address, port, method, params, options = {}, seedRequest = false) =
 
   return fetch(url, fetchOptions);
 };
-
 
 module.exports = {
   rpc,

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -103,7 +103,8 @@ const fetch = async (url, options = {}) => {
 // Wrapper for a JSON RPC request
 const rpc = (address, port, method, params, options = {}) => {
   const headers = options.headers || {};
-  const url = `${address}${port}${endpointBase}`;
+  const portString = port ? `:${port}` : '';
+  const url = `${address}${portString}${endpointBase}`;
   const body = {
     method,
     params,

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -5,7 +5,6 @@ const { parse } = require('url');
 
 const LOKI_EPHEMKEY_HEADER = 'X-Loki-EphemKey';
 const endpointBase = '/v1/storage_rpc';
-const seedEndpointBase = '/json_rpc';
 
 const decryptResponse = async (response, address) => {
   try {
@@ -108,11 +107,10 @@ const rpc = (
   method,
   params,
   options = {},
-  seedRequest = false
+  endpoint = endpointBase
 ) => {
   const headers = options.headers || {};
   const portString = port ? `:${port}` : '';
-  const endpoint = seedRequest ? seedEndpointBase : endpointBase;
   const url = `${address}${portString}${endpoint}`;
   // TODO: The jsonrpc and body field will be ignored on storage server
   const body = {

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -84,9 +84,9 @@ class LokiSnodeAPI {
     );
     const snodes = result.result.service_node_states;
     this.randomSnodePool = snodes.map(snode => ({
-        address: snode.public_ip,
-        port: snode.storage_port,
-      })
+      address: snode.public_ip,
+      port: snode.storage_port,
+    })
     );
   }
 
@@ -108,12 +108,9 @@ class LokiSnodeAPI {
   async updateLastHash(nodeUrl, lastHash, expiresAt) {
     await window.Signal.Data.updateLastHash({ nodeUrl, lastHash, expiresAt });
     if (!this.ourSwarmNodes[nodeUrl]) {
-      this.ourSwarmNodes[nodeUrl] = {
-        lastHash,
-      };
-    } else {
-      this.ourSwarmNodes[nodeUrl].lastHash = lastHash;
+      return;
     }
+    this.ourSwarmNodes[nodeUrl].lastHash = lastHash;
   }
 
   getSwarmNodesForPubKey(pubKey) {
@@ -146,6 +143,7 @@ class LokiSnodeAPI {
       this.ourSwarmNodes[snode.address] = {
         lastHash,
         port: snode.port,
+        ip: snode.ip,
       };
     });
     await Promise.all(ps);

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -82,7 +82,7 @@ class LokiSnodeAPI {
       'get_service_nodes',
       {}, // Params
       {}, // Options
-      true // Seed request
+      '/json_rpc' // Seed request endpoint
     );
     const snodes = result.result.service_node_states;
     this.randomSnodePool = snodes.map(snode => ({

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -32,13 +32,13 @@ const resolveCname = url =>
   });
 
 class LokiSnodeAPI {
-  constructor({ serverUrl, localUrl, snodeServerPort }) {
+  constructor({ serverUrl, localUrl }) {
     if (!is.string(serverUrl)) {
       throw new Error('WebAPI.initialize: Invalid server url');
     }
     this.serverUrl = serverUrl;
     this.localUrl = localUrl;
-    this.snodeServerPort = snodeServerPort ? `:${snodeServerPort}` : '';
+    this.randomSnodePool = [];
     this.swarmsPendingReplenish = {};
     this.ourSwarmNodes = {};
     this.contactSwarmNodes = {};
@@ -60,7 +60,7 @@ class LokiSnodeAPI {
     }
   }
 
-  async getMyLokiAddress() {
+  getMyLokiAddress() {
     /* resolve our local loki address */
     return resolveCname(this.localUrl);
   }

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -70,7 +70,9 @@ class LokiSnodeAPI {
     if (this.randomSnodePool.length === 0) {
       await this.initialiseRandomPool();
     }
-    return this.randomSnodePool[Math.floor(Math.random() * this.randomSnodePool.length)];
+    return this.randomSnodePool[
+      Math.floor(Math.random() * this.randomSnodePool.length)
+    ];
   }
 
   async initialiseRandomPool() {
@@ -86,8 +88,7 @@ class LokiSnodeAPI {
     this.randomSnodePool = snodes.map(snode => ({
       address: snode.public_ip,
       port: snode.storage_port,
-    })
-    );
+    }));
   }
 
   async unreachableNode(pubKey, nodeUrl) {
@@ -139,7 +140,9 @@ class LokiSnodeAPI {
   async updateOurSwarmNodes(newNodes) {
     this.ourSwarmNodes = {};
     const ps = newNodes.map(async snode => {
-      const lastHash = await window.Signal.Data.getLastHashBySnode(snode.address);
+      const lastHash = await window.Signal.Data.getLastHashBySnode(
+        snode.address
+      );
       this.ourSwarmNodes[snode.address] = {
         lastHash,
         port: snode.port,

--- a/main.js
+++ b/main.js
@@ -154,7 +154,6 @@ function prepareURL(pathSegments, moreKeys) {
       serverUrl: config.get('serverUrl'),
       localUrl: config.get('localUrl'),
       cdnUrl: config.get('cdnUrl'),
-      snodeServerPort: config.get('snodeServerPort'),
       localServerPort: config.get('localServerPort'),
       defaultPoWDifficulty: config.get('defaultPoWDifficulty'),
       certificateAuthority: config.get('certificateAuthority'),

--- a/main.js
+++ b/main.js
@@ -156,6 +156,8 @@ function prepareURL(pathSegments, moreKeys) {
       cdnUrl: config.get('cdnUrl'),
       localServerPort: config.get('localServerPort'),
       defaultPoWDifficulty: config.get('defaultPoWDifficulty'),
+      seedNodeUrl: config.get('seedNodeUrl'),
+      seedNodePort: config.get('seedNodePort'),
       certificateAuthority: config.get('certificateAuthority'),
       environment: config.environment,
       node_version: process.versions.node,

--- a/preload.js
+++ b/preload.js
@@ -293,17 +293,13 @@ const LokiSnodeAPI = require('./js/modules/loki_snode_api');
 window.lokiSnodeAPI = new LokiSnodeAPI({
   serverUrl: config.serverUrl,
   localUrl: config.localUrl,
-  snodeServerPort: config.snodeServerPort,
 });
 
 window.LokiP2pAPI = require('./js/modules/loki_p2p_api');
 
 const LokiMessageAPI = require('./js/modules/loki_message_api');
 
-window.lokiMessageAPI = new LokiMessageAPI({
-  url: config.serverUrl,
-  snodeServerPort: config.snodeServerPort,
-});
+window.lokiMessageAPI = new LokiMessageAPI();
 
 const LocalLokiServer = require('./libloki/modules/local_loki_server');
 

--- a/preload.js
+++ b/preload.js
@@ -288,6 +288,8 @@ window.WebAPI = initializeWebAPI({
   proxyUrl: config.proxyUrl,
 });
 
+window.seedNodeUrl = config.seedNodeUrl;
+window.seedNodePort = config.seedNodePort;
 const LokiSnodeAPI = require('./js/modules/loki_snode_api');
 
 window.lokiSnodeAPI = new LokiSnodeAPI({


### PR DESCRIPTION
Make the messenger send and receive to clearnet IP instead of snode addresses
Currently there is just the single hardcoded seed node, probably will add more in the future and choose randomly each time
We use the seed node to populate a list off (currently) every snode, we then use *that* list of snodes to randomly select from when we would normally use random.snode
Closes #292 