### PR TITLE
Only send read receipts if friends

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1938,6 +1938,11 @@
       //      conversation is viewed, another error message shows up for the contact
       read = read.filter(item => !item.hasErrors);
 
+      // Do not send read receipt if not friends yet
+      if (!this.isFriend()) {
+        return;
+      }
+
       if (read.length && options.sendReadReceipts) {
         window.log.info(`Sending ${read.length} read receipts`);
         // Because syncReadMessages sends to our other devices, and sendReadReceipts goes


### PR DESCRIPTION
Prevents read receipts from being sent for friend requests. Closes #366.