### PR TITLE
Make unverified https queries to the snodes

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -26,6 +26,9 @@ if (environment === 'production') {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '';
 }
 
+// temporary clearnet fix
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 // We load config after we've made our modifications to NODE_ENV
 const config = require('config');
 

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -155,7 +155,7 @@ class LokiMessageAPI {
     while (successiveFailures < 3) {
       await sleepFor(successiveFailures * 500);
       try {
-        await rpc(`http://${url}`, this.snodeServerPort, 'store', params);
+        await rpc(`https://${url}`, this.snodeServerPort, 'store', params);
         return true;
       } catch (e) {
         log.warn('Loki send message:', e);
@@ -193,7 +193,7 @@ class LokiMessageAPI {
     };
 
     const result = await rpc(
-      `http://${nodeUrl}`,
+      `https://${nodeUrl}`,
       this.snodeServerPort,
       'retrieve',
       params,

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -170,7 +170,7 @@ class LokiSnodeAPI {
     const nodeUrl = await this.getRandomSnodeAddress();
 
     const result = await rpc(
-      `http://${nodeUrl}`,
+      `https://${nodeUrl}`,
       this.snodeServerPort,
       'get_snodes_for_pubkey',
       {

--- a/libloki/crypto.js
+++ b/libloki/crypto.js
@@ -93,6 +93,7 @@
   function decodeSnodeAddressToPubKey(snodeAddress) {
     const snodeAddressClean = snodeAddress
       .replace('.snode', '')
+      .replace('https://', '')
       .replace('http://', '');
     return Multibase.decode(`${base32zCode}${snodeAddressClean}`);
   }


### PR DESCRIPTION
Next step is having the storage server sending the signature of its certificate to allow the client (messenger) to verify it post-handshake.