### PR TITLE
[Public Authentication] Auth sending

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -95,7 +95,7 @@ module.exports = {
   saveConversations,
   getConversationById,
   savePublicServerToken,
-  getPublicServerTokenByServerName,
+  getPublicServerTokenByServerUrl,
   updateConversation,
   removeConversation,
   getAllConversations,
@@ -795,7 +795,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
 
   await instance.run(
     `CREATE TABLE servers(
-      server STRING PRIMARY KEY ASC,
+      serverUrl STRING PRIMARY KEY ASC,
       token TEXT
     );`
   );
@@ -833,7 +833,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
   };
 
   const lokiPublicServerData = {
-    server: 'chat.lokinet.org',
+    serverUrl: 'https://chat.lokinet.org',
     token: null,
   };
 
@@ -851,24 +851,24 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
 
   const publicChatData = {
     ...baseData,
-    id: `publicChat:1@${lokiPublicServerData.server}`,
-    server: lokiPublicServerData.server,
+    id: 'publicChat:1@chat.lokinet.org',
+    server: lokiPublicServerData.serverUrl,
     name: 'Loki Public Chat',
     channelId: '1',
   };
 
-  const { server, token } = lokiPublicServerData;
+  const { serverUrl, token } = lokiPublicServerData;
 
   await instance.run(
     `INSERT INTO servers (
-    server,
+    serverUrl,
     token
   ) values (
-    $server,
+    $serverUrl,
     $token
   );`,
     {
-      $server: server,
+      $serverUrl: serverUrl,
       $token: token,
     }
   );
@@ -1622,27 +1622,27 @@ async function removeConversation(id) {
 }
 
 async function savePublicServerToken(data) {
-  const { server, token } = data;
+  const { serverUrl, token } = data;
   await db.run(
     `INSERT OR REPLACE INTO servers (
-    server,
+    serverUrl,
     token
   ) values (
-    $server,
+    $serverUrl,
     $token
   )`,
     {
-      $server: server,
+      $serverUrl: serverUrl,
       $token: token,
     }
   );
 }
 
-async function getPublicServerTokenByServerName(server) {
+async function getPublicServerTokenByServerUrl(serverUrl) {
   const row = await db.get(
-    'SELECT * FROM servers WHERE server = $server;',
+    'SELECT * FROM servers WHERE serverUrl = $serverUrl;',
     {
-      $server: server,
+      $serverUrl: serverUrl,
     }
   );
 

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1374,8 +1374,9 @@
 
         const options = this.getSendOptions();
         options.messageType = message.get('type');
+        options.isPublic = this.isPublic();
         if (this.isPublic()) {
-          options.publicEndpoint = this.getEndpoint();
+          options.channelSettings = this.getPublicSource();
         }
 
         const groupNumbers = this.getRecipients();
@@ -2064,17 +2065,8 @@
       return {
         server: this.get('server'),
         channelId: this.get('channelId'),
+        conversationId: this.get('id'),
       };
-    },
-    // FIXME: remove or add public and/or "sending" hint to name...
-    getEndpoint() {
-      if (!this.isPublic()) {
-        return null;
-      }
-      const server = this.get('server');
-      const channelId = this.get('channelId');
-      const endpoint = `${server}/channels/${channelId}/messages`;
-      return endpoint;
     },
 
     // SIGNAL PROFILES

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -11,6 +11,7 @@
   clipboard,
   BlockedNumberController,
   lokiP2pAPI,
+  lokiPublicChatAPI,
   JobQueue
 */
 
@@ -1376,7 +1377,7 @@
         options.messageType = message.get('type');
         options.isPublic = this.isPublic();
         if (this.isPublic()) {
-          options.channelSettings = this.getPublicSource();
+          options.publicSendData = await this.getPublicSendData();
         }
 
         const groupNumbers = this.getRecipients();
@@ -2066,6 +2067,22 @@
         server: this.get('server'),
         channelId: this.get('channelId'),
         conversationId: this.get('id'),
+      };
+    },
+    async getPublicSendData() {
+      const serverAPI = lokiPublicChatAPI.findOrCreateServer(
+        this.get('server')
+      );
+      // Can be null if fails
+      const token = await serverAPI.getOrRefreshServerToken();
+      const channelAPI = serverAPI.findOrCreateChannel(
+        this.get('channelId'),
+        this.id
+      );
+      const publicEndpoint = channelAPI.getEndpoint();
+      return {
+        publicEndpoint,
+        token,
       };
     },
 

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -122,7 +122,7 @@ module.exports = {
   getAllPublicConversations,
   getPublicConversationsByServer,
   savePublicServerToken,
-  getPublicServerTokenByServerName,
+  getPublicServerTokenByServerUrl,
   getAllGroupsInvolvingId,
 
   searchConversations,
@@ -773,8 +773,8 @@ async function savePublicServerToken(data) {
   await channels.savePublicServerToken(data);
 }
 
-async function getPublicServerTokenByServerName(server) {
-  const token = await channels.getPublicServerTokenByServerName(server);
+async function getPublicServerTokenByServerUrl(serverUrl) {
+  const token = await channels.getPublicServerTokenByServerUrl(serverUrl);
   return token;
 }
 

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-loop-func */
-/* global log, dcodeIO, window, callWorker,
-          lokiP2pAPI, lokiSnodeAPI, lokiPublicChatAPI, textsecure */
+/* global log, dcodeIO, window, callWorker, lokiP2pAPI, lokiSnodeAPI, textsecure */
 
 const _ = require('lodash');
 const { rpc } = require('./loki_rpc');
@@ -81,7 +80,7 @@ class LokiMessageAPI {
       isPing = false,
       isPublic = false,
       numConnections = DEFAULT_CONNECTIONS,
-      channelSettings = null,
+      publicSendData = null,
     } = options;
     // Data required to identify a message in a conversation
     const messageEventData = {
@@ -90,20 +89,12 @@ class LokiMessageAPI {
     };
 
     if (isPublic) {
-      // could we emit back to LokiPublicChannelAPI somehow?
-      const { server, channelId, conversationId } = channelSettings;
-      const serverAPI = lokiPublicChatAPI.findOrCreateServer(server);
-      const token = await serverAPI.getServerToken();
+      const { token, publicEndpoint } = publicSendData;
       if (!token) {
         throw new window.textsecure.PublicChatError(
-          `Failed to retrieve valid token for ${conversationId}`
+          `Failed to retrieve valid token for ${publicEndpoint}`
         );
       }
-      const channelAPI = serverAPI.findOrCreateChannel(
-        channelId,
-        conversationId
-      );
-      const publicEndpoint = channelAPI.getEndpoint(conversationId);
 
       const { profile } = data;
       let displayName = 'Anonymous';

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -49,11 +49,13 @@ function OutgoingMessage(
     online,
     messageType,
     isPing,
-    publicEndpoint,
+    isPublic,
+    channelSettings,
   } =
     options || {};
   this.numberInfo = numberInfo;
-  this.publicEndpoint = publicEndpoint;
+  this.isPublic = isPublic;
+  this.channelSettings = channelSettings;
   this.senderCertificate = senderCertificate;
   this.online = online;
   this.messageType = messageType || 'outgoing';
@@ -201,8 +203,9 @@ OutgoingMessage.prototype = {
         numConnections: NUM_SEND_CONNECTIONS,
         isPing: this.isPing,
       };
-      if (this.publicEndpoint) {
-        options.publicEndpoint = this.publicEndpoint;
+      options.isPublic = this.isPublic;
+      if (this.isPublic) {
+        options.channelSettings = this.channelSettings;
       }
       await lokiMessageAPI.sendMessage(pubKey, data, timestamp, ttl, options);
     } catch (e) {
@@ -270,7 +273,7 @@ OutgoingMessage.prototype = {
   },
   doSendMessage(number, deviceIds, recurse) {
     const ciphers = {};
-    if (this.publicEndpoint) {
+    if (this.isPublic) {
       return this.transmitMessage(
         number,
         this.message.dataMessage,

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -50,12 +50,12 @@ function OutgoingMessage(
     messageType,
     isPing,
     isPublic,
-    channelSettings,
+    publicSendData,
   } =
     options || {};
   this.numberInfo = numberInfo;
   this.isPublic = isPublic;
-  this.channelSettings = channelSettings;
+  this.publicSendData = publicSendData;
   this.senderCertificate = senderCertificate;
   this.online = online;
   this.messageType = messageType || 'outgoing';
@@ -205,7 +205,7 @@ OutgoingMessage.prototype = {
       };
       options.isPublic = this.isPublic;
       if (this.isPublic) {
-        options.channelSettings = this.channelSettings;
+        options.publicSendData = this.publicSendData;
       }
       await lokiMessageAPI.sendMessage(pubKey, data, timestamp, ttl, options);
     } catch (e) {

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -943,7 +943,7 @@ MessageSender.prototype = {
   ) {
     const me = textsecure.storage.user.getNumber();
     let numbers = groupNumbers.filter(number => number !== me);
-    if (options.publicEndpoint) {
+    if (options.isPublic) {
       numbers = [groupId];
     }
     const profile = textsecure.storage.impl.getLocalProfile();


### PR DESCRIPTION
Use the public chat api to get metadata in the sending pipeline rather than from the conversation
And retrieve the token from the public chat api (in #448) when sending