### PR TITLE
[multi-device] Fix main header being redrawn every 100ms

### DIFF
--- a/ts/components/MainHeader.tsx
+++ b/ts/components/MainHeader.tsx
@@ -88,7 +88,9 @@ export class MainHeader extends React.Component<Props, any> {
 
     setInterval(() => {
       const clipboardText = clipboard.readText();
-      this.setState({ clipboardText });
+      if (this.state.clipboardText !== clipboardText) {
+        this.setState({ clipboardText });
+      }
     }, 100);
   }
 


### PR DESCRIPTION
Noticed while debugging that the main header was being constantly redrawn.
This was due to the clipboard code updating the component state every 100ms without checking if the value actually had changed.