### PR TITLE
Fix disappearing messages and deleting contact

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -714,11 +714,14 @@
           direction: 'incoming',
           status: ['pending', 'expired'],
         });
-        window.libloki.api.sendFriendRequestAccepted(this.id);
+        window.libloki.api.sendBackgroundMessage(this.id);
       }
     },
     // Our outgoing friend request has been accepted
     async onFriendRequestAccepted() {
+      if (this.isFriend()) {
+        return false;
+      }
       if (this.unlockTimer) clearTimeout(this.unlockTimer);
       if (this.hasSentFriendRequest()) {
         this.setFriendRequestStatus(FriendRequestStatusEnum.friends);
@@ -1738,7 +1741,7 @@
       await this.setSessionResetStatus(SessionResetEnum.request_received);
       // send empty message, this will trigger the new session to propagate
       // to the reset initiator.
-      await window.libloki.api.sendEmptyMessage(this.id);
+      await window.libloki.api.sendBackgroundMessage(this.id);
     },
 
     isSessionResetReceived() {
@@ -1774,7 +1777,7 @@
     async onNewSessionAdopted() {
       if (this.get('sessionResetStatus') === SessionResetEnum.initiated) {
         // send empty message to confirm that we have adopted the new session
-        await window.libloki.api.sendEmptyMessage(this.id);
+        await window.libloki.api.sendBackgroundMessage(this.id);
       }
       await this.createAndStoreEndSessionMessage({
         type: 'incoming',

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1986,9 +1986,7 @@
               autoAccept = true;
               message.set({ friendStatus: 'accepted' });
               await conversation.onFriendRequestAccepted();
-              window.libloki.api.sendFriendRequestAccepted(
-                message.get('source')
-              );
+              window.libloki.api.sendBackgroundMessage(message.get('source'));
             } else {
               await conversation.onFriendRequestReceived();
             }

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -101,6 +101,14 @@
       // Inbox
       const inboxCollection = getInboxCollection();
 
+      // ConversationCollection
+      const conversations = getConversations();
+      this.listenTo(conversations, 'remove', conversation => {
+        if (this.conversation_stack) {
+          this.conversation_stack.close(conversation);
+        }
+      });
+
       this.listenTo(inboxCollection, 'messageError', () => {
         if (this.networkStatusView) {
           this.networkStatusView.render();

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -4,8 +4,8 @@
 (function() {
   window.libloki = window.libloki || {};
 
-  async function sendFriendRequestAccepted(pubKey) {
-    return sendEmptyMessage(pubKey, true);
+  async function sendBackgroundMessage(pubKey) {
+    return sendOnlineBroadcastMessage(pubKey);
   }
 
   async function broadcastOnlineStatus() {
@@ -30,9 +30,6 @@
     let type;
 
     if (!window.localLokiServer.isListening()) {
-      // Skip if server is not running AND we're not trying to ping a contact
-      if (!isPing) return;
-
       type = textsecure.protobuf.LokiAddressMessage.Type.HOST_UNREACHABLE;
     } else {
       // clearnet change: getMyLokiAddress -> getMyClearIP
@@ -66,51 +63,8 @@
     await outgoingMessage.sendToNumber(pubKey);
   }
 
-  async function sendEmptyMessage(pubKey, sendContentMessage = false) {
-    const options = {};
-    // send an empty message.
-    if (sendContentMessage) {
-      // The logic downstream will attach the prekeys and our profile.
-      await textsecure.messaging.sendMessageToNumber(
-        pubKey, // number
-        null, // messageText
-        [], // attachments
-        null, // quote
-        [], // preview
-        Date.now(), // timestamp
-        null, // expireTimer
-        null, // profileKey
-        options
-      );
-    } else {
-      // empty content message
-      const content = new textsecure.protobuf.Content();
-
-      // will be called once the transmission succeeded or failed
-      const callback = res => {
-        if (res.errors.length > 0) {
-          res.errors.forEach(error => log.error(error));
-        } else {
-          log.info('empty message sent successfully');
-        }
-      };
-      // send an empty message. The logic in ougoing_message will attach the prekeys.
-      const outgoingMessage = new textsecure.OutgoingMessage(
-        null, // server
-        Date.now(), // timestamp,
-        [pubKey], // numbers
-        content, // message
-        true, // silent
-        callback, // callback
-        options
-      );
-      await outgoingMessage.sendToNumber(pubKey);
-    }
-  }
-
   window.libloki.api = {
-    sendFriendRequestAccepted,
-    sendEmptyMessage,
+    sendBackgroundMessage,
     sendOnlineBroadcastMessage,
     broadcastOnlineStatus,
   };

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -892,11 +892,26 @@ MessageReceiver.prototype.extend({
     }
 
     return promise
-      .then(plaintext => {
+      .then(async plaintext => {
         const { isMe, isBlocked } = plaintext || {};
         if (isMe || isBlocked) {
           this.removeFromCache(envelope);
           return null;
+        }
+        if (
+          envelope.type !== textsecure.protobuf.Envelope.Type.FRIEND_REQUEST
+        ) {
+          // If we got here there is a valid session, which meants friend request
+          // is complete (if it wasn't already)
+          if (conversation) {
+            const isFriendRequestAccept = await conversation.onFriendRequestAccepted();
+            if (isFriendRequestAccept) {
+              await conversation.notifyFriendRequest(
+                envelope.source,
+                'accepted'
+              );
+            }
+          }
         }
 
         this.updateCache(envelope, plaintext).catch(error => {
@@ -1063,21 +1078,6 @@ MessageReceiver.prototype.extend({
             )} ignored; destined for blocked group`
           );
           return this.removeFromCache(envelope);
-        }
-
-        if (!message.body) {
-          // Trigger conversation friend request event for empty message
-          if (conversation && !message.flags) {
-            const isFriendRequestAccept = await conversation.onFriendRequestAccepted();
-            if (isFriendRequestAccept) {
-              await conversation.notifyFriendRequest(
-                envelope.source,
-                'accepted'
-              );
-            }
-          }
-          this.removeFromCache(envelope);
-          return null;
         }
 
         const ev = new Event('message');


### PR DESCRIPTION
Previously we were sending empty messages to trigger things like disappearing messages and friend request accepts. But these were getting filtered out after updating friend request status (so disappearing messages udpates didn't get fully parsed), now we send a broadcast message instead.
Also fix small bug where deleting a contact kept the (now removed) conversation open
Everything seems to be working as expected but could potentially have some unintended consequences?
First thing that comes to mind is we might start triggering ping events more than we need?

Closes #348 