### PR TITLE
Save the last retrieved message for public chats on the conversation

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -227,7 +227,7 @@
       );
       channel.refreshModStatus();
     });
-  }
+  };
 
   const initAPIs = async () => {
     const ourKey = textsecure.storage.user.getNumber();

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -2079,6 +2079,24 @@
       );
       return channelAPI;
     },
+    getLastRetrievedMessage() {
+      if (!this.isPublic()) {
+        return null;
+      }
+      const lastMessageId = this.get('lastPublicMessage') || 0;
+      return lastMessageId;
+    },
+    async setLastRetrievedMessage(newLastMessageId) {
+      if (!this.isPublic()) {
+        return;
+      }
+      if (this.get('lastPublicMessage') !== newLastMessageId) {
+        this.set({ lastPublicMessage: newLastMessageId });
+        await window.Signal.Data.updateConversation(this.id, this.attributes, {
+          Conversation: Whisper.Conversation,
+        });
+      }
+    },
     isModerator() {
       if (!this.isPublic()) {
         return false;

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -490,8 +490,8 @@ class LokiPublicChannelAPI {
         this.lastGot = !this.lastGot
           ? adnMessage.id
           : Math.max(this.lastGot, adnMessage.id);
-        conversation.setLastRetrievedMessage(this.lastGot);
       });
+      conversation.setLastRetrievedMessage(this.lastGot);
     }
 
     setTimeout(() => {

--- a/js/modules/loki_rss_api.js
+++ b/js/modules/loki_rss_api.js
@@ -49,7 +49,6 @@ class LokiRssAPI extends EventEmitter {
     this.closeable = settings.closeable;
     // non configureable options
     this.feedTimer = null;
-    this.conversationSetup = false;
     // initial set up
     this.getFeed();
   }

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -89,6 +89,7 @@ class LokiSnodeAPI {
   async initialiseRandomPool(seedNodes = [...window.seedNodeList]) {
     const params = {
       limit: 20,
+      active_only: true,
       fields: {
         public_ip: true,
         storage_port: true,


### PR DESCRIPTION
Quick and easy, just want to save the id of the last message we retrieve so we can pick up where we left off on app restart

Also snuck in a cheeky `active_only` flag to the bootstrap node request