### PR TITLE
Use server id

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -1945,10 +1945,13 @@ async function removeMessage(id) {
   );
 }
 
-async function getMessageByServerId(id) {
-  const row = await db.get('SELECT * FROM messages WHERE ServerId = $ServerId;', {
-    $ServerId: ServerId,
-  });
+async function getMessageByServerId(serverId) {
+  const row = await db.get(
+    'SELECT * FROM messages WHERE serverId = $serverId;',
+    {
+      $serverId: serverId,
+    }
+  );
 
   if (!row) {
     return null;

--- a/app/sql.js
+++ b/app/sql.js
@@ -118,6 +118,7 @@ module.exports = {
   removeMessage,
   getUnreadByConversation,
   getMessageBySender,
+  getMessageByServerId,
   getMessageById,
   getAllMessages,
   getAllMessageIds,
@@ -800,6 +801,11 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
   };
 
   const { id, type, name, friendRequestStatus } = publicChatData;
+
+  await instance.run(
+    `ALTER TABLE messages
+     ADD COLUMN serverId STRING;`
+  );
 
   await instance.run(
     `INSERT INTO conversations (
@@ -1718,6 +1724,7 @@ async function saveMessage(data, { forceSave } = {}) {
     hasFileAttachments,
     hasVisualMediaAttachments,
     id,
+    serverId,
     // eslint-disable-next-line camelcase
     received_at,
     schemaVersion,
@@ -1736,6 +1743,7 @@ async function saveMessage(data, { forceSave } = {}) {
     $id: id,
     $json: objectToJSON(data),
 
+    $serverId: serverId,
     $body: body,
     $conversationId: conversationId,
     $expirationStartTimestamp: expirationStartTimestamp,
@@ -1758,6 +1766,7 @@ async function saveMessage(data, { forceSave } = {}) {
     await db.run(
       `UPDATE messages SET
         json = $json,
+        serverId = $serverId,
         body = $body,
         conversationId = $conversationId,
         expirationStartTimestamp = $expirationStartTimestamp,
@@ -1792,6 +1801,7 @@ async function saveMessage(data, { forceSave } = {}) {
     id,
     json,
 
+    serverId,
     body,
     conversationId,
     expirationStartTimestamp,
@@ -1812,6 +1822,7 @@ async function saveMessage(data, { forceSave } = {}) {
     $id,
     $json,
 
+    $serverId,
     $body,
     $conversationId,
     $expirationStartTimestamp,
@@ -1932,6 +1943,18 @@ async function removeMessage(id) {
     `DELETE FROM messages WHERE id IN ( ${id.map(() => '?').join(', ')} );`,
     id
   );
+}
+
+async function getMessageByServerId(id) {
+  const row = await db.get('SELECT * FROM messages WHERE ServerId = $ServerId;', {
+    $ServerId: ServerId,
+  });
+
+  if (!row) {
+    return null;
+  }
+
+  return jsonToObject(row.json);
 }
 
 async function getMessageById(id) {

--- a/js/background.js
+++ b/js/background.js
@@ -750,14 +750,17 @@
       }
     });
 
-    Whisper.events.on('publicMessageSent', ({ pubKey, timestamp }) => {
-      try {
-        const conversation = ConversationController.get(pubKey);
-        conversation.onPublicMessageSent(pubKey, timestamp);
-      } catch (e) {
-        window.log.error('Error setting public on message');
+    Whisper.events.on(
+      'publicMessageSent',
+      ({ pubKey, timestamp, serverId }) => {
+        try {
+          const conversation = ConversationController.get(pubKey);
+          conversation.onPublicMessageSent(pubKey, timestamp, serverId);
+        } catch (e) {
+          window.log.error('Error setting public on message');
+        }
       }
-    });
+    );
 
     Whisper.events.on('password-updated', () => {
       if (appView && appView.inboxView) {

--- a/js/background.js
+++ b/js/background.js
@@ -1411,7 +1411,6 @@
     const { isError } = options;
 
     let messageData = {
-      id: data.id,
       source: data.source,
       sourceDevice: data.sourceDevice,
       sent_at: data.timestamp,

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1357,7 +1357,6 @@
         options.messageType = message.get('type');
         if (this.isPublic()) {
           options.publicEndpoint = this.getEndpoint();
-          options.messageId = id;
         }
 
         const groupNumbers = this.getRecipients();

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -368,9 +368,14 @@
       await Promise.all(messages.map(m => m.setIsP2p(true)));
     },
 
-    async onPublicMessageSent(pubKey, timestamp) {
+    async onPublicMessageSent(pubKey, timestamp, serverId) {
       const messages = this._getMessagesWithTimestamp(pubKey, timestamp);
-      await Promise.all(messages.map(m => m.setIsPublic(true)));
+      await Promise.all(
+        messages.map(message => [
+          message.setIsPublic(true),
+          message.setServerId(serverId),
+        ])
+      );
     },
 
     async onNewMessage(message) {

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -2014,9 +2014,7 @@
           } else {
             await conversation.onFriendRequestAccepted();
           }
-          // Force save if the message already has an id, used for public channels
           const id = await window.Signal.Data.saveMessage(message.attributes, {
-            forceSave: !!message.id,
             Message: Whisper.Message,
           });
           message.set({ id });

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1242,6 +1242,17 @@
         Message: Whisper.Message,
       });
     },
+    async setServerId(serverId) {
+      if (_.isEqual(this.get('serverId'), serverId)) return;
+
+      this.set({
+        serverId,
+      });
+
+      await window.Signal.Data.saveMessage(this.attributes, {
+        Message: Whisper.Message,
+      });
+    },
     async setIsPublic(isPublic) {
       if (_.isEqual(this.get('isPublic'), isPublic)) return;
 

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -141,6 +141,7 @@ module.exports = {
   removeAllMessagesInConversation,
 
   getMessageBySender,
+  getMessageByServerId,
   getMessageById,
   getAllMessages,
   getAllUnsentMessages,
@@ -873,6 +874,15 @@ async function removeMessage(id, { Message }) {
 // Note: this method will not clean up external files, just delete from SQL
 async function _removeMessages(ids) {
   await channels.removeMessage(ids);
+}
+
+async function getMessageByServerId(id, { Message }) {
+  const message = await channels.getMessageByServerId(id);
+  if (!message) {
+    return null;
+  }
+
+  return new Message(message);
 }
 
 async function getMessageById(id, { Message }) {

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -80,7 +80,6 @@ class LokiMessageAPI {
       isPing = false,
       numConnections = DEFAULT_CONNECTIONS,
       publicEndpoint = null,
-      messageId = null,
     } = options;
     // Data required to identify a message in a conversation
     const messageEventData = {
@@ -106,7 +105,6 @@ class LokiMessageAPI {
               timestamp: messageTimeStamp,
               from: displayName,
               source: this.ourKey,
-              id: messageId,
             },
           },
         ],

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -110,7 +110,7 @@ class LokiMessageAPI {
         ],
       };
       try {
-        await nodeFetch(publicEndpoint, {
+        const result = await nodeFetch(publicEndpoint, {
           method: 'post',
           headers: {
             'Content-Type': 'application/json',
@@ -118,6 +118,8 @@ class LokiMessageAPI {
           },
           body: JSON.stringify(payload),
         });
+        const body = await result.json();
+        messageEventData.serverId = body.data.id;
         window.Whisper.events.trigger('publicMessageSent', messageEventData);
         return;
       } catch (e) {

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -167,6 +167,7 @@ class LokiPublicChannelAPI {
         }
 
         const messageData = {
+          serverId: adnMessage.id,
           friendRequest: false,
           source,
           sourceDevice: 1,

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -161,14 +161,12 @@ class LokiPublicChannelAPI {
         let timestamp = new Date(adnMessage.created_at).getTime();
         let from = adnMessage.user.username;
         let source;
-        let id;
         if (adnMessage.annotations.length) {
           const noteValue = adnMessage.annotations[0].value;
-          ({ from, timestamp, source, id } = noteValue);
+          ({ from, timestamp, source } = noteValue);
         }
 
         const messageData = {
-          id,
           friendRequest: false,
           source,
           sourceDevice: 1,

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -50,12 +50,10 @@ function OutgoingMessage(
     messageType,
     isPing,
     publicEndpoint,
-    messageId,
   } =
     options || {};
   this.numberInfo = numberInfo;
   this.publicEndpoint = publicEndpoint;
-  this.messageId = messageId;
   this.senderCertificate = senderCertificate;
   this.online = online;
   this.messageType = messageType || 'outgoing';
@@ -205,7 +203,6 @@ OutgoingMessage.prototype = {
       };
       if (this.publicEndpoint) {
         options.publicEndpoint = this.publicEndpoint;
-        options.messageId = this.messageId;
       }
       await lokiMessageAPI.sendMessage(pubKey, data, timestamp, ttl, options);
     } catch (e) {


### PR DESCRIPTION
Revert the sending of message UUIDs from earlier and instead add a server id field to messages which is only used for public chats
This will allow us to send delete requests for a particular server/channel/messageServerId and have all the clients know which message this is for