### PR TITLE
Refactor snode api

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -233,6 +233,8 @@
       window.libloki.api.sendOnlineBroadcastMessage(pubKey, isPing);
     });
 
+    window.lokiMessageAPI = new window.LokiMessageAPI();
+
     const currentPoWDifficulty = storage.get('PoWDifficulty', null);
     if (!currentPoWDifficulty) {
       storage.put('PoWDifficulty', window.getDefaultPoWDifficulty());

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -89,10 +89,8 @@ class LokiSnodeAPI {
   async unreachableNode(pubKey, nodeUrl) {
     const conversation = ConversationController.get(pubKey);
     const swarmNodes = [...conversation.get('swarmNodes')];
-    if (swarmNodes.includes(nodeUrl)) {
-      const filteredNodes = swarmNodes.filter(node => node !== nodeUrl);
-      await conversation.updateSwarmNodes(filteredNodes);
-    }
+    const filteredNodes = swarmNodes.filter(node => node.address !== nodeUrl);
+    await conversation.updateSwarmNodes(filteredNodes);
   }
 
   async updateLastHash(nodeUrl, lastHash, expiresAt) {

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -6,9 +6,6 @@ const dns = require('dns');
 const process = require('process');
 const { rpc } = require('./loki_rpc');
 
-// Will be raised (to 3?) when we get more nodes
-const MINIMUM_SWARM_NODES = 1;
-
 const resolve4 = url =>
   new Promise((resolve, reject) => {
     dns.resolve4(url, (err, ip) => {
@@ -40,8 +37,6 @@ class LokiSnodeAPI {
     this.localUrl = localUrl;
     this.randomSnodePool = [];
     this.swarmsPendingReplenish = {};
-    this.ourSwarmNodes = {};
-    this.contactSwarmNodes = {};
     // When we package lokinet with messenger we can ensure this ip is correct
     if (process.platform === 'win32') {
       dns.setServers(['127.0.0.1']);
@@ -92,26 +87,16 @@ class LokiSnodeAPI {
   }
 
   async unreachableNode(pubKey, nodeUrl) {
-    if (pubKey === window.textsecure.storage.user.getNumber()) {
-      delete this.ourSwarmNodes[nodeUrl];
-      return;
-    }
-
     const conversation = ConversationController.get(pubKey);
     const swarmNodes = [...conversation.get('swarmNodes')];
     if (swarmNodes.includes(nodeUrl)) {
       const filteredNodes = swarmNodes.filter(node => node !== nodeUrl);
       await conversation.updateSwarmNodes(filteredNodes);
-      delete this.contactSwarmNodes[nodeUrl];
     }
   }
 
   async updateLastHash(nodeUrl, lastHash, expiresAt) {
     await window.Signal.Data.updateLastHash({ nodeUrl, lastHash, expiresAt });
-    if (!this.ourSwarmNodes[nodeUrl]) {
-      return;
-    }
-    this.ourSwarmNodes[nodeUrl].lastHash = lastHash;
   }
 
   getSwarmNodesForPubKey(pubKey) {
@@ -135,33 +120,6 @@ class LokiSnodeAPI {
         message: 'Could not get conversation',
       });
     }
-  }
-
-  async updateOurSwarmNodes(newNodes) {
-    this.ourSwarmNodes = {};
-    const ps = newNodes.map(async snode => {
-      const lastHash = await window.Signal.Data.getLastHashBySnode(
-        snode.address
-      );
-      this.ourSwarmNodes[snode.address] = {
-        lastHash,
-        port: snode.port,
-        ip: snode.ip,
-      };
-    });
-    await Promise.all(ps);
-  }
-
-  async getOurSwarmNodes() {
-    if (
-      !this.ourSwarmNodes ||
-      Object.keys(this.ourSwarmNodes).length < MINIMUM_SWARM_NODES
-    ) {
-      const ourKey = window.textsecure.storage.user.getNumber();
-      const nodeAddresses = await this.getSwarmNodes(ourKey);
-      await this.updateOurSwarmNodes(nodeAddresses);
-    }
-    return { ...this.ourSwarmNodes };
   }
 
   async refreshSwarmNodesForPubKey(pubKey) {

--- a/preload.js
+++ b/preload.js
@@ -302,9 +302,7 @@ window.lokiSnodeAPI = new LokiSnodeAPI({
 
 window.LokiP2pAPI = require('./js/modules/loki_p2p_api');
 
-const LokiMessageAPI = require('./js/modules/loki_message_api');
-
-window.lokiMessageAPI = new LokiMessageAPI();
+window.LokiMessageAPI = require('./js/modules/loki_message_api');
 
 const LocalLokiServer = require('./libloki/modules/local_loki_server');
 


### PR DESCRIPTION
Now that the successful request tracking is happening in loki_message_api I have tried to clean up snode_api
I have stopped differentiating between our snodes and contact snodes which simplifies things
I moved the instantiation of LokiMessageAPI to background.js so I have access to storage and can grab our key in the constructor
Fixed a big where `lastHash` !== `lashHash`
