### PR TITLE
[multi-device] Allow receiving and sending messages before lokiP2PApi is defined.

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -167,7 +167,7 @@
 
       if (this.id === this.ourNumber) {
         this.set({ friendRequestStatus: FriendRequestStatusEnum.friends });
-      } else if (lokiP2pAPI) {
+      } else if (typeof lokiP2pAPI !== 'undefined') {
         // Online status handling, only for contacts that aren't us
         this.set({ isOnline: lokiP2pAPI.isOnline(this.id) });
       } else {

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -39,6 +39,9 @@ const calcNonce = (messageEventData, pubKey, data64, timestamp, ttl) => {
 };
 
 const trySendP2p = async (pubKey, data64, isPing, messageEventData) => {
+  if (typeof lokiP2pAPI === 'undefined') {
+    return false;
+  }
   const p2pDetails = lokiP2pAPI.getContactP2pDetails(pubKey);
   if (!p2pDetails || (!isPing && !p2pDetails.isOnline)) {
     return false;


### PR DESCRIPTION
The secondary device registration step requires to send and receive messages before lokiP2PApi is instantiated, which happens after the registration is done.