### PR TITLE
Add loki schema versioning and create new public conversation

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -789,7 +789,11 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
     sessionResetStatus: 0,
     swarmNodes: [],
     type: 'private',
-    profileName: 'Loki Public Chat',
+    profile: {
+      displayName: 'Loki Public Chat',
+    },
+    server: 'https://chat.lokinet.org',
+    channelId: '1',
     unlockTimestamp: null,
     unreadCount: 0,
     verified: 0,

--- a/app/sql.js
+++ b/app/sql.js
@@ -869,10 +869,9 @@ async function updateLokiSchema(instance) {
 
 async function getLokiSchemaVersion(instance) {
   const result = await instance.get(
-    `SELECT version FROM loki_schema WHERE version =
-    (SELECT MAX(version) FROM loki_schema);`
+    'SELECT MAX(version) as version FROM loki_schema;'
   );
-  if (!result.version) {
+  if (!result || !result.version) {
     return 0;
   }
   return result.version;

--- a/app/sql.js
+++ b/app/sql.js
@@ -843,7 +843,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
 
 async function updateLokiSchema(instance) {
   const result = await instance.get(
-    "SELECT name FROM sqlite_master WHERE type = 'table' AND name='loki_schema'"
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name='loki_schema';"
   );
   if (!result) {
     await createLokiSchemaTable(instance);
@@ -869,7 +869,8 @@ async function updateLokiSchema(instance) {
 
 async function getLokiSchemaVersion(instance) {
   const result = await instance.get(
-    'SELECT version FROM loki_schema WHERE version = (SELECT MAX(version) FROM loki_schema);'
+    `SELECT version FROM loki_schema WHERE version =
+    (SELECT MAX(version) FROM loki_schema);`
   );
   if (!result.version) {
     return 0;

--- a/app/sql.js
+++ b/app/sql.js
@@ -773,9 +773,7 @@ async function updateSchema(instance) {
   await updateLokiSchema(instance);
 }
 
-const LOKI_SCHEMA_VERSIONS = [
-  updateToLokiSchemaVersion1,
-];
+const LOKI_SCHEMA_VERSIONS = [updateToLokiSchemaVersion1];
 
 async function updateToLokiSchemaVersion1(currentVersion, instance) {
   if (currentVersion >= 1) {
@@ -798,13 +796,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
     version: 2,
   };
 
-  const {
-    id,
-    type,
-    name,
-    friendRequestStatus,
-    profileName,
-  } = publicChatData;
+  const { id, type, name, friendRequestStatus, profileName } = publicChatData;
 
   await instance.run(
     `INSERT INTO conversations (
@@ -850,7 +842,9 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
 }
 
 async function updateLokiSchema(instance) {
-  const result = await instance.get("SELECT name FROM sqlite_master WHERE type = 'table' AND name='loki_schema'");
+  const result = await instance.get(
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name='loki_schema'"
+  );
   if (!result) {
     await createLokiSchemaTable(instance);
   }
@@ -860,7 +854,11 @@ async function updateLokiSchema(instance) {
     `Current loki schema version: ${lokiSchemaVersion};`,
     `Most recent schema version: ${LOKI_SCHEMA_VERSIONS.length};`
   );
-  for (let index = 0, max = LOKI_SCHEMA_VERSIONS.length; index < max; index += 1) {
+  for (
+    let index = 0, max = LOKI_SCHEMA_VERSIONS.length;
+    index < max;
+    index += 1
+  ) {
     const runSchemaUpdate = LOKI_SCHEMA_VERSIONS[index];
 
     // Yes, we really want to do this asynchronously, in order
@@ -870,7 +868,9 @@ async function updateLokiSchema(instance) {
 }
 
 async function getLokiSchemaVersion(instance) {
-  const result = await instance.get('SELECT version FROM loki_schema WHERE version = (SELECT MAX(version) FROM loki_schema);');
+  const result = await instance.get(
+    'SELECT version FROM loki_schema WHERE version = (SELECT MAX(version) FROM loki_schema);'
+  );
   if (!result.version) {
     return 0;
   }

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -167,7 +167,7 @@
 
       if (this.id === this.ourNumber) {
         this.set({ friendRequestStatus: FriendRequestStatusEnum.friends });
-      } else if (lokiP2pAPI) {
+      } else if (typeof lokiP2pAPI !== 'undefined') {
         // Online status handling, only for contacts that aren't us
         this.set({ isOnline: lokiP2pAPI.isOnline(this.id) });
       } else {


### PR DESCRIPTION
It would break all the databases of the current testnet messengers but we might want to look into moving all the other loki related database stuff (which was put into some of the old schema versions early on when we had a worse idea of how everything worked...) into this versioning model