### PR TITLE
Report mnemonic errors instead of silent failure

### DIFF
--- a/background.html
+++ b/background.html
@@ -579,6 +579,7 @@
               <div class='standalone-mnemonic-inputs'>
                 <input class='form-control' type='text' id='mnemonic' placeholder='Mnemonic Seed' autocomplete='off' spellcheck='false' />
               </div>
+              <div id='error' class='collapse'></div>
               <div class='restore standalone-register-language'>
                 <span>Language:</span>
                 <div class='select-container'>
@@ -586,7 +587,6 @@
                 </div>
               </div>
               <a class='button' id='register-mnemonic'>Restore</a>
-              <div id='error' class='collapse'></div>
               <div id=status></div>
             </div>
             <h4 class='section-toggle section-toggle-visible'>Register a new account</h4>

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -90,7 +90,7 @@
     async register(mnemonic, language) {
       // Make sure the password is valid
       if (this.validatePassword()) {
-        this.showToast('Invalid password');
+        this.showToast(i18n('invalidPassword'));
         return;
       }
 
@@ -119,6 +119,16 @@
     registerWithMnemonic() {
       const mnemonic = this.$('#mnemonic').val();
       const language = this.$('#mnemonic-language').val();
+      try {
+        window.mnemonic.mn_decode(mnemonic, language);
+      } catch (error) {
+        this.$('#mnemonic').addClass('error-input');
+        this.$('#error').text(error);
+        this.$('#error').show();
+        return;
+      }
+      this.$('#error').hide();
+      this.$('#mnemonic').removeClass('error-input');
       if (!mnemonic) {
         this.log('Please provide a mnemonic word list');
       } else {
@@ -148,11 +158,7 @@
     onCopyMnemonic() {
       window.clipboard.writeText(this.$('#mnemonic-display').text());
 
-      const toast = new Whisper.MessageToastView({
-        message: i18n('copiedMnemonic'),
-      });
-      toast.$el.appendTo(this.$el);
-      toast.render();
+      this.showToast(i18n('copiedMnemonic'));
     },
     log(s) {
       window.log.info(s);

--- a/libloki/modules/mnemonic.js
+++ b/libloki/modules/mnemonic.js
@@ -141,7 +141,7 @@ function mn_decode(str, wordset_name) {
       checksum_word.slice(0, wordset.prefix_len)
     ) {
       throw new MnemonicError(
-        'Your private key could not be verified, please try again'
+        'Your private key could not be verified, please verify the checksum word'
       );
     }
   }

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -806,7 +806,8 @@ $loading-height: 16px;
     }
   }
 
-  .password-inputs {
+  .password-inputs,
+  .standalone-mnemonic-inputs {
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
Show the mnemonic error message on the page, in a consistent manner with the password validation.
<img width="746" alt="Screen Shot 2019-08-09 at 4 00 49 pm" src="https://user-images.githubusercontent.com/40749766/62757930-30fec180-bac0-11e9-8c65-44f392b110b1.png">

Plus a couple of minor improvements along the way.