### PR TITLE
[multi-device] DB and proto changes

### DIFF
--- a/libloki/api.js
+++ b/libloki/api.js
@@ -73,8 +73,8 @@
     if (
       !primaryDevicePubKey ||
       !secondaryDevicePubKey ||
-      type === undefined ||
-      type === null
+      !requestSignature ||
+      typeof type !== 'number'
     ) {
       throw new Error(
         'createPairingAuthorisationProtoMessage: pubkeys or type is not set'

--- a/libloki/storage.js
+++ b/libloki/storage.js
@@ -113,16 +113,33 @@
     }
   }
 
-  async function savePairingAuthorisation(
-    issuerPubKey,
+  function savePairingAuthorisation({
+    primaryDevicePubKey,
     secondaryDevicePubKey,
-    signature
-  ) {
-    return textsecure.storage.protocol.storePairingAuthorisation(
-      issuerPubKey,
+    requestSignature,
+    grantSignature,
+  }) {
+    return window.Signal.Data.createOrUpdatePairingAuthorisation({
+      primaryDevicePubKey,
       secondaryDevicePubKey,
-      signature
-    );
+      requestSignature,
+      grantSignature,
+    });
+  }
+
+  function getGrantAuthorisationForSecondaryPubKey(secondaryPubKey) {
+    return window.Signal.Data.getGrantAuthorisationForPubKey(secondaryPubKey);
+  }
+
+  function getAuthorisationForSecondaryPubKey(secondaryPubKey) {
+    return window.Signal.Data.getAuthorisationForPubKey(secondaryPubKey);
+  }
+
+  async function getAllDevicePubKeysForPrimaryPubKey(primaryDevicePubKey) {
+    const secondaryPubKeys =
+      (await window.Signal.Data.getSecondaryDevicesFor(primaryDevicePubKey)) ||
+      [];
+    return secondaryPubKeys.concat(primaryDevicePubKey);
   }
 
   window.libloki.storage = {
@@ -131,6 +148,9 @@
     removeContactPreKeyBundle,
     verifyFriendRequestAcceptPreKey,
     savePairingAuthorisation,
+    getGrantAuthorisationForSecondaryPubKey,
+    getAuthorisationForSecondaryPubKey,
+    getAllDevicePubKeysForPrimaryPubKey,
   };
 
   // Libloki protocol store
@@ -256,15 +276,4 @@
   store.clearContactSignedPreKeysStore = async () => {
     await window.Signal.Data.removeAllContactSignedPreKeys();
   };
-
-  store.storePairingAuthorisation = (
-    issuerPubKey,
-    secondaryDevicePubKey,
-    signature
-  ) =>
-    window.Signal.Data.createOrUpdatePairingAuthorisation({
-      issuerPubKey,
-      secondaryDevicePubKey,
-      signature,
-    });
 })();

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -51,13 +51,15 @@ message LokiAddressMessage {
 
 message PairingAuthorisationMessage {
   enum Type {
-    PAIRING_REQUEST = 1;
-    UNPAIRING_REQUEST = 2;
+    REQUEST = 1;
+    GRANT = 2;
+    REVOKE = 3;
   }
   optional string primaryDevicePubKey   = 1;
   optional string secondaryDevicePubKey = 2;
-  optional bytes  signature             = 3;
-  optional Type   type                  = 4;
+  optional bytes  requestSignature      = 3;
+  optional bytes  grantSignature        = 4;
+  optional Type   type                  = 5;
 }
 
 message PreKeyBundleMessage {


### PR DESCRIPTION
This PR makes multiple changes to the db table and proto message, mainly adding getters and differentiating between the request signature (provided by the secondary device) and the grant signature (provided by the primary device):

- Allow updating authorisation in DB (with `INSERT OR REPLACE`) typically when an authorisation progresses from "requested" to "granted"
- Add unique index to `secondaryPubKey` since a pubkey can be linked to only one other primary key
- Removed `signature`  from table and add `isGranted` instead (the signatures are actually in the json field since we never need to query by signature)
- Add optional filter to retrieve authorisation only if it has a grant signature (allows to differentiate authorisation state between requested and granted)
- Add additional utility getters, e.g. `getSecondaryDevicesFor`
- Make `sendPairingAuthorisation` return a promise to know if the message was successfully sent or not