### PR TITLE
[multi-device] Secondary registration UX changes

### DIFF
--- a/background.html
+++ b/background.html
@@ -658,8 +658,9 @@
               <div class='standalone-secondary-device-inputs'>
                 <input class='form-control' type='text' id='primary-pubkey' placeholder='Primary Account Public Key' autocomplete='off' spellcheck='false' />
               </div>
+              <div id='pubkey' class='collapse'></div>
               <div id='error' class='collapse'></div>
-              <a class='button' id='register-secondary-device'>Link</a>
+              <button type='button' class='button' id='register-secondary-device'>Link</button>
             </div>
           </div>
 

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -715,12 +715,9 @@ $loading-height: 16px;
     background: $color-loki-green-gradient;
     border-radius: 100px;
 
-    &[disabled='disabled'] {
-      &,
-      &:hover {
-        background: $color-loki-dark-gray;
-        cursor: default;
-      }
+    &:disabled, &:disabled:hover {
+      background: $color-loki-dark-gray;
+      cursor: default;
     }
   }
 

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -714,6 +714,14 @@ $loading-height: 16px;
   .button {
     background: $color-loki-green-gradient;
     border-radius: 100px;
+
+    &[disabled='disabled'] {
+      &,
+      &:hover {
+        background: $color-loki-dark-gray;
+        cursor: default;
+      }
+    }
   }
 
   #mnemonic-display {


### PR DESCRIPTION
- Disabled button after pressed, until timeout or an error occurred.
- Display public key
- Display timeout count down

<img width="561" alt="Screen Shot 2019-08-30 at 11 47 03 am" src="https://user-images.githubusercontent.com/40749766/63987542-fc5cb380-cb1b-11e9-8546-a0fea5385aac.png">
<img width="894" alt="Screen Shot 2019-08-30 at 11 47 11 am" src="https://user-images.githubusercontent.com/40749766/63987854-00d59c00-cb1d-11e9-9d05-fbe48200d030.png">

Also ensure the `secondaryDeviceStatus` is only set while waiting for a response.
So it's cleared at startup and also if the user registers as a new account.
