### PR TITLE
[multi-device] UI for accepting pairing request on Primary devices

### DIFF
--- a/background.html
+++ b/background.html
@@ -245,6 +245,40 @@
       </div>
     </div>
   </script>
+  <script type='text/x-tmpl-mustache' id='device-pairing-dialog'>
+    <div class="content">
+      <!-- Waiting for request -->
+      <div class="waitingForRequestView">
+        <h4>{{ waitingForRequestTitle }}</h4>
+        <div class='buttons'>
+          <button class="cancel">{{ cancelText }}</button>
+        </div>
+      </div>
+
+      <!-- Request Received -->
+      <div class="requestReceivedView" style="display: none;">
+        <h4>{{ requestReceivedTitle }}</h4>
+        Please verify that the pubkey shown here is your secondary device pubkey!
+        <p class="secondaryPubKey"></p>
+        <div class='buttons'>
+          <button class="skip">{{ skipText }}</button>
+          <button id="allowPairing">{{ allowPairingText }}</button>
+        </div>
+      </div>
+
+      <!-- Request accepted -->
+      <div class="requestAcceptedView" style="display: none;">
+        <h4>{{ requestAcceptedTitle }}</h4>
+        Sending pairing authorisation to:
+        <p class="secondaryPubKey"></p>
+        <p class="transmissionStatus">Please be patient...</p>
+        <div class='buttons'>
+          <button class="ok" style="display: none;">{{ okText }}</button>
+        </div>
+      </div>
+    </div>
+  </script>
+
   <script type='text/x-tmpl-mustache' id='beta-disclaimer-dialog'>
     <div class="content">
       <div class="betaDisclaimerView" style="display: none;">
@@ -693,6 +727,7 @@
   <script type='text/javascript' src='js/views/app_view.js'></script>
   <script type='text/javascript' src='js/views/import_view.js'></script>
   <script type='text/javascript' src='js/views/clear_data_view.js'></script>
+  <script type='text/javascript' src='js/views/device_pairing_dialog_view.js'></script>
 
   <script type='text/javascript' src='js/wall_clock_listener.js'></script>
   <script type='text/javascript' src='js/rotate_signed_prekey_listener.js'></script>

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -196,5 +196,15 @@
       const dialog = new Whisper.SeedDialogView({ seed });
       this.el.append(dialog.el);
     },
+    showDevicePairingDialog() {
+      const dialog = new Whisper.DevicePairingDialogView();
+      Whisper.events.on('devicePairingRequestReceived', pubKey =>
+        dialog.requestReceived(pubKey)
+      );
+      dialog.on('devicePairingRequestAccepted', (pubKey, cb) =>
+        Whisper.events.trigger('devicePairingRequestAccepted', pubKey, cb)
+      );
+      this.el.append(dialog.el);
+    },
   });
 })();

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -198,10 +198,13 @@
     },
     showDevicePairingDialog() {
       const dialog = new Whisper.DevicePairingDialogView();
+      // remove all listeners for this events is fine since the
+      // only listener is right below.
+      Whisper.events.off('devicePairingRequestReceived');
       Whisper.events.on('devicePairingRequestReceived', pubKey =>
         dialog.requestReceived(pubKey)
       );
-      dialog.on('devicePairingRequestAccepted', (pubKey, cb) =>
+      dialog.once('devicePairingRequestAccepted', (pubKey, cb) =>
         Whisper.events.trigger('devicePairingRequestAccepted', pubKey, cb)
       );
       this.el.append(dialog.el);

--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -1,0 +1,91 @@
+/* global Whisper, i18n */
+
+// eslint-disable-next-line func-names
+(function() {
+  'use strict';
+
+  window.Whisper = window.Whisper || {};
+
+  Whisper.DevicePairingDialogView = Whisper.View.extend({
+    className: 'loki-dialog device-pairing-dialog modal',
+    templateName: 'device-pairing-dialog',
+    initialize() {
+      this.pubKeyRequests = [];
+      this.pubKey = null;
+      this.accepted = false;
+      this.view = '';
+      this.render();
+      this.showView();
+    },
+    events: {
+      'click .waitingForRequestView .cancel': 'close',
+      'click .requestReceivedView .skip': 'skipDevice',
+      'click #allowPairing': 'allowDevice',
+      'click .requestAcceptedView .ok': 'close',
+    },
+    render_attributes() {
+      return {
+        waitingForRequestTitle: 'Waiting for device to register...',
+        requestReceivedTitle: 'Device Pairing Received',
+        requestAcceptedTitle: 'Device Pairing Accepted',
+        cancelText: i18n('cancel'),
+        skipText: 'Skip',
+        okText: i18n('ok'),
+        allowPairingText: 'Allow Pairing',
+      };
+    },
+    requestReceived(secondaryDevicePubKey) {
+      // FIFO: push at the front of the array with unshift()
+      this.pubKeyRequests.unshift(secondaryDevicePubKey);
+      if (!this.pubKey) {
+        this.nextPubKey();
+        this.showView('requestReceived');
+      }
+    },
+    allowDevice() {
+      this.accepted = true;
+      this.trigger('devicePairingRequestAccepted', this.pubKey, errors =>
+        this.transmisssionCB(errors)
+      );
+      this.showView();
+    },
+    transmisssionCB(errors) {
+      if (!errors) {
+        this.$('.transmissionStatus').text('Sent successfully');
+      } else {
+        this.$('.transmissionStatus').text(errors);
+      }
+      this.$('.requestAcceptedView .ok').show();
+    },
+    skipDevice() {
+      this.nextPubKey();
+      this.showView();
+    },
+    nextPubKey() {
+      // FIFO: pop at the back of the array using pop()
+      this.pubKey = this.pubKeyRequests.pop();
+    },
+    showView() {
+      const waitingForRequestView = this.$('.waitingForRequestView');
+      const requestReceivedView = this.$('.requestReceivedView');
+      const requestAcceptedView = this.$('.requestAcceptedView');
+      if (this.accepted) {
+        requestReceivedView.hide();
+        waitingForRequestView.hide();
+        requestAcceptedView.show();
+      } else if (this.pubKey) {
+        this.$('.secondaryPubKey').text(this.pubKey);
+        requestReceivedView.show();
+        waitingForRequestView.hide();
+        requestAcceptedView.hide();
+      } else {
+        waitingForRequestView.show();
+        requestReceivedView.hide();
+        requestAcceptedView.hide();
+      }
+    },
+    close() {
+      this.remove();
+    },
+  });
+})();


### PR DESCRIPTION
This PR adds the UI modals that appear when clicking on the "Pair new Device" item in the menu.
There are 3 steps:

- Waiting for request to come through
- Request received, requires user to discard or accept the request based on the secondary pub key
- Message sent/error. User can only click OK. If there was an error, the user should start over.

Again, events are handled via `Whisper.events` to allow decoupling.
TODO: replace hard-coded strings with `i18n` translation thingy (in another PR)

<img width="1123" alt="Screen Shot 2019-08-16 at 5 14 05 pm" src="https://user-images.githubusercontent.com/40749766/63658594-3a419b00-c7ef-11e9-8fe4-fad94955ad06.png">
<img width="1126" alt="Screen Shot 2019-08-16 at 5 14 42 pm" src="https://user-images.githubusercontent.com/40749766/63658596-3dd52200-c7ef-11e9-9943-c58764c21e4d.png">
<img width="1126" alt="Screen Shot 2019-08-16 at 5 15 05 pm" src="https://user-images.githubusercontent.com/40749766/63658598-40d01280-c7ef-11e9-9439-a3a85e4b4cc3.png">
<img width="1124" alt="Screen Shot 2019-08-16 at 5 15 19 pm" src="https://user-images.githubusercontent.com/40749766/63658599-43326c80-c7ef-11e9-9128-536199e8d6db.png">
