### PR TITLE
[multi-device] Shorter TTL for pairing requests

### DIFF
--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -55,7 +55,9 @@
 
       this.onValidatePassword();
 
-      this.onSecondaryDeviceRegistered = this.onSecondaryDeviceRegistered.bind(this);
+      this.onSecondaryDeviceRegistered = this.onSecondaryDeviceRegistered.bind(
+        this
+      );
     },
     events: {
       'validation input.number': 'onValidation',

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -106,7 +106,7 @@
     const content = new textsecure.protobuf.Content({
       pairingAuthorisation,
     });
-    const options = {};
+    const options = { messageType: 'pairing-request' };
     const p = new Promise((resolve, reject) => {
       const outgoingMessage = new textsecure.OutgoingMessage(
         null, // server

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -370,7 +370,7 @@ OutgoingMessage.prototype = {
             dcodeIO.ByteBuffer.wrap(ciphertext.body, 'binary').toArrayBuffer()
           );
         }
-        const getTTL = (type) => {
+        const getTTL = type => {
           switch (type) {
             case 'friend-request':
               return 4 * 24 * 60 * 60 * 1000; // 4 days for friend request message
@@ -383,7 +383,7 @@ OutgoingMessage.prototype = {
             default:
               return (window.getMessageTTL() || 24) * 60 * 60 * 1000; // 1 day default for any other message
           }
-        }
+        };
         const ttl = getTTL(this.messageType);
 
         return {

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -370,17 +370,21 @@ OutgoingMessage.prototype = {
             dcodeIO.ByteBuffer.wrap(ciphertext.body, 'binary').toArrayBuffer()
           );
         }
-        let ttl;
-        if (this.messageType === 'friend-request') {
-          ttl = 4 * 24 * 60 * 60 * 1000; // 4 days for friend request message
-        } else if (this.messageType === 'onlineBroadcast') {
-          ttl = 60 * 1000; // 1 minute for online broadcast message
-        } else if (this.messageType === 'typing') {
-          ttl = 60 * 1000; // 1 minute for typing indicators
-        } else {
-          const hours = window.getMessageTTL() || 24; // 1 day default for any other message
-          ttl = hours * 60 * 60 * 1000;
+        const getTTL = (type) => {
+          switch (type) {
+            case 'friend-request':
+              return 4 * 24 * 60 * 60 * 1000; // 4 days for friend request message
+            case 'onlineBroadcast':
+              return 60 * 1000; // 1 minute for online broadcast message
+            case 'typing':
+              return 60 * 1000; // 1 minute for typing indicators
+            case 'pairing-request':
+              return 2 * 60 * 1000; // 2 minutes for pairing requests
+            default:
+              return (window.getMessageTTL() || 24) * 60 * 60 * 1000; // 1 day default for any other message
+          }
         }
+        const ttl = getTTL(this.messageType);
 
         return {
           type: ciphertext.type, // FallBackSessionCipher sets this to FRIEND_REQUEST


### PR DESCRIPTION
Since the pairing process should be done with both devices online, the pairing request message should have a short TTL. I've set it to 2 minutes. The timeout for receiving the grant message back on the secondary device is 1 minute, so this leaves 30 seconds for messages to travel in each direction.
Also, I've replaced a `if/else if` statement with a `switch` and moved that into a local function to allow returning the values. This makes the thing slightly more robust against forgetting `break`'s, even though usually IDE's and linters pick this error up easily.