### PR TITLE
Fix duplicate detection for sent messages in public chat

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1333,6 +1333,10 @@
 
         if (this.isPrivate()) {
           messageWithSchema.destination = destination;
+        } else if (this.isPublic()) {
+          // Public chats require this data to detect duplicates
+          messageWithSchema.source = textsecure.storage.user.getNumber();
+          messageWithSchema.sourceDevice = 1;
         }
         const attributes = {
           ...messageWithSchema,

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -2019,7 +2019,10 @@
                 }
               );
             }
-          } else if (dataMessage.profile) {
+          } else if (
+            source !== textsecure.storage.user.getNumber() &&
+            dataMessage.profile
+          ) {
             ConversationController.getOrCreateAndWait(source, 'private').then(
               sender => {
                 sender.setLokiProfile(dataMessage.profile);


### PR DESCRIPTION
We need to ensure we are treating incoming public chat messages from ourselves as outgoing messages and we also need to make we have all the message data required to detect duplicates