### PR TITLE
[multi-device] Ensure the latest contact signed prekey is used

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -1169,7 +1169,7 @@ async function getContactSignedPreKeyById(id) {
 }
 async function getContactSignedPreKeyByIdentityKey(key) {
   const row = await db.get(
-    `SELECT * FROM ${CONTACT_SIGNED_PRE_KEYS_TABLE} WHERE identityKeyString = $identityKeyString;`,
+    `SELECT * FROM ${CONTACT_SIGNED_PRE_KEYS_TABLE} WHERE identityKeyString = $identityKeyString ORDER BY keyId DESC;`,
     {
       $identityKeyString: key,
     }

--- a/js/background.js
+++ b/js/background.js
@@ -171,6 +171,8 @@
     return -1;
   };
   Whisper.events = _.clone(Backbone.Events);
+  Whisper.events.isListenedTo = eventName =>
+    Whisper.events._events ? !!Whisper.events._events[eventName] : false;
   let accountManager;
   window.getAccountManager = () => {
     if (!accountManager) {
@@ -756,6 +758,10 @@
       } catch (e) {
         cb(e);
       }
+    });
+
+    Whisper.events.on('devicePairingRequestRejected', async pubKey => {
+      await window.libloki.storage.removeContactPreKeyBundle(pubKey);
     });
   }
 

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -207,6 +207,12 @@
       dialog.once('devicePairingRequestAccepted', (pubKey, cb) =>
         Whisper.events.trigger('devicePairingRequestAccepted', pubKey, cb)
       );
+      dialog.on('devicePairingRequestRejected', (pubKey, cb) =>
+        Whisper.events.trigger('devicePairingRequestRejected', pubKey)
+      );
+      dialog.once('close', () => {
+        Whisper.events.off('devicePairingRequestReceived');
+      });
       this.el.append(dialog.el);
     },
   });

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -207,7 +207,7 @@
       dialog.once('devicePairingRequestAccepted', (pubKey, cb) =>
         Whisper.events.trigger('devicePairingRequestAccepted', pubKey, cb)
       );
-      dialog.on('devicePairingRequestRejected', (pubKey, cb) =>
+      dialog.on('devicePairingRequestRejected', pubKey =>
         Whisper.events.trigger('devicePairingRequestRejected', pubKey)
       );
       dialog.once('close', () => {

--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -58,6 +58,7 @@
       this.$('.requestAcceptedView .ok').show();
     },
     skipDevice() {
+      this.trigger('devicePairingRequestRejected', this.pubKey);
       this.nextPubKey();
       this.showView();
     },
@@ -91,6 +92,10 @@
     },
     close() {
       this.remove();
+      if (this.pubKey && !this.accepted) {
+        this.trigger('devicePairingRequestRejected', this.pubKey);
+      }
+      this.trigger('close');
     },
   });
 })();

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -145,8 +145,6 @@
     },
     async resetRegistration() {
       await window.Signal.Data.removeAllIdentityKeys();
-      await window.Signal.Data.removeAllPreKeys();
-      await window.Signal.Data.removeAllSignedPreKeys();
       await window.Signal.Data.removeAllConversations();
       Whisper.Registration.remove();
       // Do not remove all items since they are only set

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1095,10 +1095,18 @@ MessageReceiver.prototype.extend({
   },
   async handlePairingRequest(envelope, pairingRequest) {
     const valid = await this.validateAuthorisation(pairingRequest);
-    if (valid) {
-      await window.libloki.storage.savePairingAuthorisation(pairingRequest);
+    if (!valid) {
+      return this.removeFromCache(envelope);
+    }
+    await window.libloki.storage.savePairingAuthorisation(pairingRequest);
+    if (Whisper.events.isListenedTo('devicePairingRequestReceived')) {
       Whisper.events.trigger(
         'devicePairingRequestReceived',
+        pairingRequest.secondaryDevicePubKey
+      );
+    } else {
+      Whisper.events.trigger(
+        'devicePairingRequestRejected',
         pairingRequest.secondaryDevicePubKey
       );
     }

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1095,20 +1095,16 @@ MessageReceiver.prototype.extend({
   },
   async handlePairingRequest(envelope, pairingRequest) {
     const valid = await this.validateAuthorisation(pairingRequest);
-    if (!valid) {
-      return this.removeFromCache(envelope);
-    }
-    await window.libloki.storage.savePairingAuthorisation(pairingRequest);
-    if (Whisper.events.isListenedTo('devicePairingRequestReceived')) {
-      Whisper.events.trigger(
-        'devicePairingRequestReceived',
-        pairingRequest.secondaryDevicePubKey
-      );
-    } else {
-      Whisper.events.trigger(
-        'devicePairingRequestRejected',
-        pairingRequest.secondaryDevicePubKey
-      );
+    if (valid) {
+      // Pairing dialog is open and is listening
+      if (Whisper.events.isListenedTo('devicePairingRequestReceived')) {
+        await window.libloki.storage.savePairingAuthorisation(pairingRequest);
+        Whisper.events.trigger(
+          'devicePairingRequestReceived',
+          pairingRequest.secondaryDevicePubKey
+        );
+      }
+      // Ignore requests if the dialog is closed
     }
     return this.removeFromCache(envelope);
   },


### PR DESCRIPTION
This PR fixes the following bug:
- the secondary device sends a first pairing request with a signed prekey id = 1.
- after timeout, the secondary device is allowed to re-send a request. Signed prekeys are wiped and a new signed prekey with id 2 is sent.
- the secondary device accepts but uses the signed prekey with id 1.

Also, improves cleaning up bundles when requests are not accepted.

Removed `removeAllPreKeys` in `resetRegistration` since that already happens inside the registerSingleDevice function.