### PR TITLE
[multi-device] Share contact upon authorising secondary device

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -101,7 +101,7 @@ module.exports = {
   updateConversation,
   removeConversation,
   getAllConversations,
-  getPubKeysWithFriendStatus,
+  getConversationsWithFriendStatus,
   getAllConversationIds,
   getAllPrivateConversations,
   getAllGroupsInvolvingId,
@@ -1566,7 +1566,9 @@ async function updateConversation(data) {
 
 async function removeConversation(id) {
   if (!Array.isArray(id)) {
-    await db.run(`DELETE FROM ${CONVERSATIONS_TABLE} WHERE id = $id;`, { $id: id });
+    await db.run(`DELETE FROM ${CONVERSATIONS_TABLE} WHERE id = $id;`, {
+      $id: id,
+    });
     return;
   }
 
@@ -1584,9 +1586,12 @@ async function removeConversation(id) {
 }
 
 async function getConversationById(id) {
-  const row = await db.get(`SELECT * FROM ${CONVERSATIONS_TABLE} WHERE id = $id;`, {
-    $id: id,
-  });
+  const row = await db.get(
+    `SELECT * FROM ${CONVERSATIONS_TABLE} WHERE id = $id;`,
+    {
+      $id: id,
+    }
+  );
 
   if (!row) {
     return null;
@@ -1596,24 +1601,29 @@ async function getConversationById(id) {
 }
 
 async function getAllConversations() {
-  const rows = await db.all(`SELECT json FROM ${CONVERSATIONS_TABLE} ORDER BY id ASC;`);
+  const rows = await db.all(
+    `SELECT json FROM ${CONVERSATIONS_TABLE} ORDER BY id ASC;`
+  );
   return map(rows, row => jsonToObject(row.json));
 }
 
-async function getPubKeysWithFriendStatus(status) {
+async function getConversationsWithFriendStatus(status) {
   const rows = await db.all(
-    `SELECT id FROM ${CONVERSATIONS_TABLE} WHERE
+    `SELECT * FROM ${CONVERSATIONS_TABLE} WHERE
       friendRequestStatus = $status
+      AND type = 'private'
     ORDER BY id ASC;`,
     {
       $status: status,
     }
   );
-  return map(rows, row => row.id);
+  return map(rows, row => jsonToObject(row.json));
 }
 
 async function getAllConversationIds() {
-  const rows = await db.all(`SELECT id FROM ${CONVERSATIONS_TABLE} ORDER BY id ASC;`);
+  const rows = await db.all(
+    `SELECT id FROM ${CONVERSATIONS_TABLE} ORDER BY id ASC;`
+  );
   return map(rows, row => row.id);
 }
 

--- a/js/background.js
+++ b/js/background.js
@@ -1113,11 +1113,18 @@
         }
       }
 
+      // Do not set name to allow working with lokiProfile and nicknames
       conversation.set({
-        name: details.name,
+        // name: details.name,
         color: details.color,
         active_at: activeAt,
       });
+
+      await conversation.setLokiProfile({ displayName: details.name });
+
+      if (details.nickname) {
+        await conversation.setNickname(details.nickname);
+      }
 
       // Update the conversation avatar only if new avatar exists and hash differs
       const { avatar } = details;

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -122,6 +122,7 @@ module.exports = {
 
   getAllConversations,
   getPubKeysWithFriendStatus,
+  getConversationsWithFriendStatus,
   getAllConversationIds,
   getAllPrivateConversations,
   getAllGroupsInvolvingId,
@@ -782,8 +783,20 @@ async function _removeConversations(ids) {
   await channels.removeConversation(ids);
 }
 
+async function getConversationsWithFriendStatus(
+  status,
+  { ConversationCollection }
+) {
+  const conversations = await channels.getConversationsWithFriendStatus(status);
+
+  const collection = new ConversationCollection();
+  collection.add(conversations);
+  return collection;
+}
+
 async function getPubKeysWithFriendStatus(status) {
-  return channels.getPubKeysWithFriendStatus(status);
+  const conversations = await getConversationsWithFriendStatus(status);
+  return conversations.map(row => row.id);
 }
 
 async function getAllConversations({ ConversationCollection }) {

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -39,6 +39,21 @@
     return false;
   }
 
+  function convertVerifiedStatusToProtoState(status) {
+    switch (status) {
+      case VerifiedStatus.VERIFIED:
+        return textsecure.protobuf.Verified.State.VERIFIED;
+
+      case VerifiedStatus.UNVERIFIED:
+        return textsecure.protobuf.Verified.State.VERIFIED;
+
+      case VerifiedStatus.DEFAULT:
+      // intentional fallthrough
+      default:
+        return textsecure.protobuf.Verified.State.DEFAULT;
+    }
+  }
+
   const StaticByteBufferProto = new dcodeIO.ByteBuffer().__proto__;
   const StaticArrayBufferProto = new ArrayBuffer().__proto__;
   const StaticUint8ArrayProto = new Uint8Array().__proto__;
@@ -913,4 +928,5 @@
   window.SignalProtocolStore = SignalProtocolStore;
   window.SignalProtocolStore.prototype.Direction = Direction;
   window.SignalProtocolStore.prototype.VerifiedStatus = VerifiedStatus;
+  window.SignalProtocolStore.prototype.convertVerifiedStatusToProtoState = convertVerifiedStatusToProtoState;
 })();

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -151,7 +151,7 @@
       Whisper.Registration.remove();
       // Do not remove all items since they are only set
       // at startup.
-      textsecure.storage.remove('identityKey')
+      textsecure.storage.remove('identityKey');
       textsecure.storage.remove('secondaryDeviceStatus');
       window.ConversationController.reset();
       await window.ConversationController.load();

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -1,4 +1,4 @@
-/* global window, textsecure, log */
+/* global window, textsecure, log, Whisper, dcodeIO, StringView */
 
 // eslint-disable-next-line func-names
 (function() {
@@ -98,7 +98,66 @@
       type,
     });
   }
-
+  // Serialise as <Element0.length><Element0><Element1.length><Element1>...
+  // This is an implementation of the reciprocal of contacts_parser.js
+  function serialiseByteBuffers(buffers) {
+    const result = new dcodeIO.ByteBuffer();
+    buffers.forEach(buffer => {
+      // bytebuffer container expands and increments
+      // offset automatically
+      result.writeVarint32(buffer.limit);
+      result.append(buffer);
+    });
+    result.limit = result.offset;
+    result.reset();
+    return result;
+  }
+  async function createContactSyncProtoMessage() {
+    const conversations = await window.Signal.Data.getConversationsWithFriendStatus(
+      window.friends.friendRequestStatusEnum.friends,
+      { ConversationCollection: Whisper.ConversationCollection }
+    );
+    // Extract required contacts information out of conversations
+    const rawContacts = conversations.map(conversation => {
+      const profile = conversation.getLokiProfile();
+      const number = conversation.getNumber();
+      const name = profile
+        ? profile.displayName
+        : conversation.getProfileName();
+      const status = conversation.safeGetVerified();
+      const protoState = textsecure.storage.protocol.convertVerifiedStatusToProtoState(
+        status
+      );
+      const verified = new textsecure.protobuf.Verified({
+        state: protoState,
+        destination: number,
+        identityKey: StringView.hexToArrayBuffer(number),
+      });
+      return {
+        name,
+        verified,
+        number,
+        nickname: conversation.getNickname(),
+        blocked: conversation.isBlocked(),
+        expireTimer: conversation.get('expireTimer'),
+      };
+    });
+    // Convert raw contacts to an array of buffers
+    const contactDetails = rawContacts
+      .filter(x => x.number !== textsecure.storage.user.getNumber())
+      .map(x => new textsecure.protobuf.ContactDetails(x))
+      .map(x => x.encode());
+    // Serialise array of byteBuffers into 1 byteBuffer
+    const byteBuffer = serialiseByteBuffers(contactDetails);
+    const data = new Uint8Array(byteBuffer.toArrayBuffer());
+    const contacts = new textsecure.protobuf.SyncMessage.Contacts({
+      data,
+    });
+    const syncMessage = new textsecure.protobuf.SyncMessage({
+      contacts,
+    });
+    return syncMessage;
+  }
   async function sendPairingAuthorisation(authorisation, recipientPubKey) {
     const pairingAuthorisation = createPairingAuthorisationProtoMessage(
       authorisation
@@ -116,10 +175,14 @@
     const dataMessage = new textsecure.protobuf.DataMessage({
       profile,
     });
+    // Attach contact list
+    const syncMessage = await createContactSyncProtoMessage();
     const content = new textsecure.protobuf.Content({
       pairingAuthorisation,
       dataMessage,
+      syncMessage,
     });
+    // Send
     const options = { messageType: 'pairing-request' };
     const p = new Promise((resolve, reject) => {
       const outgoingMessage = new textsecure.OutgoingMessage(
@@ -149,5 +212,6 @@
     broadcastOnlineStatus,
     sendPairingAuthorisation,
     createPairingAuthorisationProtoMessage,
+    createContactSyncProtoMessage,
   };
 })();

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -272,6 +272,7 @@ message SyncMessage {
   message Contacts {
     optional AttachmentPointer blob     = 1;
     optional bool              complete = 2 [default = false];
+    optional bytes             data     = 101;
   }
 
   message Groups {
@@ -365,6 +366,7 @@ message ContactDetails {
   optional bytes    profileKey  = 6;
   optional bool     blocked     = 7;
   optional uint32   expireTimer = 8;
+  optional string   nickname    = 101;
 }
 
 message GroupDetails {


### PR DESCRIPTION
Reuse the existing sync mechanism from signal, at least the receiving side.
The sending side needed to be written, it's mainly a matter of wrapping proto objects inside each others and getting the bytes in the right format (byteBuffer vs ArrayBuffer vs Uint8Array).
I've added a new `data` field in the proto to bypass the need for `attachmentPointer` (Signal treats syncs as attachements that need to be downloaded separately) and added a `nickname` field in contact details.