### PR TITLE
Get public chats and retrieve messages

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -97,6 +97,7 @@ module.exports = {
   updateConversation,
   removeConversation,
   getAllConversations,
+  getAllPublicConversations,
   getPubKeysWithFriendStatus,
   getAllConversationIds,
   getAllPrivateConversations,
@@ -1598,6 +1599,17 @@ async function getAllPrivateConversations() {
   const rows = await db.all(
     `SELECT json FROM conversations WHERE
       type = 'private'
+     ORDER BY id ASC;`
+  );
+
+  return map(rows, row => jsonToObject(row.json));
+}
+
+async function getAllPublicConversations() {
+  const rows = await db.all(
+    `SELECT json FROM conversations WHERE
+      type = 'private' AND
+      id LIKE '06%'
      ORDER BY id ASC;`
   );
 

--- a/js/background.js
+++ b/js/background.js
@@ -207,13 +207,19 @@
     const ourKey = textsecure.storage.user.getNumber();
     window.lokiMessageAPI = new window.LokiMessageAPI(ourKey);
     window.lokiPublicChatAPI = new window.LokiPublicChatAPI(ourKey);
-    const publicConversations = await window.Signal.Data.getAllPublicConversations({
-      ConversationCollection: Whisper.ConversationCollection,
-    });
+    const publicConversations = await window.Signal.Data.getAllPublicConversations(
+      {
+        ConversationCollection: Whisper.ConversationCollection,
+      }
+    );
     publicConversations.forEach(conversation => {
       const endpoint = conversation.getEndpoint();
       const groupName = conversation.getProfileName();
-      window.lokiPublicChatAPI.pollForMessages(conversation.id, groupName, endpoint);
+      window.lokiPublicChatAPI.pollForMessages(
+        conversation.id,
+        groupName,
+        endpoint
+      );
     });
     window.lokiP2pAPI = new window.LokiP2pAPI(ourKey);
     window.lokiP2pAPI.on('pingContact', pubKey => {

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -2004,6 +2004,15 @@
     getNickname() {
       return this.get('nickname');
     },
+    getEndpoint() {
+      if (!this.id.match(/^06/)) {
+        return null;
+      }
+      const server = this.get('server');
+      const channelId = this.get('channelId');
+      const endpoint = `${server}/channels/${channelId}/messages`;
+      return endpoint;
+    },
 
     // SIGNAL PROFILES
 

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -118,6 +118,7 @@ module.exports = {
   getPubKeysWithFriendStatus,
   getAllConversationIds,
   getAllPrivateConversations,
+  getAllPublicConversations,
   getAllGroupsInvolvingId,
 
   searchConversations,
@@ -737,6 +738,14 @@ async function getAllConversations({ ConversationCollection }) {
 async function getAllConversationIds() {
   const ids = await channels.getAllConversationIds();
   return ids;
+}
+
+async function getAllPublicConversations({ ConversationCollection }) {
+  const conversations = await channels.getAllPublicConversations();
+
+  const collection = new ConversationCollection();
+  collection.add(conversations);
+  return collection;
 }
 
 async function getAllPrivateConversations({ ConversationCollection }) {

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -1,0 +1,70 @@
+
+const EventEmitter = require('events');
+const nodeFetch = require('node-fetch');
+const { URL, URLSearchParams } = require('url');
+
+
+const GROUPCHAT_POLL_EVERY = 5 * 1000;
+
+class LokiPublicChatAPI extends EventEmitter {
+  constructor(ourKey) {
+    super();
+    this.ourKey = ourKey;
+    this.lastGot = {};
+  }
+
+  async pollForMessages(source, groupName, endpoint) {
+    const url = new URL(endpoint);
+    const params = {
+      include_annotations: 1,
+      count: -20,
+    }
+    if (this.lastGot[endpoint]) {
+      params.since_id = this.lastGot[endpoint];
+    }
+    url.search = new URLSearchParams(params)
+
+    let res;
+    let success = true;
+    try {
+      res = await nodeFetch(url);
+    } catch (e) {
+      success = false;
+    }
+
+    const response = await res.json();
+    if (response.meta.code !== 200) {
+      success = false;
+    }
+
+    if (success) {
+      const revChono = response.data.reverse();
+      revChono.forEach(post => {
+        let from = post.user.username;
+        const createdAtTimestamp = new Date(post.created_at).getTime();
+        let timestamp = createdAtTimestamp;
+        if (post.annotations.length) {
+          const noteValue = post.annotations[0].value;
+          ({ from, timestamp } = noteValue);
+        }
+
+        this.emit('publicMessage', {
+          message: {
+            created_at: createdAtTimestamp,
+            body: `${post.created_at} ${post.user.username}: ${post.text}`,
+            from,
+            source,
+            timestamp,
+          },
+        });
+        this.lastGot[endpoint] = !this.lastGot[endpoint] ? post.id : Math.max(this.lastGot[endpoint], post.id);
+      });
+    }
+
+    setTimeout(() => {
+      this.pollForMessages(source, groupName, endpoint);
+    }, GROUPCHAT_POLL_EVERY);
+  }
+}
+
+module.exports = LokiPublicChatAPI;

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -1,8 +1,6 @@
-
 const EventEmitter = require('events');
 const nodeFetch = require('node-fetch');
 const { URL, URLSearchParams } = require('url');
-
 
 const GROUPCHAT_POLL_EVERY = 5 * 1000;
 
@@ -18,11 +16,11 @@ class LokiPublicChatAPI extends EventEmitter {
     const params = {
       include_annotations: 1,
       count: -20,
-    }
+    };
     if (this.lastGot[endpoint]) {
       params.since_id = this.lastGot[endpoint];
     }
-    url.search = new URLSearchParams(params)
+    url.search = new URLSearchParams(params);
 
     let res;
     let success = true;
@@ -57,7 +55,9 @@ class LokiPublicChatAPI extends EventEmitter {
             timestamp,
           },
         });
-        this.lastGot[endpoint] = !this.lastGot[endpoint] ? post.id : Math.max(this.lastGot[endpoint], post.id);
+        this.lastGot[endpoint] = !this.lastGot[endpoint]
+          ? post.id
+          : Math.max(this.lastGot[endpoint], post.id);
       });
     }
 

--- a/libtextsecure/errors.js
+++ b/libtextsecure/errors.js
@@ -263,6 +263,18 @@
     }
   }
 
+  function PublicChatError(message) {
+    this.name = 'PublicChatError';
+    this.message = message;
+    Error.call(this, message);
+
+    // Maintains proper stack trace, where our error was thrown (only available on V8)
+    //   via https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this);
+    }
+  }
+
   window.textsecure.UnregisteredUserError = UnregisteredUserError;
   window.textsecure.SendMessageNetworkError = SendMessageNetworkError;
   window.textsecure.IncomingIdentityKeyError = IncomingIdentityKeyError;
@@ -281,4 +293,5 @@
   window.textsecure.NotFoundError = NotFoundError;
   window.textsecure.WrongSwarmError = WrongSwarmError;
   window.textsecure.WrongDifficultyError = WrongDifficultyError;
+  window.textsecure.PublicChatError = PublicChatError;
 })();

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -156,14 +156,13 @@ MessageReceiver.prototype.extend({
   handlePublicMessage({ message }) {
     const ev = new Event('message');
     ev.confirm = function confirmTerm() {};
-    const ts = Date.now();
     ev.data = {
       friendRequest: false,
       source: message.source,
       sourceDevice: 1,
       timestamp: message.timestamp,
-      serverTimestamp: message.created_at,
-      receivedAt: ts,
+      serverTimestamp: message.serverTimestamp,
+      receivedAt: message.receivedAt,
       isP2p: true, // masquerade as a p2p
       message: {
         body: message.body,
@@ -173,7 +172,7 @@ MessageReceiver.prototype.extend({
         expireTimer: 0,
         profileKey: null,
         timestamp: message.timestamp,
-        received_at: ts,
+        received_at: message.receivedAt,
         // this is used for idForLogging and keying
         sent_at: message.timestamp,
         quote: null,

--- a/preload.js
+++ b/preload.js
@@ -317,6 +317,8 @@ window.LokiP2pAPI = require('./js/modules/loki_p2p_api');
 
 window.LokiMessageAPI = require('./js/modules/loki_message_api');
 
+window.LokiPublicChatAPI = require('./js/modules/loki_public_chat_api');
+
 window.LocalLokiServer = require('./libloki/modules/local_loki_server');
 
 window.localServerPort = config.localServerPort;


### PR DESCRIPTION
Added ability to retrieve all public conversations
Added loki_public_chat_api which conversations can use to register their endpoints for polling
Initiate public conversation polling on app launch
TODO: Since the messages that currently exist on the server do not provide a source I have passed it in to the startPollingForMessages function from the conversation. When the send message logic is reintroduced we should be attaching the public conversation id as the source to messages and use that