### PR TITLE
Add a toggle option for typing indicators; use short ttl for them

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1259,6 +1259,10 @@
     "message": "Enable the sending and receiving of read receipts",
     "description": "Description of the read receipts setting"
   },
+  "typingIndicatorsSettingDescription": {
+    "message": "Enable the sending and receiving of typing indicators",
+    "description": "Description of the typing indicators setting"
+  },
   "messageTTL": {
     "message": "Message TTL",
     "description": "Title of the Message TTL setting"

--- a/js/background.js
+++ b/js/background.js
@@ -281,6 +281,11 @@
       setReadReceiptSetting: value =>
         storage.put('read-receipt-setting', value),
 
+      getTypingIndicatorsSetting: () =>
+        storage.get('typing-indicators-setting'),
+      setTypingIndicatorsSetting: value =>
+        storage.put('typing-indicators-setting', value),
+
       getLinkPreviewSetting: () => storage.get('linkPreviews', false),
       setLinkPreviewSetting: value => storage.put('linkPreviews', value),
 
@@ -999,7 +1004,7 @@
     }
 
     if (typingIndicators === true || typingIndicators === false) {
-      storage.put('typingIndicators', typingIndicators);
+      storage.put('typing-indicators-setting', typingIndicators);
     }
 
     if (linkPreviews === true || linkPreviews === false) {
@@ -1014,7 +1019,7 @@
     const { groupId, started } = typing || {};
 
     // We don't do anything with incoming typing messages if the setting is disabled
-    if (!storage.get('typingIndicators')) {
+    if (!storage.get('typing-indicators-setting')) {
       return;
     }
 

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -209,7 +209,7 @@
 
     bumpTyping() {
       // We don't send typing messages if the setting is disabled
-      if (!storage.get('typingIndicators')) {
+      if (!storage.get('typing-indicators-setting')) {
         return;
       }
 
@@ -274,6 +274,7 @@
       const groupNumbers = this.getRecipients();
 
       const sendOptions = this.getSendOptions();
+      sendOptions.messageType = 'typing';
       this.wrapSend(
         textsecure.messaging.sendTypingMessage(
           {

--- a/js/settings_start.js
+++ b/js/settings_start.js
@@ -20,6 +20,7 @@ const getInitialData = async () => ({
 
   messageTTL: await window.getMessageTTL(),
   readReceiptSetting: await window.getReadReceiptSetting(),
+  typingIndicatorsSetting: await window.getTypingIndicatorsSetting(),
   linkPreviewSetting: await window.getLinkPreviewSetting(),
   notificationSetting: await window.getNotificationSetting(),
   audioNotification: await window.getAudioNotification(),

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -94,6 +94,25 @@
     },
   });
 
+  const TypingIndicatorsSettingView = Whisper.View.extend({
+    initialize(options) {
+      this.value = options.value;
+      this.setFn = options.setFn;
+      this.populate();
+    },
+    events: {
+      change: 'change',
+    },
+    change(e) {
+      this.value = e.target.checked;
+      this.setFn(this.value);
+      window.log.info('typing-indicators-setting changed to', this.value);
+    },
+    populate() {
+      this.$('input').prop('checked', Boolean(this.value));
+    },
+  });
+
   const RadioButtonGroupView = Whisper.View.extend({
     initialize(options) {
       this.name = options.name;
@@ -174,6 +193,11 @@
         value: window.initialData.readReceiptSetting,
         setFn: window.setReadReceiptSetting,
       });
+      new TypingIndicatorsSettingView({
+        el: this.$('.typing-indicators-setting'),
+        value: window.initialData.typingIndicatorsSetting,
+        setFn: window.setTypingIndicatorsSetting,
+      });
       new MessageTTLSettingView({
         el: this.$('.message-ttl-setting'),
         value: window.initialData.messageTTL,
@@ -216,6 +240,9 @@
         mediaPermissionsDescription: i18n('mediaPermissionsDescription'),
         generalHeader: i18n('general'),
         readReceiptSettingDescription: i18n('readReceiptSettingDescription'),
+        typingIndicatorsSettingDescription: i18n(
+          'typingIndicatorsSettingDescription'
+        ),
         messageTTL: i18n('messageTTL'),
         messageTTLSettingDescription: i18n('messageTTLSettingDescription'),
         messageTTLSettingWarning: i18n('messageTTLSettingWarning'),

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -387,7 +387,8 @@
         textsecure.storage.remove('number_id'),
         textsecure.storage.remove('device_name'),
         textsecure.storage.remove('userAgent'),
-        textsecure.storage.remove('read-receipts-setting'),
+        textsecure.storage.remove('read-receipt-setting'),
+        textsecure.storage.remove('typing-indicators-setting'),
         textsecure.storage.remove('regionCode'),
       ]);
 
@@ -418,6 +419,9 @@
         'read-receipt-setting',
         Boolean(readReceipts)
       );
+
+      // Enable typing indicators by default
+      await textsecure.storage.put('typing-indicators-setting', Boolean(true));
 
       await textsecure.storage.user.setNumberAndDeviceId(pubKeyString, 1);
       await textsecure.storage.put('regionCode', null);

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -347,6 +347,8 @@ OutgoingMessage.prototype = {
           ttl = 4 * 24 * 60 * 60 * 1000; // 4 days for friend request message
         } else if (this.messageType === 'onlineBroadcast') {
           ttl = 60 * 1000; // 1 minute for online broadcast message
+        } else if (this.messageType === 'typing') {
+          ttl = 60 * 1000; // 1 minute for typing indicators
         } else {
           const hours = window.getMessageTTL() || 24; // 1 day default for any other message
           ttl = hours * 60 * 60 * 1000;

--- a/main.js
+++ b/main.js
@@ -1109,6 +1109,10 @@ installSettingsSetter('message-ttl');
 
 installSettingsGetter('read-receipt-setting');
 installSettingsSetter('read-receipt-setting');
+
+installSettingsGetter('typing-indicators-setting');
+installSettingsSetter('typing-indicators-setting');
+
 installSettingsGetter('notification-setting');
 installSettingsSetter('notification-setting');
 installSettingsGetter('audio-notification');

--- a/preload.js
+++ b/preload.js
@@ -185,6 +185,10 @@ installSetter('message-ttl', 'setMessageTTL');
 
 installGetter('read-receipt-setting', 'getReadReceiptSetting');
 installSetter('read-receipt-setting', 'setReadReceiptSetting');
+
+installGetter('typing-indicators-setting', 'getTypingIndicatorsSetting');
+installSetter('typing-indicators-setting', 'setTypingIndicatorsSetting');
+
 installGetter('notification-setting', 'getNotificationSetting');
 installSetter('notification-setting', 'setNotificationSetting');
 installGetter('audio-notification', 'getAudioNotification');

--- a/settings.html
+++ b/settings.html
@@ -120,6 +120,10 @@
         <input type='checkbox' name='read-receipt-setting' id='read-receipt-setting' />
         <label for='read-receipt-setting'>{{ readReceiptSettingDescription }}</label>
       </div>
+      <div class='typing-indicators-setting'>
+        <input type='checkbox' name='typing-indicators-setting' id='typing-indicators-setting' /> 
+        <label for='typing-indicators-setting'>{{ typingIndicatorsSettingDescription }}</label>
+      </div>
     </div>
     <div class='sync-setting'></div>
     <hr>

--- a/settings_preload.js
+++ b/settings_preload.js
@@ -47,6 +47,10 @@ window.setMessageTTL = makeSetter('message-ttl');
 
 window.getReadReceiptSetting = makeGetter('read-receipt-setting');
 window.setReadReceiptSetting = makeSetter('read-receipt-setting');
+
+window.getTypingIndicatorsSetting = makeGetter('typing-indicators-setting');
+window.setTypingIndicatorsSetting = makeSetter('typing-indicators-setting');
+
 window.getNotificationSetting = makeGetter('notification-setting');
 window.setNotificationSetting = makeSetter('notification-setting');
 window.getAudioNotification = makeGetter('audio-notification');


### PR DESCRIPTION
- enables typing indicators by default (and adds an option to disable them)
- changes ttl for typing indicators to 1 min
