### PR TITLE
[multi-device] Fix bugs revealed during reviews

### DIFF
--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -54,6 +54,8 @@
       this.showRegisterPage();
 
       this.onValidatePassword();
+
+      this.onSecondaryDeviceRegistered = this.onSecondaryDeviceRegistered.bind(this);
     },
     events: {
       'validation input.number': 'onValidation',

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1057,7 +1057,7 @@ MessageReceiver.prototype.extend({
         'Received a pairing request addressed to another pubkey. Ignored.'
       );
       return false;
-    } else if (authorisation.secondaryDevicePubKey === ourPubKey) {
+    } else if (isRequest && authorisation.secondaryDevicePubKey === ourPubKey) {
       window.log.warn('Received a pairing request from ourselves. Ignored.');
       return false;
     }
@@ -1066,7 +1066,7 @@ MessageReceiver.prototype.extend({
         primaryDevicePubKey,
         secondaryDevicePubKey,
         dcodeIO.ByteBuffer.wrap(requestSignature).toArrayBuffer(),
-        type
+        textsecure.protobuf.PairingAuthorisationMessage.Type.REQUEST
       );
     } catch (e) {
       window.log.warn(
@@ -1081,7 +1081,7 @@ MessageReceiver.prototype.extend({
           primaryDevicePubKey,
           secondaryDevicePubKey,
           dcodeIO.ByteBuffer.wrap(grantSignature).toArrayBuffer(),
-          type
+          textsecure.protobuf.PairingAuthorisationMessage.Type.GRANT
         );
       } catch (e) {
         window.log.warn(


### PR DESCRIPTION
- Need to bind `onSecondaryDeviceRegistered` to `this` because it's passed as callback
- Use the correct type for request vs grant signature validation
- Only reject request authorisation sent by the secondary pubkey to itself (edge case)