### PR TITLE
[multi-device] Cleanup after failed registration

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -588,7 +588,7 @@
       window.log.info('Import was interrupted, showing import error screen');
       appView.openImporter();
     } else if (
-      Whisper.Registration.everDone() &&
+      Whisper.Registration.isDone() &&
       !Whisper.Registration.ongoingSecondaryDeviceRegistration()
     ) {
       // listeners
@@ -711,6 +711,12 @@
       }
     });
 
+    Whisper.events.on('showDevicePairingDialog', async () => {
+      if (appView) {
+        appView.showDevicePairingDialog();
+      }
+    });
+
     Whisper.events.on('calculatingPoW', ({ pubKey, timestamp }) => {
       try {
         const conversation = ConversationController.get(pubKey);
@@ -732,6 +738,15 @@
     Whisper.events.on('password-updated', () => {
       if (appView && appView.inboxView) {
         appView.inboxView.trigger('password-updated');
+      }
+    });
+
+    Whisper.events.on('devicePairingRequestAccepted', async (pubKey, cb) => {
+      try {
+        await getAccountManager().authoriseSecondaryDevice(pubKey);
+        cb(null);
+      } catch (e) {
+        cb(e);
       }
     });
   }

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -177,6 +177,7 @@ module.exports = {
 
   removeAll,
   removeAllConfiguration,
+  removeAllConversations,
 
   removeOtherData,
   cleanupOrphanedAttachments,
@@ -1112,6 +1113,10 @@ async function removeAll() {
 
 async function removeAllConfiguration() {
   await channels.removeAllConfiguration();
+}
+
+async function removeAllConversations() {
+  await channels.removeAllConversations();
 }
 
 async function cleanupOrphanedAttachments() {


### PR DESCRIPTION
- Make sure we clean up right before we register a new account
  - Add `removeAllConversations` to data/sql
  - Allow to stop and restart `Whisper.rotateSignedPreKeyListener`
- validate primary public key before registering new account
- Add missing listeners (ties up previous PR's)