### PR TITLE
Add one-time disclaimer at startup for beta release

### DIFF
--- a/background.html
+++ b/background.html
@@ -245,6 +245,42 @@
       </div>
     </div>
   </script>
+  <script type='text/x-tmpl-mustache' id='beta-disclaimer-dialog'>
+    <div class="content">
+      <div class="betaDisclaimerView" style="display: none;">
+        <h2>
+          Thanks for testing Loki Messenger!
+        </h2>
+        <p>
+            Thanks for testing Loki Messenger! This software is a beta version of the full Loki Messenger software suite, and so is missing some of the features the full version will have.
+        </p>
+
+        <p>
+          <b>
+            This version of Loki Messenger provides no guarantees of metadata privacy.
+          </b>
+        </p>
+
+        <p>
+            While your messages are secured using end to end encryption, in this beta version of Loki messenger, <b>third parties (like your ISP or the Service Node network) can see who you’re talking to</b> and when you’re sending or receiving messages.
+        </p>
+
+        <p>
+            It is also possible that <b>third parties could correlate your public key to your IP address</b> and your real identity if they learn your public key.
+        </p>
+
+        <p>
+            However, no one except you and your intended recipients will be able to see the contents of your messages. We recommend using existing methods, like Tor or I2P to mask your IP address while using Loki Messenger beta version.
+        </p>
+
+        <p>
+            As a beta, this software is still experimental. When things aren't working for you, or you feel confused by the app, please let us know by filing an issue on <a href="https://github.com/loki-project/loki-messenger">Github</a> or making suggestions on <a href="https://discordapp.com/invite/67GXfD6">Discord</a>.
+        </p>
+
+        <button class='ok' tabindex='1'>{{ ok }}</button>
+      </div>
+    </div>
+  </script>
   <script type='text/x-tmpl-mustache' id='identicon-svg'>
       <svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
          <circle cx='50' cy='50' r='40' fill='{{ color }}' />
@@ -648,6 +684,7 @@
   <script type='text/javascript' src='js/views/nickname_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/password_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/seed_dialog_view.js'></script>
+  <script type='text/javascript' src='js/views/beta_release_disclaimer_view.js'></script>
   <script type='text/javascript' src='js/views/identicon_svg_view.js'></script>
   <script type='text/javascript' src='js/views/install_view.js'></script>
   <script type='text/javascript' src='js/views/banner_view.js'></script>

--- a/js/views/beta_release_disclaimer_view.js
+++ b/js/views/beta_release_disclaimer_view.js
@@ -1,0 +1,42 @@
+/* global Whisper, i18n, window */
+
+// eslint-disable-next-line func-names
+(function() {
+  'use strict';
+
+  window.Whisper = window.Whisper || {};
+
+  Whisper.BetaReleaseDisclaimer = Whisper.View.extend({
+    className: 'loki-dialog beta-disclaimer-dialog modal',
+    templateName: 'beta-disclaimer-dialog',
+    initialize(options = {}) {
+      this.okText = options.okText || i18n('ok');
+      this.render();
+      this.$('.betaDisclaimerView').show();
+      this.$('.beta-disclaimer-dialog').bind('keyup', event => this.onKeyup(event));
+    },
+    events: {
+      'click .ok': 'close',
+    },
+    render_attributes() {
+      return {
+        ok: this.okText,
+      };
+    },
+    close() {
+      window.storage.put('betaReleaseDisclaimerAccepted', true);
+      this.remove();
+    },
+    onKeyup(event) {
+      switch (event.key) {
+        case 'Enter':
+        case 'Escape':
+        case 'Esc':
+          this.close();
+          break;
+        default:
+          break;
+      }
+    },
+  });
+})();

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -91,6 +91,11 @@
         model: { window: options.window },
       });
 
+      if (!window.storage.get('betaReleaseDisclaimerAccepted'))
+      {
+        this.showBetaReleaseDisclaimer();
+      }
+
       if (!options.initialLoadComplete) {
         this.appLoadingScreen = new Whisper.AppLoadingScreen();
         this.appLoadingScreen.render();
@@ -343,6 +348,10 @@
       });
       toast.$el.appendTo(this.$('.gutter'));
       toast.render();
+    },
+    showBetaReleaseDisclaimer() {
+      const dialog = new Whisper.BetaReleaseDisclaimer();
+      this.el.append(dialog.el);
     },
   });
 

--- a/test/index.html
+++ b/test/index.html
@@ -155,7 +155,42 @@
       </div>
     </div>
   </script>
+  <script type='text/x-tmpl-mustache' id='beta-disclaimer-dialog'>
+    <div class="content">
+      <div class="betaDisclaimerView" style="display: none;">
+        <h2>
+          Thanks for testing Loki Messenger!
+        </h2>
+        <p>
+            Thanks for testing Loki Messenger! This software is a beta version of the full Loki Messenger software suite, and so is missing some of the features the full version will have.
+        </p>
 
+        <p>
+          <b>
+            This version of Loki Messenger provides no guarantees of metadata privacy.
+          </b>
+        </p>
+
+        <p>
+            While your messages are secured using end to end encryption, in this beta version of Loki messenger, <b>third parties (like your ISP or the Service Node network) can see who you’re talking to</b> and when you’re sending or receiving messages.
+        </p>
+
+        <p>
+            It is also possible that <b>third parties could correlate your public key to your IP address</b> and your real identity if they learn your public key.
+        </p>
+
+        <p>
+            However, no one except you and your intended recipients will be able to see the contents of your messages. We recommend using existing methods, like Tor or I2P to mask your IP address while using Loki Messenger beta version.
+        </p>
+
+        <p>
+            As a beta, this software is still experimental. When things aren't working for you, or you feel confused by the app, please let us know by filing an issue on <a href="https://github.com/loki-project/loki-messenger">Github</a> or making suggestions on <a href="https://discordapp.com/invite/67GXfD6">Discord</a>.
+        </p>
+
+        <button class='ok' tabindex='1'>{{ ok }}</button>
+      </div>
+    </div>
+  </script>
   <script type='text/x-tmpl-mustache' id='identicon-svg'>
       <svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
          <circle cx='50' cy='50' r='40' fill='{{ color }}' />
@@ -537,6 +572,8 @@
   <script type='text/javascript' src='../js/views/scroll_down_button_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/banner_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/clear_data_view.js'></script>
+  <script type='text/javascript' src='../js/views/beta_release_disclaimer_view.js'></script>
+
 
   <!-- <script type="text/javascript" src="metadata/SecretSessionCipher_test.js"></script> -->
 


### PR DESCRIPTION
Simply checks the key-value storage at startup for `betaReleaseDisclaimerAccepted`.
If falsy, then display the modal. When the modal is accepted, it writes down a `true` to that same key in the storage.

HTML will most probably need some love, but this PR is mostly about getting the code at the right place.

<img width="1176" alt="Screen Shot 2019-07-26 at 3 48 26 pm" src="https://user-images.githubusercontent.com/40749766/61929688-004a6280-afbf-11e9-997b-e8cc33a8cc89.png">
