### PR TITLE
Remove nodes after 1 failure and only wait for a single successful send

### DIFF
--- a/libloki/api.js
+++ b/libloki/api.js
@@ -14,8 +14,7 @@
     );
     await Promise.all(
       friendKeys.map(async pubKey => {
-        if (pubKey === textsecure.storage.user.getNumber())
-          return
+        if (pubKey === textsecure.storage.user.getNumber()) return;
         try {
           await sendOnlineBroadcastMessage(pubKey);
         } catch (e) {


### PR DESCRIPTION
These will likely be clearnet only changes where we expect requests to ip addresses to be quite consistent
The first true part seems a little back hacky because of the raw promise handling but it's also pretty cool

This PR is to smooth the UX for the clearnet where we can be pretty sure that failures are caused by snodes not being accessible so we shouldn't bother trying for a long time