### PR TITLE
Fix last hash all being NULL in database

### DIFF
--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -136,8 +136,8 @@ class LokiSnodeAPI {
     await conversation.updateSwarmNodes(filteredNodes);
   }
 
-  async updateLastHash(nodeUrl, lastHash, expiresAt) {
-    await window.Signal.Data.updateLastHash({ nodeUrl, lastHash, expiresAt });
+  async updateLastHash(snode, hash, expiresAt) {
+    await window.Signal.Data.updateLastHash({ snode, hash, expiresAt });
   }
 
   getSwarmNodesForPubKey(pubKey) {


### PR DESCRIPTION
I noticed the `lastHashes` table was showing all `NULL` for the snode and hash rows.
Hopefully this fixes issues related to  UNIQUE key constraints with seen message hashes 🤞 

The related code is in sql.js:
```js
async function updateLastHash(data) {
  const { snode, hash, expiresAt } = data;
```