### PR TITLE
Display groupname

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -790,10 +790,8 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
     sessionResetStatus: 0,
     swarmNodes: [],
     type: 'group',
-    profile: {
-      displayName: 'Loki Public Chat',
-    },
     server: 'https://chat.lokinet.org',
+    name: 'Loki Public Chat',
     channelId: '1',
     unlockTimestamp: null,
     unreadCount: 0,
@@ -801,7 +799,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
     version: 2,
   };
 
-  const { id, type, name, friendRequestStatus, profileName } = publicChatData;
+  const { id, type, name, friendRequestStatus } = publicChatData;
 
   await instance.run(
     `INSERT INTO conversations (
@@ -811,8 +809,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
     type,
     members,
     name,
-    friendRequestStatus,
-    profileName
+    friendRequestStatus
   ) values (
     $id,
     $json,
@@ -820,8 +817,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
     $type,
     $members,
     $name,
-    $friendRequestStatus,
-    $profileName
+    $friendRequestStatus
   );`,
     {
       $id: id,
@@ -831,7 +827,6 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
       $members: null,
       $name: name,
       $friendRequestStatus: friendRequestStatus,
-      $profileName: profileName,
     }
   );
 

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -96,7 +96,14 @@ export class ConversationHeader extends React.Component<Props> {
   }
 
   public renderTitle() {
-    const { phoneNumber, i18n, profileName, isKeysPending, isMe, name } = this.props;
+    const {
+      phoneNumber,
+      i18n,
+      profileName,
+      isKeysPending,
+      isMe,
+      name,
+    } = this.props;
 
     if (isMe) {
       return (

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -96,7 +96,7 @@ export class ConversationHeader extends React.Component<Props> {
   }
 
   public renderTitle() {
-    const { phoneNumber, i18n, profileName, isKeysPending, isMe } = this.props;
+    const { phoneNumber, i18n, profileName, isKeysPending, isMe, name } = this.props;
 
     if (isMe) {
       return (
@@ -111,6 +111,7 @@ export class ConversationHeader extends React.Component<Props> {
         <ContactName
           phoneNumber={phoneNumber}
           profileName={profileName}
+          name={name}
           i18n={i18n}
         />
         {isKeysPending ? '(pending)' : null}


### PR DESCRIPTION
Use 'name' instead of 'profile' for public group
Update conversation header to read the name again