### PR TITLE
[multi-device] Display incoming messages in the primary device conversation

### DIFF
--- a/js/delivery_receipts.js
+++ b/js/delivery_receipts.js
@@ -3,7 +3,8 @@
   Whisper,
   ConversationController,
   MessageController,
-  _
+  _,
+  libloki,
 */
 
 /* eslint-disable more/no-then */
@@ -34,6 +35,15 @@
       if (messages.length === 0) {
         return null;
       }
+
+      const authorisation = await libloki.storage.getGrantAuthorisationForSecondaryPubKey(
+        source
+      );
+      if (authorisation) {
+        // eslint-disable-next-line no-param-reassign
+        source = authorisation.primaryDevicePubKey;
+      }
+
       const message = messages.find(
         item => !item.isIncoming() && source === item.get('conversationId')
       );

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -10,7 +10,8 @@
   Signal,
   textsecure,
   Whisper,
-  clipboard
+  clipboard,
+  libloki,
 */
 
 /* eslint-disable more/no-then */
@@ -1697,7 +1698,7 @@
       return message;
     },
 
-    handleDataMessage(initialMessage, confirm) {
+    async handleDataMessage(initialMessage, confirm) {
       // This function is called from the background script in a few scenarios:
       //   1. on an incoming message
       //   2. on a sent message sync'd from another device
@@ -1707,9 +1708,15 @@
       const source = message.get('source');
       const type = message.get('type');
       let conversationId = message.get('conversationId');
+      const authorisation = await libloki.storage.getGrantAuthorisationForSecondaryPubKey(
+        source
+      );
       if (initialMessage.group) {
         conversationId = initialMessage.group.id;
+      } else if (authorisation) {
+        conversationId = authorisation.primaryDevicePubKey;
       }
+
       const GROUP_TYPES = textsecure.protobuf.GroupContext.Type;
 
       const conversation = ConversationController.get(conversationId);


### PR DESCRIPTION
Ensure messages coming from secondary devices are forwarded to the primary conversation.
There is multiple occurrences of the same check because it's required for typing indicator messages, normal messages, read receipts, etc. Some code paths might see the same check twice, but I figured it keep things more modular as well (you could still call an intermediary function without knowing or caring about the substitution)