### PR TITLE
[multi-device] Outgoing messages

### DIFF
--- a/libloki/storage.js
+++ b/libloki/storage.js
@@ -113,18 +113,8 @@
     }
   }
 
-  function savePairingAuthorisation({
-    primaryDevicePubKey,
-    secondaryDevicePubKey,
-    requestSignature,
-    grantSignature,
-  }) {
-    return window.Signal.Data.createOrUpdatePairingAuthorisation({
-      primaryDevicePubKey,
-      secondaryDevicePubKey,
-      requestSignature,
-      grantSignature,
-    });
+  function savePairingAuthorisation(authorisation) {
+    return window.Signal.Data.createOrUpdatePairingAuthorisation(authorisation);
   }
 
   function getGrantAuthorisationForSecondaryPubKey(secondaryPubKey) {

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -259,7 +259,7 @@ OutgoingMessage.prototype = {
     const bytes = new Uint8Array(websocketMessage.encode().toArrayBuffer());
     return bytes;
   },
-  async doSendMessage(number, devicesPubKeys, recurse) {
+  doSendMessage(number, devicesPubKeys, recurse) {
     const ciphers = {};
 
     this.numbers = devicesPubKeys;
@@ -389,20 +389,15 @@ OutgoingMessage.prototype = {
           sourceDevice: 1,
           destinationRegistrationId: ciphertext.registrationId,
           content: ciphertext.body,
-          number: devicePubKey,
+          pubKey: devicePubKey,
         };
       })
     )
       .then(async outgoingObjects => {
         // TODO: handle multiple devices/messages per transmit
-        let counter = 0;
         const promises = outgoingObjects.map(async outgoingObject => {
-          const destination = outgoingObject.number;
+          const destination = outgoingObject.pubKey;
           try {
-            counter += 1;
-            if (counter > 1) {
-              throw new Error(`Error for device ${counter}`);
-            }
             const socketMessage = await this.wrapInWebsocketMessage(
               outgoingObject
             );


### PR DESCRIPTION
- Re-visited the existing Signal logic that sends a message to all the devices linked to a primary pubkey. I have replaced `deviceIds` with `devicePubKeys`, which includes the primary device pubkey.
- Make secondary device attach the authorisation to any outgoing friend requests
- Show the message as sent if sent to at least one message