### PR TITLE
Delay disconnected status and stop emitting empty events

### DIFF
--- a/js/views/network_status_view.js
+++ b/js/views/network_status_view.js
@@ -46,7 +46,7 @@
     getSocketStatus() {
       return window.getSocketStatus();
     },
-    getNetworkStatus() {
+    getNetworkStatus(shortCircuit = false) {
       let message = '';
       let instructions = '';
       let hasInterruption = false;
@@ -67,26 +67,28 @@
           this.connectedTimer = null;
           break;
         case WebSocket.CLOSED:
-          if (!this.connectedTimer) {
-            // Mark offline if disconnected for 30 seconds
-            this.connectedTimer = window.setTimeout(() => {
-              message = i18n('disconnected');
-              instructions = i18n('checkNetworkConnection');
-              hasInterruption = true;
-            }, DISCONNECTED_DELAY);
-          }
-          break;
+        // Intentional fallthrough
         case WebSocket.CLOSING:
-        default:
+        // Intentional fallthrough
+        default: {
+          const markOffline = () => {
+            message = i18n('disconnected');
+            instructions = i18n('checkNetworkConnection');
+            hasInterruption = true;
+          };
+          if (shortCircuit) {
+            // Used to skip the timer for testing
+            markOffline();
+            break;
+          }
           if (!this.connectedTimer) {
             // Mark offline if disconnected for 30 seconds
             this.connectedTimer = window.setTimeout(() => {
-              message = i18n('disconnected');
-              instructions = i18n('checkNetworkConnection');
-              hasInterruption = true;
+              markOffline();
             }, DISCONNECTED_DELAY);
           }
           break;
+        }
       }
 
       if (

--- a/libtextsecure/http-resources.js
+++ b/libtextsecure/http-resources.js
@@ -83,8 +83,7 @@
       }
     };
 
-    // Note: calling callback(false) is currently not necessary
-    this.pollServer = async callback => {
+    this.pollServer = async () => {
       // This blocking call will return only when all attempts
       // at reaching snodes are exhausted or a DNS error occured
       try {
@@ -93,7 +92,6 @@
           stopPolling,
           messages => {
             connected = true;
-            callback(connected);
             messages.forEach(message => {
               const { data } = message;
               this.handleMessage(data);
@@ -111,7 +109,7 @@
       connected = false;
       // Exhausted all our snodes urls, trying again later from scratch
       setTimeout(() => {
-        this.pollServer(callback);
+        this.pollServer();
       }, EXHAUSTED_SNODES_RETRY_DELAY);
     };
 

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -73,16 +73,7 @@ MessageReceiver.prototype.extend({
     this.httpPollingResource = new HttpResource(lokiMessageAPI, {
       handleRequest: this.handleRequest.bind(this),
     });
-    this.httpPollingResource.pollServer(connected => {
-      // Emulate receiving an 'empty' websocket messages from the server.
-      // This is required to update the internal logic that checks
-      // if we are connected to the server. Without this, for example,
-      // the loading screen would never disappear if the navigator
-      // detects internet connectivity but never receives an 'empty' signal.
-      if (connected) {
-        this.onEmpty();
-      }
-    });
+    this.httpPollingResource.pollServer();
     localLokiServer.on('message', this.handleP2pMessage.bind(this));
     this.startLocalServer();
 

--- a/test/views/network_status_view_test.js
+++ b/test/views/network_status_view_test.js
@@ -153,7 +153,8 @@ describe('NetworkStatusView', () => {
         it('should be interrupted', () => {
           socketStatus = socketStatusVal;
           networkStatusView.update();
-          const status = networkStatusView.getNetworkStatus();
+          const shortCircuit = true;
+          const status = networkStatusView.getNetworkStatus(shortCircuit);
           assert(status.hasInterruption);
         });
       });


### PR DESCRIPTION
Remove empty event trigger, doesn't seem to be required any more but could be wrong
Looked through upstream signal and doesn't seem relevant to call every time we poll