### PR TITLE
WIP: PR353 Use group chat advancement

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -97,6 +97,7 @@ module.exports = {
   updateConversation,
   removeConversation,
   getAllConversations,
+  getAllPublicConversations,
   getPubKeysWithFriendStatus,
   getAllConversationIds,
   getAllPrivateConversations,
@@ -1598,6 +1599,17 @@ async function getAllPrivateConversations() {
   const rows = await db.all(
     `SELECT json FROM conversations WHERE
       type = 'private'
+     ORDER BY id ASC;`
+  );
+
+  return map(rows, row => jsonToObject(row.json));
+}
+
+async function getAllPublicConversations() {
+  const rows = await db.all(
+    `SELECT json FROM conversations WHERE
+      type = 'private' AND
+      id LIKE '06%'
      ORDER BY id ASC;`
   );
 

--- a/app/sql.js
+++ b/app/sql.js
@@ -789,7 +789,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
     sealedSender: 0,
     sessionResetStatus: 0,
     swarmNodes: [],
-    type: 'private',
+    type: 'group',
     profile: {
       displayName: 'Loki Public Chat',
     },
@@ -1608,7 +1608,7 @@ async function getAllPrivateConversations() {
 async function getAllPublicConversations() {
   const rows = await db.all(
     `SELECT json FROM conversations WHERE
-      type = 'private' AND
+      type = 'group' AND
       id LIKE '06%'
      ORDER BY id ASC;`
   );

--- a/js/background.js
+++ b/js/background.js
@@ -1254,6 +1254,11 @@
         return handleProfileUpdate({ data, confirm, messageDescriptor });
       }
 
+      const ourNumber = textsecure.storage.user.getNumber();
+      if (messageDescriptor.type === 'group' && messageDescriptor.id.match(/^06/) && data.source === ourNumber) {
+        // Remove public chat messages to ourselves
+        return event.confirm();
+      }
       const message = await createMessage(data);
       const isDuplicate = await isMessageDuplicate(message);
       if (isDuplicate) {

--- a/js/background.js
+++ b/js/background.js
@@ -207,13 +207,19 @@
     const ourKey = textsecure.storage.user.getNumber();
     window.lokiMessageAPI = new window.LokiMessageAPI(ourKey);
     window.lokiPublicChatAPI = new window.LokiPublicChatAPI(ourKey);
-    const publicConversations = await window.Signal.Data.getAllPublicConversations({
-      ConversationCollection: Whisper.ConversationCollection,
-    });
+    const publicConversations = await window.Signal.Data.getAllPublicConversations(
+      {
+        ConversationCollection: Whisper.ConversationCollection,
+      }
+    );
     publicConversations.forEach(conversation => {
       const endpoint = conversation.getEndpoint();
       const groupName = conversation.getProfileName();
-      window.lokiPublicChatAPI.pollForMessages(conversation.id, groupName, endpoint);
+      window.lokiPublicChatAPI.pollForMessages(
+        conversation.id,
+        groupName,
+        endpoint
+      );
     });
     window.lokiP2pAPI = new window.LokiP2pAPI(ourKey);
     window.lokiP2pAPI.on('pingContact', pubKey => {

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -2004,6 +2004,15 @@
     getNickname() {
       return this.get('nickname');
     },
+    getEndpoint() {
+      if (!this.id.match(/^06/)) {
+        return null;
+      }
+      const server = this.get('server');
+      const channelId = this.get('channelId');
+      const endpoint = `${server}/channels/${channelId}/messages`;
+      return endpoint;
+    },
 
     // SIGNAL PROFILES
 

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -367,6 +367,11 @@
       await Promise.all(messages.map(m => m.setIsP2p(true)));
     },
 
+    async onPublicMessageSent(pubKey, timestamp) {
+      const messages = this._getMessagesWithTimestamp(pubKey, timestamp);
+      await Promise.all(messages.map(m => m.setIsPublic(true)));
+    },
+
     async onNewMessage(message) {
       await this.updateLastMessage();
 
@@ -2010,6 +2015,17 @@
     getNickname() {
       return this.get('nickname');
     },
+    // maybe "Backend" instead of "Source"?
+    getPublicSource() {
+      if (!this.isPublic()) {
+        return null;
+      }
+      return {
+        server: this.get('server'),
+        channel_id: this.get('channelId'),
+      };
+    },
+    // FIXME: remove or add public and/or "sending" hint to name...
     getEndpoint() {
       if (!this.isPublic()) {
         return null;

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -193,6 +193,9 @@
     isMe() {
       return this.id === this.ourNumber;
     },
+    isPublic() {
+      return this.id.match(/^06/);
+    },
     isBlocked() {
       return BlockedNumberController.isBlocked(this.id);
     },
@@ -1342,6 +1345,9 @@
 
         const options = this.getSendOptions();
         options.messageType = message.get('type');
+        if (this.isPublic()) {
+          options.publicEndpoint = this.getEndpoint();
+        }
 
         const groupNumbers = this.getRecipients();
 
@@ -2005,7 +2011,7 @@
       return this.get('nickname');
     },
     getEndpoint() {
-      if (!this.id.match(/^06/)) {
+      if (!this.isPublic()) {
         return null;
       }
       const server = this.get('server');

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -670,6 +670,7 @@
         expirationLength,
         expirationTimestamp,
         isP2p: !!this.get('isP2p'),
+        isPublic: !!this.get('isPublic'),
 
         onCopyText: () => this.copyText(),
         onReply: () => this.trigger('reply', this),
@@ -1232,6 +1233,17 @@
 
       this.set({
         isP2p: !!isP2p,
+      });
+
+      await window.Signal.Data.saveMessage(this.attributes, {
+        Message: Whisper.Message,
+      });
+    },
+    async setIsPublic(isPublic) {
+      if (_.isEqual(this.get('isPublic'), isPublic)) return;
+
+      this.set({
+        isPublic: !!isPublic,
       });
 
       await window.Signal.Data.saveMessage(this.attributes, {

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -118,6 +118,7 @@ module.exports = {
   getPubKeysWithFriendStatus,
   getAllConversationIds,
   getAllPrivateConversations,
+  getAllPublicConversations,
   getAllGroupsInvolvingId,
 
   searchConversations,
@@ -737,6 +738,14 @@ async function getAllConversations({ ConversationCollection }) {
 async function getAllConversationIds() {
   const ids = await channels.getAllConversationIds();
   return ids;
+}
+
+async function getAllPublicConversations({ ConversationCollection }) {
+  const conversations = await channels.getAllPublicConversations();
+
+  const collection = new ConversationCollection();
+  collection.add(conversations);
+  return collection;
 }
 
 async function getAllPrivateConversations({ ConversationCollection }) {

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -82,10 +82,11 @@ class LokiMessageAPI {
       pubKey,
       timestamp: messageTimeStamp,
     };
+    const data64 = dcodeIO.ByteBuffer.wrap(data).toString('base64');
 
-    if (options.isPublic) {
+    if (options.endpoint) {
       const payload = {
-        text: data.message.dataMessage.body,
+        text: data64,
         annotations: [
           {
             type: 'network.loki.messenger.publicChat',
@@ -113,7 +114,6 @@ class LokiMessageAPI {
       }
     }
 
-    const data64 = dcodeIO.ByteBuffer.wrap(data).toString('base64');
     const p2pSuccess = await trySendP2p(
       pubKey,
       data64,

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-loop-func */
-/* global log, dcodeIO, window, callWorker, lokiP2pAPI, lokiSnodeAPI, textsecure */
+/* global dcodeIO, log, window, callWorker, lokiP2pAPI, lokiSnodeAPI, textsecure */
 
 const _ = require('lodash');
 const { rpc } = require('./loki_rpc');
@@ -84,15 +84,19 @@ class LokiMessageAPI {
     };
     const data64 = dcodeIO.ByteBuffer.wrap(data).toString('base64');
 
+    // FIXME: should have public/sending(ish hint) in the option to make
+    // this more obvious...
     if (options.endpoint) {
+      // could we emit back to LokiPublicChannelAPI somehow?
       const payload = {
-        text: data64,
+        text: options.messageText,
         annotations: [
           {
             type: 'network.loki.messenger.publicChat',
             value: {
               timestamp: messageTimeStamp,
-              from: data.ourKey,
+              from: options.ourKey,
+              // what other envelope data do we need to recreate the envelope?
             },
           },
         ],
@@ -106,6 +110,7 @@ class LokiMessageAPI {
           },
           body: JSON.stringify(payload),
         });
+        window.Whisper.events.trigger('publicMessageSent', messageEventData);
         return;
       } catch (e) {
         throw new window.textsecure.PublicChatError(

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -1,0 +1,70 @@
+
+const EventEmitter = require('events');
+const nodeFetch = require('node-fetch');
+const { URL, URLSearchParams } = require('url');
+
+
+const GROUPCHAT_POLL_EVERY = 5 * 1000;
+
+class LokiPublicChatAPI extends EventEmitter {
+  constructor(ourKey) {
+    super();
+    this.ourKey = ourKey;
+    this.lastGot = {};
+  }
+
+  async pollForMessages(source, groupName, endpoint) {
+    const url = new URL(endpoint);
+    const params = {
+      include_annotations: 1,
+      count: -20,
+    }
+    if (this.lastGot[endpoint]) {
+      params.since_id = this.lastGot[endpoint];
+    }
+    url.search = new URLSearchParams(params)
+
+    let res;
+    let success = true;
+    try {
+      res = await nodeFetch(url);
+    } catch (e) {
+      success = false;
+    }
+
+    const response = await res.json();
+    if (response.meta.code !== 200) {
+      success = false;
+    }
+
+    if (success) {
+      const revChono = response.data.reverse();
+      revChono.forEach(post => {
+        let from = post.user.username;
+        const createdAtTimestamp = new Date(post.created_at).getTime();
+        let timestamp = createdAtTimestamp;
+        if (post.annotations.length) {
+          const noteValue = post.annotations[0].value;
+          ({ from, timestamp } = noteValue);
+        }
+
+        this.emit('publicMessage', {
+          message: {
+            created_at: createdAtTimestamp,
+            body: `${post.created_at} ${post.user.username}: ${post.text}`,
+            from,
+            source,
+            timestamp,
+          },
+        });
+        this.lastGot[endpoint] = !this.lastGot[endpoint] ? post.id : Math.max(this.lastGot[endpoint], post.id);
+      });
+    }
+
+    setTimeout(() => {
+      this.pollForMessages(source, groupName, endpoint);
+    }, GROUPCHAT_POLL_EVERY);
+  }
+}
+
+module.exports = LokiPublicChatAPI;

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -1,24 +1,297 @@
+/* global log, textsecure, dcodeIO, libsignal */
 const EventEmitter = require('events');
 const nodeFetch = require('node-fetch');
 const { URL, URLSearchParams } = require('url');
 
 const GROUPCHAT_POLL_EVERY = 1000; // 1 second
 
+// start sendmessage.js lift
+function stringToArrayBuffer(str) {
+  if (typeof str !== 'string') {
+    throw new Error('Passed non-string to stringToArrayBuffer');
+  }
+  const res = new ArrayBuffer(str.length);
+  const uint = new Uint8Array(res);
+  for (let i = 0; i < str.length; i += 1) {
+    uint[i] = str.charCodeAt(i);
+  }
+  return res;
+}
+
+function Message(options) {
+  this.body = options.body;
+  this.attachments = options.attachments || [];
+  this.quote = options.quote;
+  this.preview = options.preview;
+  this.group = options.group;
+  this.flags = options.flags;
+  this.recipients = options.recipients;
+  this.timestamp = options.timestamp;
+  this.needsSync = options.needsSync;
+  this.expireTimer = options.expireTimer;
+  this.profileKey = options.profileKey;
+  this.profile = options.profile;
+
+  if (!(this.recipients instanceof Array)) {
+    throw new Error('Invalid recipient list');
+  }
+
+  if (!this.group && this.recipients.length !== 1) {
+    throw new Error('Invalid recipient list for non-group');
+  }
+
+  if (typeof this.timestamp !== 'number') {
+    throw new Error('Invalid timestamp');
+  }
+
+  if (this.expireTimer !== undefined && this.expireTimer !== null) {
+    if (typeof this.expireTimer !== 'number' || !(this.expireTimer >= 0)) {
+      throw new Error('Invalid expireTimer');
+    }
+  }
+
+  if (this.attachments) {
+    if (!(this.attachments instanceof Array)) {
+      throw new Error('Invalid message attachments');
+    }
+  }
+  if (this.flags !== undefined) {
+    if (typeof this.flags !== 'number') {
+      throw new Error('Invalid message flags');
+    }
+  }
+  if (this.isEndSession()) {
+    if (
+      this.body !== null ||
+      this.group !== null ||
+      this.attachments.length !== 0
+    ) {
+      throw new Error('Invalid end session message');
+    }
+  } else {
+    if (
+      typeof this.timestamp !== 'number' ||
+      (this.body && typeof this.body !== 'string')
+    ) {
+      throw new Error('Invalid message body');
+    }
+    if (this.group) {
+      if (
+        typeof this.group.id !== 'string' ||
+        typeof this.group.type !== 'number'
+      ) {
+        throw new Error('Invalid group context');
+      }
+    }
+  }
+}
+
+Message.prototype = {
+  constructor: Message,
+  isEndSession() {
+    /* eslint-disable more/no-then, no-bitwise */
+    return this.flags & textsecure.protobuf.DataMessage.Flags.END_SESSION;
+  },
+  toProto() {
+    if (this.dataMessage instanceof textsecure.protobuf.DataMessage) {
+      return this.dataMessage;
+    }
+    const proto = new textsecure.protobuf.DataMessage();
+    if (this.body) {
+      proto.body = this.body;
+    }
+    proto.attachments = this.attachmentPointers;
+    if (this.flags) {
+      proto.flags = this.flags;
+    }
+    if (this.group) {
+      proto.group = new textsecure.protobuf.GroupContext();
+      proto.group.id = stringToArrayBuffer(this.group.id);
+      proto.group.type = this.group.type;
+    }
+    if (Array.isArray(this.preview)) {
+      proto.preview = this.preview.map(preview => {
+        const item = new textsecure.protobuf.DataMessage.Preview();
+        item.title = preview.title;
+        item.url = preview.url;
+        item.image = preview.image || null;
+        return item;
+      });
+    }
+    if (this.quote) {
+      const { QuotedAttachment } = textsecure.protobuf.DataMessage.Quote;
+      const { Quote } = textsecure.protobuf.DataMessage;
+
+      proto.quote = new Quote();
+      const { quote } = proto;
+
+      quote.id = this.quote.id;
+      quote.author = this.quote.author;
+      quote.text = this.quote.text;
+      quote.attachments = (this.quote.attachments || []).map(attachment => {
+        const quotedAttachment = new QuotedAttachment();
+
+        quotedAttachment.contentType = attachment.contentType;
+        quotedAttachment.fileName = attachment.fileName;
+        if (attachment.attachmentPointer) {
+          quotedAttachment.thumbnail = attachment.attachmentPointer;
+        }
+
+        return quotedAttachment;
+      });
+    }
+    if (this.expireTimer) {
+      proto.expireTimer = this.expireTimer;
+    }
+
+    if (this.profileKey) {
+      proto.profileKey = this.profileKey;
+    }
+
+    // Only send the display name for now.
+    // In the future we might want to extend this to send other things.
+    if (this.profile && this.profile.displayName) {
+      const profile = new textsecure.protobuf.DataMessage.LokiProfile();
+      profile.displayName = this.profile.displayName;
+      proto.profile = profile;
+    }
+
+    this.dataMessage = proto;
+    return proto;
+  },
+  toArrayBuffer() {
+    return this.toProto().toArrayBuffer();
+  },
+};
+// end sendmessage.js lift
+
+// singleton to relay events to libtextsecure/message_receiver
 class LokiPublicChatAPI extends EventEmitter {
   constructor(ourKey) {
     super();
     this.ourKey = ourKey;
     this.lastGot = {};
+    this.servers = [];
+  }
+  findOrCreateServer(hostport) {
+    let thisServer = null;
+    log.info(`LokiPublicChatAPI looking for ${hostport}`);
+    this.servers.forEach(server => {
+      // if we already have this hostport registered
+      if (server.server === hostport) {
+        thisServer = server;
+        // FIXME: how do you break out of this loop?
+      }
+    });
+    if (thisServer === null) {
+      thisServer = new LokiPublicServerAPI(this, hostport);
+      this.servers.push(thisServer);
+    }
+    return thisServer;
+  }
+}
+
+class LokiPublicServerAPI {
+  constructor(chatAPI, hostport) {
+    this.chatAPI = chatAPI;
+    this.server = hostport;
+    this.channels = [];
+  }
+  findOrCreateChannel(channelId, conversationId) {
+    let thisChannel = null;
+    this.channels.forEach(channel => {
+      if (
+        channel.channelId === channelId &&
+        channel.conversationId === conversationId
+      ) {
+        thisChannel = channel;
+      }
+    });
+    if (thisChannel === null) {
+      thisChannel = new LokiPublicChannelAPI(this, channelId, conversationId);
+      this.channels.push(thisChannel);
+    }
+    return thisChannel;
+  }
+  unregisterChannel(channelId) {
+    // find it, remove it
+    // if no channels left, request we deregister server
+    return channelId || this; // this is just to make eslint happy
+  }
+}
+
+class LokiPublicChannelAPI {
+  constructor(serverAPI, channelId, conversationId) {
+    this.serverAPI = serverAPI;
+    this.channelId = channelId;
+    this.baseChannelUrl = `${serverAPI.server}/channels/${this.channelId}`;
+    this.groupName = 'unknown';
+    this.conversationId = conversationId;
+    this.group_id = '06lokiPublicChat';
+    this.lastGot = 0;
+    log.info(`registered LokiPublicChannel ${channelId}`);
+    // start polling
+    this.pollForMessages();
   }
 
-  async pollForMessages(source, groupName, endpoint) {
-    const url = new URL(endpoint);
+  async pollForChannel(source, endpoint) {
+    // groupName will be loaded from server
+    const url = new URL(this.baseChannelUrl);
+    /*
+    const params = {
+      include_annotations: 1,
+    };
+    */
+    let res;
+    let success = true;
+    try {
+      res = await nodeFetch(url);
+    } catch (e) {
+      success = false;
+    }
+
+    const response = await res.json();
+    if (response.meta.code !== 200) {
+      success = false;
+    }
+    // update this.group_id
+    return endpoint || success;
+  }
+
+  async pollForDeletions() {
+    // let id = 0;
+    // read all messages from 0 to current
+    // delete local copies if server state has changed to delete
+    // run every minute
+    const url = new URL(this.baseChannelUrl);
+    /*
+    const params = {
+      include_annotations: 1,
+    };
+    */
+    let res;
+    let success = true;
+    try {
+      res = await nodeFetch(url);
+    } catch (e) {
+      success = false;
+    }
+
+    const response = await res.json();
+    if (response.meta.code !== 200) {
+      success = false;
+    }
+    return success;
+  }
+
+  async pollForMessages() {
+    const url = new URL(`${this.baseChannelUrl}/messages`);
     const params = {
       include_annotations: 1,
       count: -20,
     };
-    if (this.lastGot[endpoint]) {
-      params.since_id = this.lastGot[endpoint];
+    if (this.lastGot) {
+      params.since_id = this.lastGot;
     }
     url.search = new URLSearchParams(params);
 
@@ -36,18 +309,167 @@ class LokiPublicChatAPI extends EventEmitter {
     }
 
     if (success) {
-      response.data.forEach(post => {
-        this.emit('publicMessage', {
-          message: post.text,
+      response.data.forEach(adnMessage => {
+        // FIXME: create proper message for this message.DataMessage.body
+        let timestamp = new Date(adnMessage.created_at).getTime();
+        let from = adnMessage.user.username;
+        if (adnMessage.annotations.length) {
+          const noteValue = adnMessage.annotations[0].value;
+          ({ from, timestamp } = noteValue);
+        }
+
+        // FIXME: could be much neater if we can get access to something
+        // like outgoing_message create new message object
+
+        // getPlaintext is just a cacheOnce wrapper around
+        // convertMessageToText
+
+        const attrs = {
+          recipients: [this.group_id],
+          body: adnMessage.text,
+          timestamp,
+          attachments: [],
+          quote: null,
+          preview: [],
+          // needsSync: true,
+          expireTimer: 0,
+          profileKey: null,
+          group: {
+            id: this.group_id,
+            type: textsecure.protobuf.GroupContext.Type.DELIVER,
+          },
+        };
+        log.info('LokiPublicChannel attrs', JSON.stringify(attrs));
+
+        const textMessage = new textsecure.protobuf.DataMessage();
+        textMessage.body = adnMessage.text;
+        const serverMessage = {
+          type: 4, // unencrypted
+          source: from,
+          timestamp,
+          message: textMessage.encode(),
+        };
+        log.info(
+          'LokiPublicChannel serverMessage',
+          JSON.stringify(serverMessage)
+        );
+
+        /*
+        const attrs2 = {
+          type: textsecure.protobuf.Envelope.Type.CIPHERTEXT,
+          source: from,
+          sourceDevice: 1,
+          timestamp,
+        };
+        const signal = new textsecure.protobuf.Envelope(attrs2).toArrayBuffer();
+        const websocketmessage = new textsecure.protobuf.WebSocketMessage({
+          type: textsecure.protobuf.WebSocketMessage.Type.REQUEST,
+          request: { verb: 'PUT', path: '/messages' },
         });
-        this.lastGot[endpoint] = !this.lastGot[endpoint]
-          ? post.id
-          : Math.max(this.lastGot[endpoint], post.id);
+        log.info(`LokiPublicChannel websocketmessage`, JSON.stringify(websocketmessage));
+        log.info(`LokiPublicChannel signal`, JSON.stringify(signal));
+        */
+
+        // const dataMessage = new Message(attrs);
+        // didn't try this
+        /*
+        const dataMessage = new textsecure.protobuf.DataMessage();
+        dataMessage.group = new textsecure.protobuf.GroupContext();
+        dataMessage.group.id = stringToArrayBuffer(this.group_id);
+        dataMessage.group.type = textsecure.protobuf.GroupContext.Type.DELIVER;
+        dataMessage.group.name = "Some Group";
+        */
+
+        /*
+        const protoBufContent = new textsecure.protobuf.Content();
+        protoBufContent.dataMessage = dataMessage;
+        const message = protoBufContent;
+        */
+
+        const message = textMessage;
+        log.info('LokiPublicChannel message', JSON.stringify(message));
+
+        // start convertMessageToText
+        const messageBuffer = message.toArrayBuffer();
+        log.info(
+          'LokiPublicChannel messageBuffer',
+          JSON.stringify(messageBuffer)
+        );
+
+        // start getPaddedMessageLength
+        const messageLengthWithTerminator = messageBuffer.byteLength + 1 + 1;
+        let messagePartCount = Math.floor(messageLengthWithTerminator / 160);
+
+        if (messageLengthWithTerminator % 160 !== 0) {
+          messagePartCount += 1;
+        }
+        // end getPaddedMessageLength
+
+        const plaintext = new Uint8Array(messagePartCount * 160 - 1);
+        plaintext.set(new Uint8Array(messageBuffer));
+        plaintext[messageBuffer.byteLength] = 0x80;
+        // end convertMessageToText
+        log.info('LokiPublicChannel going to wrap', JSON.stringify(plaintext));
+
+        const content = new Uint8Array(
+          dcodeIO.ByteBuffer.wrap(plaintext, 'binary').toArrayBuffer()
+        );
+        log.info('LokiPublicChannel content', content);
+        // start wrapInWebsocketMessage
+        // outgoingObject
+        const messageEnvelope = new textsecure.protobuf.Envelope({
+          type: textsecure.protobuf.Envelope.Type.PUBLIC_CHAT_MSG,
+          source: from,
+          sourceDevice: 1,
+          relay: null,
+          timestamp,
+          legacyMessage: null,
+          content,
+          serverGuid: adnMessage.id, // FIXME: include server/channelId
+          serverTimestamp: timestamp,
+          // not in the SignalService.proto
+          // ourKey: from,
+          // friendRequest: false,
+          // destinationRegistrationId: 1,
+          // isP2p: false,
+          // isPublic: true,
+        });
+        log.info(
+          'LokiPublicChannel messageEnvelope',
+          JSON.stringify(messageEnvelope)
+        );
+        const requestMessage = new textsecure.protobuf.WebSocketRequestMessage({
+          id: new Uint8Array(libsignal.crypto.getRandomBytes(1))[0], // random ID for now
+          verb: 'PUT',
+          path: '/api/v1/message',
+          body: messageEnvelope.encode().toArrayBuffer(),
+        });
+        const websocketMessage = new textsecure.protobuf.WebSocketMessage({
+          type: textsecure.protobuf.WebSocketMessage.Type.REQUEST,
+          request: requestMessage,
+        });
+        const socketMessage = new Uint8Array(
+          websocketMessage.encode().toArrayBuffer()
+        );
+        // end wrapInWebsocketMessage
+
+        // const socketMessage = new Uint8Array(websocketMessage.encode()
+        // .toArrayBuffer());
+
+        // log.info(`socketMessage LokiPublicChannel`, JSON.stringify(socketMessage));
+        this.serverAPI.chatAPI.emit('publicMessage', {
+          // message: post.text,
+          message: socketMessage, // break it somewhere else...
+          isPublic: true,
+        });
+        this.lastGot = !this.lastGot
+          ? adnMessage.id
+          : Math.max(this.lastGot, adnMessage.id);
       });
     }
 
     setTimeout(() => {
-      this.pollForMessages(source, groupName, endpoint);
+      this.pollForMessages();
     }, GROUPCHAT_POLL_EVERY);
   }
 }

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -36,26 +36,9 @@ class LokiPublicChatAPI extends EventEmitter {
     }
 
     if (success) {
-      let receivedAt = new Date().getTime();
       response.data.forEach(post => {
-        let from = post.user.username;
-        const serverTimestamp = new Date(post.created_at).getTime();
-        let timestamp = serverTimestamp;
-        if (post.annotations.length) {
-          const noteValue = post.annotations[0].value;
-          ({ from, timestamp } = noteValue);
-        }
-        receivedAt += 1; // Add 1ms to prevent duplicate timestamps
-
         this.emit('publicMessage', {
-          message: {
-            body: `${post.created_at} ${post.user.username}: ${post.text}`,
-            from,
-            source,
-            timestamp,
-            serverTimestamp,
-            receivedAt,
-          },
+          message: post.text,
         });
         this.lastGot[endpoint] = !this.lastGot[endpoint]
           ? post.id

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -1,8 +1,6 @@
-
 const EventEmitter = require('events');
 const nodeFetch = require('node-fetch');
 const { URL, URLSearchParams } = require('url');
-
 
 const GROUPCHAT_POLL_EVERY = 5 * 1000;
 
@@ -18,11 +16,11 @@ class LokiPublicChatAPI extends EventEmitter {
     const params = {
       include_annotations: 1,
       count: -20,
-    }
+    };
     if (this.lastGot[endpoint]) {
       params.since_id = this.lastGot[endpoint];
     }
-    url.search = new URLSearchParams(params)
+    url.search = new URLSearchParams(params);
 
     let res;
     let success = true;
@@ -57,7 +55,9 @@ class LokiPublicChatAPI extends EventEmitter {
             timestamp,
           },
         });
-        this.lastGot[endpoint] = !this.lastGot[endpoint] ? post.id : Math.max(this.lastGot[endpoint], post.id);
+        this.lastGot[endpoint] = !this.lastGot[endpoint]
+          ? post.id
+          : Math.max(this.lastGot[endpoint], post.id);
       });
     }
 

--- a/libtextsecure/errors.js
+++ b/libtextsecure/errors.js
@@ -263,6 +263,18 @@
     }
   }
 
+  function PublicChatError(message) {
+    this.name = 'PublicChatError';
+    this.message = message;
+    Error.call(this, message);
+
+    // Maintains proper stack trace, where our error was thrown (only available on V8)
+    //   via https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this);
+    }
+  }
+
   window.textsecure.UnregisteredUserError = UnregisteredUserError;
   window.textsecure.SendMessageNetworkError = SendMessageNetworkError;
   window.textsecure.IncomingIdentityKeyError = IncomingIdentityKeyError;
@@ -281,4 +293,5 @@
   window.textsecure.NotFoundError = NotFoundError;
   window.textsecure.WrongSwarmError = WrongSwarmError;
   window.textsecure.WrongDifficultyError = WrongDifficultyError;
+  window.textsecure.PublicChatError = PublicChatError;
 })();

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -154,36 +154,42 @@ MessageReceiver.prototype.extend({
     this.httpPollingResource.handleMessage(message, options);
   },
   handlePublicMessage({ message }) {
-    const ev = new Event('message');
-    ev.confirm = function confirmTerm() {};
-    ev.data = {
-      friendRequest: false,
-      source: message.source,
-      sourceDevice: 1,
-      timestamp: message.timestamp,
-      serverTimestamp: message.serverTimestamp,
-      receivedAt: message.receivedAt,
-      isP2p: true, // masquerade as a p2p
-      message: {
-        body: message.body,
-        attachments: [],
-        group: null,
-        flags: 0,
-        expireTimer: 0,
-        profileKey: null,
-        timestamp: message.timestamp,
-        received_at: message.receivedAt,
-        // this is used for idForLogging and keying
-        sent_at: message.timestamp,
-        quote: null,
-        contact: [],
-        preview: [],
-        profile: {
-          displayName: message.from,
-        },
-      },
+    const options = {
+      isP2p: true,
+      onSuccess: () => console.log('Successfully handled public message'),
+      onFailure: () => console.log('Failed to handle public message'),
     };
-    this.dispatchAndWait(ev);
+    this.httpPollingResource.handleMessage(message, options);
+    // const ev = new Event('message');
+    // ev.confirm = function confirmTerm() {};
+    // ev.data = {
+    //   friendRequest: false,
+    //   source: message.source,
+    //   sourceDevice: 1,
+    //   timestamp: message.timestamp,
+    //   serverTimestamp: message.serverTimestamp,
+    //   receivedAt: message.receivedAt,
+    //   isP2p: true, // masquerade as a p2p
+    //   message: {
+    //     body: message.body,
+    //     attachments: [],
+    //     group: null,
+    //     flags: 0,
+    //     expireTimer: 0,
+    //     profileKey: null,
+    //     timestamp: message.timestamp,
+    //     received_at: message.receivedAt,
+    //     // this is used for idForLogging and keying
+    //     sent_at: message.timestamp,
+    //     quote: null,
+    //     contact: [],
+    //     preview: [],
+    //     profile: {
+    //       displayName: message.from,
+    //     },
+    //   },
+    // };
+    // this.dispatchAndWait(ev);
   },
   stopProcessing() {
     window.log.info('MessageReceiver: stopProcessing requested');
@@ -824,6 +830,11 @@ MessageReceiver.prototype.extend({
         promise = fallBackSessionCipher
           .decrypt(ciphertext.toArrayBuffer())
           .then(this.unpad);
+        break;
+      }
+      case textsecure.protobuf.Envelope.Type.PUBLIC_CHAT_MSG: {
+        window.log.info('Public chat message from ', envelope.source);
+        promise = Promise.resolve(this.unpad(ciphertext.toArrayBuffer()));
         break;
       }
       case textsecure.protobuf.Envelope.Type.PREKEY_BUNDLE:

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -156,14 +156,13 @@ MessageReceiver.prototype.extend({
   handlePublicMessage({ message }) {
     const ev = new Event('message');
     ev.confirm = function confirmTerm() {};
-    const ts = Date.now();
     ev.data = {
       friendRequest: false,
       source: message.source,
       sourceDevice: 1,
       timestamp: message.timestamp,
-      serverTimestamp: message.created_at,
-      receivedAt: ts,
+      serverTimestamp: message.serverTimestamp,
+      receivedAt: message.receivedAt,
       isP2p: true, // masquerade as a p2p
       message: {
         body: message.body,
@@ -173,7 +172,7 @@ MessageReceiver.prototype.extend({
         expireTimer: 0,
         profileKey: null,
         timestamp: message.timestamp,
-        received_at: ts,
+        received_at: message.receivedAt,
         // this is used for idForLogging and keying
         sent_at: message.timestamp,
         quote: null,

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -43,7 +43,14 @@ function OutgoingMessage(
   this.failoverNumbers = [];
   this.unidentifiedDeliveries = [];
 
-  const { numberInfo, senderCertificate, online, messageType, isPing, publicEndpoint } =
+  const {
+    numberInfo,
+    senderCertificate,
+    online,
+    messageType,
+    isPing,
+    publicEndpoint,
+  } =
     options || {};
   this.numberInfo = numberInfo;
   this.publicEndpoint = publicEndpoint;
@@ -186,7 +193,13 @@ OutgoingMessage.prototype = {
   },
 
   // Default ttl to 24 hours if no value provided
-  async transmitMessage(number, data, timestamp, ttl = 24 * 60 * 60 * 1000, sendOptions = {}) {
+  async transmitMessage(
+    number,
+    data,
+    timestamp,
+    ttl = 24 * 60 * 60 * 1000,
+    sendOptions = {}
+  ) {
     const pubKey = number;
     try {
       // TODO: Make NUM_CONCURRENT_CONNECTIONS a global constant
@@ -296,9 +309,13 @@ OutgoingMessage.prototype = {
       deviceIds.map(async deviceId => {
         if (this.publicEndpoint) {
           const content = new Uint8Array(
-            dcodeIO.ByteBuffer.wrap(this.getPlaintext(), 'binary').toArrayBuffer()
+            dcodeIO.ByteBuffer.wrap(
+              this.getPlaintext(),
+              'binary'
+            ).toArrayBuffer()
           );
 
+          // we're returning an envelope
           return {
             type: textsecure.protobuf.Envelope.Type.PUBLIC_CHAT_MSG,
             ourKey,
@@ -379,12 +396,17 @@ OutgoingMessage.prototype = {
       .then(async outgoingObjects => {
         // TODO: handle multiple devices/messages per transmit
         const outgoingObject = outgoingObjects[0];
+        window.log.info('outgoingObject', JSON.stringify(outgoingObject));
         const socketMessage = await this.wrapInWebsocketMessage(outgoingObject);
         let options = {};
         if (this.publicEndpoint) {
+          window.log.info('attaching plaintext to publicChat', this.message);
+          const ourNumber = textsecure.storage.user.getNumber();
           options = {
             endpoint: this.publicEndpoint,
-          }
+            ourKey: ourNumber,
+            messageText: this.message.dataMessage.body,
+          };
         }
         await this.transmitMessage(
           number,

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -942,7 +942,10 @@ MessageSender.prototype = {
     options
   ) {
     const me = textsecure.storage.user.getNumber();
-    const numbers = groupNumbers.filter(number => number !== me);
+    let numbers = groupNumbers.filter(number => number !== me);
+    if (options.publicEndpoint) {
+      numbers = [groupId];
+    }
     const attrs = {
       recipients: numbers,
       body: messageText,

--- a/preload.js
+++ b/preload.js
@@ -317,6 +317,8 @@ window.LokiP2pAPI = require('./js/modules/loki_p2p_api');
 
 window.LokiMessageAPI = require('./js/modules/loki_message_api');
 
+window.LokiPublicChatAPI = require('./js/modules/loki_public_chat_api');
+
 window.LocalLokiServer = require('./libloki/modules/local_loki_server');
 
 window.localServerPort = config.localServerPort;

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -13,6 +13,7 @@ message Envelope {
     RECEIPT       = 5;
     UNIDENTIFIED_SENDER = 6;
     FRIEND_REQUEST = 101; // contains prekeys + message and is using simple encryption
+    PUBLIC_CHAT_MSG = 102;
   }
 
   optional Type   type            = 1;

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -517,8 +517,18 @@
   color: $color-gray-60;
   text-transform: uppercase;
 }
+.module-message__metadata__public {
+  font-size: 11px;
+  line-height: 16px;
+  letter-spacing: 0.3px;
+  color: $color-gray-60;
+  text-transform: uppercase;
+}
 .module-message__metadata__date--incoming,
 .module-message__metadata__p2p--incoming {
+  color: $color-white-08;
+}
+.module-message__metadata__public--incoming {
   color: $color-white-08;
 }
 .module-message__metadata__date--with-image-no-caption {
@@ -526,6 +536,9 @@
 }
 
 .module-message__metadata__p2p {
+  font-weight: bold;
+}
+.module-message__metadata__public {
   font-weight: bold;
 }
 

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -86,6 +86,7 @@ export interface Props {
   expirationLength?: number;
   expirationTimestamp?: number;
   isP2p?: boolean;
+  isPublic?: boolean;
 
   onClickAttachment?: (attachment: AttachmentType) => void;
   onClickLinkPreview?: (url: string) => void;
@@ -203,6 +204,7 @@ export class Message extends React.PureComponent<Props, State> {
       textPending,
       timestamp,
       isP2p,
+      isPublic,
     } = this.props;
 
     if (collapseMetadata) {
@@ -212,6 +214,9 @@ export class Message extends React.PureComponent<Props, State> {
     const isShowingImage = this.isShowingImage();
     const withImageNoCaption = Boolean(!text && isShowingImage);
     const showError = status === 'error' && direction === 'outgoing';
+    const hasBadge = isP2p || isPublic;
+    const badgeText = isPublic ? 'Public' : isP2p ? 'P2p' : '';
+    const badgeType = badgeText.toLowerCase();
 
     return (
       <div
@@ -244,14 +249,14 @@ export class Message extends React.PureComponent<Props, State> {
             module="module-message__metadata__date"
           />
         )}
-        {isP2p ? (
+        {hasBadge ? (
           <span
             className={classNames(
-              'module-message__metadata__p2p',
-              `module-message__metadata__p2p--${direction}`
+              `module-message__metadata__${badgeType}`,
+              `module-message__metadata__${badgeType}--${direction}`
             )}
           >
-            &nbsp;•&nbsp;P2P
+            &nbsp;•&nbsp;${badgeText}
           </span>
         ) : null}
         {expirationLength && expirationTimestamp ? (


### PR DESCRIPTION
starts with PR353
- store text as clear text server-side
- refactor LokiPublicChatAPI into server/channel classes
- as isPublic/public badge to messages
- conversation add method getPublicSource() to cleanly get structure backend settings
- lint

comments
- isPublic is a bit intrusive but no more than we did with p2p (so I'm considering that acceptable). We could refactor to a "string", so it isn't of two flags to store a message badge
- it's broken, it doesn't create proper envelopes, just committing now so you can review where I'm at. I could use help with this.
- will remove all the temporary debug

questions
- how can I properly make a /websocketMessage/socketMessage?
- remove 06? in favor for a public conversation type?