### PR TITLE
Multi-device part 1: make primary account generate and send authorisa…

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -775,9 +775,7 @@ async function updateSchema(instance) {
   await updateLokiSchema(instance);
 }
 
-const LOKI_SCHEMA_VERSIONS = [
-  updateToLokiSchemaVersion2,
-];
+const LOKI_SCHEMA_VERSIONS = [updateToLokiSchemaVersion2];
 
 async function updateToLokiSchemaVersion2(currentVersion, instance) {
   if (currentVersion >= 2) {
@@ -808,7 +806,9 @@ async function updateToLokiSchemaVersion2(currentVersion, instance) {
 }
 
 async function updateLokiSchema(instance) {
-  const result = await instance.get("SELECT name FROM sqlite_master WHERE type = 'table' AND name='loki_schema'");
+  const result = await instance.get(
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name='loki_schema'"
+  );
   if (!result) {
     await createLokiSchemaTable(instance);
   }
@@ -818,7 +818,11 @@ async function updateLokiSchema(instance) {
     `Current loki schema version: ${lokiSchemaVersion};`,
     `Most recent schema version: ${LOKI_SCHEMA_VERSIONS.length};`
   );
-  for (let index = 0, max = LOKI_SCHEMA_VERSIONS.length; index < max; index += 1) {
+  for (
+    let index = 0, max = LOKI_SCHEMA_VERSIONS.length;
+    index < max;
+    index += 1
+  ) {
     const runSchemaUpdate = LOKI_SCHEMA_VERSIONS[index];
 
     // Yes, we really want to do this asynchronously, in order
@@ -828,7 +832,9 @@ async function updateLokiSchema(instance) {
 }
 
 async function getLokiSchemaVersion(instance) {
-  const result = await instance.get('SELECT version FROM loki_schema WHERE version = (SELECT MAX(version) FROM loki_schema);');
+  const result = await instance.get(
+    'SELECT version FROM loki_schema WHERE version = (SELECT MAX(version) FROM loki_schema);'
+  );
   if (!result.version) {
     return 0;
   }
@@ -1237,7 +1243,10 @@ async function getPairingAuthorisation(issuerPubKey, secondaryDevicePubKey) {
 async function createOrUpdatePairingAuthorisation(data) {
   const { issuerPubKey, secondaryDevicePubKey, signature } = data;
 
-  const existing = await getPairingAuthorisation(issuerPubKey, secondaryDevicePubKey);
+  const existing = await getPairingAuthorisation(
+    issuerPubKey,
+    secondaryDevicePubKey
+  );
   // prevent adding duplicate entries
   if (existing) {
     return;

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -12,6 +12,7 @@ const {
   merge,
   set,
   omit,
+  isArrayBuffer,
 } = require('lodash');
 
 const { base64ToArrayBuffer, arrayBufferToBase64 } = require('./crypto');
@@ -87,6 +88,8 @@ module.exports = {
   bulkAddContactSignedPreKeys,
   removeContactSignedPreKeyByIdentityKey,
   removeAllContactSignedPreKeys,
+
+  createOrUpdatePairingAuthorisation,
 
   createOrUpdateItem,
   getItemById,
@@ -568,6 +571,23 @@ async function removeContactSignedPreKeyByIdentityKey(id) {
 }
 async function removeAllContactSignedPreKeys() {
   await channels.removeAllContactSignedPreKeys();
+}
+
+async function createOrUpdatePairingAuthorisation(data) {
+  let sig;
+  if (isArrayBuffer(data.signature)) {
+    sig = arrayBufferToBase64(data.signature);
+  } else if (typeof signature === 'string') {
+    sig = data.signature;
+  } else {
+    throw new Error(
+      'Invalid signature provided in createOrUpdatePairingAuthorisation. Needs to be either ArrayBuffer or string.'
+    );
+  }
+  return channels.createOrUpdatePairingAuthorisation({
+    ...data,
+    signature: sig,
+  });
 }
 
 // Items

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -63,9 +63,37 @@
     await outgoingMessage.sendToNumber(pubKey);
   }
 
+  async function sendPairingAuthorisation(secondaryDevicePubKey, signature) {
+    const pairingAuthorisation = new textsecure.protobuf.PairingAuthorisationMessage(
+      {
+        signature,
+        primaryDevicePubKey: textsecure.storage.user.getNumber(),
+        secondaryDevicePubKey,
+        type:
+          textsecure.protobuf.PairingAuthorisationMessage.Type.PAIRING_REQUEST,
+      }
+    );
+    const content = new textsecure.protobuf.Content({
+      pairingAuthorisation,
+    });
+    const options = {};
+    // Send a empty message with information about how to contact us directly
+    const outgoingMessage = new textsecure.OutgoingMessage(
+      null, // server
+      Date.now(), // timestamp,
+      [secondaryDevicePubKey], // numbers
+      content, // message
+      true, // silent
+      () => null, // callback
+      options
+    );
+    await outgoingMessage.sendToNumber(secondaryDevicePubKey);
+  }
+
   window.libloki.api = {
     sendBackgroundMessage,
     sendOnlineBroadcastMessage,
     broadcastOnlineStatus,
+    sendPairingAuthorisation,
   };
 })();

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -77,7 +77,6 @@
       pairingAuthorisation,
     });
     const options = {};
-    // Send a empty message with information about how to contact us directly
     const outgoingMessage = new textsecure.OutgoingMessage(
       null, // server
       Date.now(), // timestamp,

--- a/libloki/storage.js
+++ b/libloki/storage.js
@@ -113,11 +113,24 @@
     }
   }
 
+  async function savePairingAuthorisation(
+    issuerPubKey,
+    secondaryDevicePubKey,
+    signature
+  ) {
+    return textsecure.storage.protocol.storePairingAuthorisation(
+      issuerPubKey,
+      secondaryDevicePubKey,
+      signature
+    );
+  }
+
   window.libloki.storage = {
     getPreKeyBundleForContact,
     saveContactPreKeyBundle,
     removeContactPreKeyBundle,
     verifyFriendRequestAcceptPreKey,
+    savePairingAuthorisation,
   };
 
   // Libloki protocol store
@@ -243,4 +256,15 @@
   store.clearContactSignedPreKeysStore = async () => {
     await window.Signal.Data.removeAllContactSignedPreKeys();
   };
+
+  store.storePairingAuthorisation = (
+    issuerPubKey,
+    secondaryDevicePubKey,
+    signature
+  ) =>
+    window.Signal.Data.createOrUpdatePairingAuthorisation({
+      issuerPubKey,
+      secondaryDevicePubKey,
+      signature,
+    });
 })();

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -3,7 +3,6 @@
   textsecure,
   libsignal,
   libloki,
-  Whisper,
   mnemonic,
   btoa,
   Signal,

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -563,23 +563,15 @@
       }
 
       // Validate pubKey
-      const c = new Whisper.Conversation({
-        id: secondaryDevicePubKey,
-        type: 'private',
-      });
+      const c = await ConversationController.getOrCreateAndWait(
+        secondaryDevicePubKey,
+        'private'
+      );
       const validationError = c.validateNumber();
       if (validationError) {
         throw new Error('Invalid secondary device pubkey provided');
       }
       // Ensure there is a conversation existing
-      try {
-        await ConversationController.getOrCreateAndWait(
-          secondaryDevicePubKey,
-          'private'
-        );
-      } catch (e) {
-        window.log.error(e);
-      }
       const signature = await libloki.crypto.generateSignatureForPairing(
         secondaryDevicePubKey,
         textsecure.protobuf.PairingAuthorisationMessage.Type.PAIRING_REQUEST

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -36,6 +36,7 @@ message Content {
   optional TypingMessage  typingMessage  = 6;
   optional PreKeyBundleMessage preKeyBundleMessage = 101;
   optional LokiAddressMessage lokiAddressMessage = 102;
+  optional PairingAuthorisationMessage pairingAuthorisation = 103;
 }
 
 message LokiAddressMessage {
@@ -46,6 +47,17 @@ message LokiAddressMessage {
   optional string p2pAddress    = 1;
   optional uint32 p2pPort       = 2;
   optional Type   type          = 3;
+}
+
+message PairingAuthorisationMessage {
+  enum Type {
+    PAIRING_REQUEST = 1;
+    UNPAIRING_REQUEST = 2;
+  }
+  optional string primaryDevicePubKey   = 1;
+  optional string secondaryDevicePubKey = 2;
+  optional bytes  signature             = 3;
+  optional Type   type                  = 4;
 }
 
 message PreKeyBundleMessage {


### PR DESCRIPTION
Baby steps.

This PR allows you to run
```js
window.getAccountManager().authoriseSecondaryDevice("<pubkey>");
```
in the console of a primary device.

It basically generates and sends a pairing authorisation from a primary device to a secondary device.
An authorisation is basically:
- an issuer pubkey A (the primary device)
- a secondary device pubkey B
- a type  T (pairing or unpairing)
- a signature `sig(B + T)` generated by A

On the primary device side:
- Verify the secondary device pubkey
- Create a conversation if necessary
- Generate a signature of "pubKey + pairing type"
- send the signature to the pubkey, in a new protobuf message

On the secondary device side:
- detect the authorisation proto
- verify the signature
- store the authorisation in a new table

I was able to manually verity the presence of the authorisation in the secondary device db.