### PR TITLE
Return profile name for non-private conversations

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -2241,7 +2241,7 @@
       if (this.isPrivate() && !this.get('name')) {
         return this.get('profileName');
       }
-      return null;
+      return this.getTitle();
     },
 
     getDisplayName() {


### PR DESCRIPTION
Noticed that some changes to the name system we made a while ago broke group names
This might not be the best fix (not sure of all consequences) but seems to be working with the public chat