### PR TITLE
Make sure we are always updating the last deleted id

### DIFF
--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -474,14 +474,9 @@ class LokiPublicChannelAPI {
         });
       });
 
-      // if we had a problem break the loop
-      if (res.response.data.length < 200) {
-        break;
-      }
-
       // update where we last checked
       this.deleteLastId = res.response.meta.max_id;
-      ({ more } = res.response);
+      more = res.response.more && res.response.data.length >= params.count;
     }
   }
 


### PR DESCRIPTION
I realised we were hitting the database a ton of times every few seconds, turns out we were constantly trying to delete all the messages that have been deleted because we were exiting a while loop before updating the deletedLastId