### PR TITLE
[multi-device] Prevent showing inbox if secondary registration is ongoing

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -587,7 +587,10 @@
     if (Whisper.Import.isIncomplete()) {
       window.log.info('Import was interrupted, showing import error screen');
       appView.openImporter();
-    } else if (Whisper.Registration.everDone()) {
+    } else if (
+      Whisper.Registration.everDone() &&
+      !Whisper.Registration.ongoingSecondaryDeviceRegistration()
+    ) {
       // listeners
       Whisper.RotateSignedPreKeyListener.init(Whisper.events, newVersion);
       // window.Signal.RefreshSenderCertificate.initialize({

--- a/js/registration.js
+++ b/js/registration.js
@@ -21,6 +21,9 @@
         storage.get('chromiumRegistrationDone') === ''
       );
     },
+    ongoingSecondaryDeviceRegistration() {
+      return storage.get('secondaryDeviceStatus') === 'ongoing';
+    },
     remove() {
       storage.remove('chromiumRegistrationDone');
     },


### PR DESCRIPTION
This PR ensures the inbox is shown only when the secondary device registration process is truly complete.

The current condition only checks for the existence of the key pair, which is not enough for secondary devices since they were created to send the authorisation request to the primary device. For secondary device, we also need to check the `secondaryDeviceStatus`, which is cleared after the registration is done.