### PR TITLE
Display timestamp for friend requests

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -483,6 +483,7 @@
 
       return {
         text: this.createNonBreakingLastSeparator(this.get('body')),
+        timestamp: this.get('sent_at'),
         status: this.getMessagePropStatus(),
         direction,
         friendStatus,

--- a/ts/components/conversation/FriendRequest.md
+++ b/ts/components/conversation/FriendRequest.md
@@ -5,6 +5,7 @@
 | Name                 | Values                                       |
 | -------------------- | -------------------------------------------- |
 | text                 | string                                       |
+| timstamp             | number                                       |
 | direction            | 'outgoing' \| 'incoming                      |
 | status               | 'sending' \| 'sent' \| 'read' \| 'delivered' |
 | friendStatus         | 'pending' \| 'accepted' \| 'declined'        |
@@ -21,6 +22,7 @@
   <li>
     <FriendRequest
       text="This is my friend request message!"
+      timestamp={1567994022804}
       direction="outgoing"
       status="sending"
       friendStatus="pending"

--- a/ts/components/conversation/FriendRequest.md
+++ b/ts/components/conversation/FriendRequest.md
@@ -5,7 +5,7 @@
 | Name                 | Values                                       |
 | -------------------- | -------------------------------------------- |
 | text                 | string                                       |
-| timstamp             | number                                       |
+| timestamp            | number                                       |
 | direction            | 'outgoing' \| 'incoming                      |
 | status               | 'sending' \| 'sent' \| 'read' \| 'delivered' |
 | friendStatus         | 'pending' \| 'accepted' \| 'declined'        |

--- a/ts/components/conversation/FriendRequest.tsx
+++ b/ts/components/conversation/FriendRequest.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 
 import { LocalizerType } from '../../types/Util';
 import { MessageBody } from './MessageBody';
+import { Timestamp } from './Timestamp';
 
 interface Props {
   text: string;
@@ -11,6 +12,7 @@ interface Props {
   friendStatus: 'pending' | 'accepted' | 'declined' | 'expired';
   i18n: LocalizerType;
   isBlocked: boolean;
+  timestamp: number;
   onAccept: () => void;
   onDecline: () => void;
   onDeleteConversation: () => void;
@@ -142,13 +144,23 @@ export class FriendRequest extends React.Component<Props> {
 
   // Renders 'sending', 'read' icons
   public renderStatusIndicator() {
-    const { direction, status } = this.props;
-    if (direction !== 'outgoing' || status === 'error') {
+    const { direction, status, i18n, text, timestamp } = this.props;
+    if (status === 'error') {
       return null;
     }
 
+    const withImageNoCaption = Boolean(!text);
+
     return (
       <div className="module-message__metadata">
+        <Timestamp
+          i18n={i18n}
+          timestamp={timestamp}
+          extended={true}
+          direction={direction}
+          withImageNoCaption={withImageNoCaption}
+          module="module-message__metadata__date"
+        />
         <span className="module-message__metadata__spacer" />
         <div
           className={classNames(


### PR DESCRIPTION
Fixes  #355.
![Screen Shot 2019-09-09 at 12 02 21 pm](https://user-images.githubusercontent.com/40749766/64498847-cf698700-d2f9-11e9-93d3-81cfb69721d9.png)
<img width="557" alt="Screen Shot 2019-09-09 at 12 02 38 pm" src="https://user-images.githubusercontent.com/40749766/64498850-d2647780-d2f9-11e9-8ab6-26f725f7f7e2.png">
 Then after accepting:
<img width="545" alt="Screen Shot 2019-09-09 at 12 02 48 pm" src="https://user-images.githubusercontent.com/40749766/64498864-da241c00-d2f9-11e9-9c8c-f48a3ca84bb3.png">
