### PR TITLE
[multi-device] Secondary device registration UI

### DIFF
--- a/background.html
+++ b/background.html
@@ -574,21 +574,7 @@
 
           <!-- Registration -->
           <div class='page'>
-            <h4 class='section-toggle'>Restore using seed</h4>
-            <div class='standalone-mnemonic section-content'>
-              <div class='standalone-mnemonic-inputs'>
-                <input class='form-control' type='text' id='mnemonic' placeholder='Mnemonic Seed' autocomplete='off' spellcheck='false' />
-              </div>
-              <div id='error' class='collapse'></div>
-              <div class='restore standalone-register-language'>
-                <span>Language:</span>
-                <div class='select-container'>
-                  <select id='mnemonic-language'></select>
-                </div>
-              </div>
-              <a class='button' id='register-mnemonic'>Restore</a>
-              <div id=status></div>
-            </div>
+            <!-- New account -->
             <h4 class='section-toggle section-toggle-visible'>Register a new account</h4>
             <div class='standalone-register section-content'>
               <div class='standalone-register-warning'>
@@ -608,6 +594,38 @@
                 <a class='button grey' id='copy-mnemonic'>Copy Seed</a>
                 <a class='button' id='register' data-loading-text='Please wait...'>Register</a>
               </div>
+            </div>
+            <!-- Restore using seed -->
+            <h4 class='section-toggle'>Restore using seed</h4>
+            <div class='standalone-mnemonic section-content'>
+              <div class='standalone-mnemonic-inputs'>
+                <input class='form-control' type='text' id='mnemonic' placeholder='Mnemonic Seed' autocomplete='off' spellcheck='false' />
+              </div>
+              <div id='error' class='collapse'></div>
+              <div class='restore standalone-register-language'>
+                <span>Language:</span>
+                <div class='select-container'>
+                  <select id='mnemonic-language'></select>
+                </div>
+              </div>
+              <a class='button' id='register-mnemonic'>Restore</a>
+              <div id=status></div>
+            </div>
+            <!-- Link device to an existing account -->
+            <h4 class='section-toggle'>Link device to an existing account</h4>
+            <div class='standalone-secondary-device section-content'>
+              <p class='standalone-register-warning'>
+                You will need your Primary Device handy during this step.
+                </br>
+                Open the Loki Messenger App on your Primary Device
+              </br>
+                and select "Pair New Device" in the main menu.
+              </p>
+              <div class='standalone-secondary-device-inputs'>
+                <input class='form-control' type='text' id='primary-pubkey' placeholder='Primary Account Public Key' autocomplete='off' spellcheck='false' />
+              </div>
+              <div id='error' class='collapse'></div>
+              <a class='button' id='register-secondary-device'>Link</a>
             </div>
           </div>
 

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -126,16 +126,25 @@
       const language = this.$('#mnemonic-display-language').val();
       this.showProfilePage(mnemonic, language);
     },
+    onSecondaryDeviceRegistered() {
+      // Ensure the left menu is updated
+      Whisper.events.trigger('userChanged', { isSecondaryDevice: true });
+      this.$el.trigger('openInbox');
+    },
     async registerSecondaryDevice() {
       const mnemonic = this.$('#mnemonic-display').text();
       const language = this.$('#mnemonic-display-language').val();
       const primaryPubKey = this.$('#primary-pubkey').val();
       this.$('.standalone-secondary-device #error').hide();
-      Whisper.events.on('secondaryDeviceRegistration', () => {
-        // Ensure the left menu is updated
-        Whisper.events.trigger('userChanged', { isSecondaryDevice: true });
-        this.$el.trigger('openInbox');
-      });
+      // Ensure only one listener
+      Whisper.events.off(
+        'secondaryDeviceRegistration',
+        this.onSecondaryDeviceRegistered
+      );
+      Whisper.events.once(
+        'secondaryDeviceRegistration',
+        this.onSecondaryDeviceRegistered
+      );
       clearTimeout(this.pairingTimeout);
       this.pairingTimeout = setTimeout(() => {
         this.$('.standalone-secondary-device #error').text(


### PR DESCRIPTION
First iteration for UI for secondary device registration.
<img width="1082" alt="Screen Shot 2019-08-20 at 10 11 20 am" src="https://user-images.githubusercontent.com/40749766/63571961-0aaf4a80-c5c5-11e9-8d6b-645948b89474.png">
Also, re-ordered the accordion to show the default pane "Register a new account" on top.
Note:
The line:
`Whisper.events.trigger('userChanged', { isSecondaryDevice: true });`
is part of another review, but didn't want to exclude it to prevent forgetting it!
It basically forces the left pane UI to update and hide the "Pair New Device" item in the menu dropdown.

TODO: the "Link" button should be disabled while waiting for the authorisation to come through, or until timeout.