### PR TITLE
[multi-device] Ensure API objects are inited only once

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -205,7 +205,11 @@
   window.log.info('Storage fetch');
   storage.fetch();
 
+  let initialisedAPI = false;
   const initAPIs = () => {
+    if (initialisedAPI) {
+      return;
+    }
     const ourKey = textsecure.storage.user.getNumber();
     window.lokiMessageAPI = new window.LokiMessageAPI(ourKey);
     window.lokiP2pAPI = new window.LokiP2pAPI(ourKey);
@@ -215,6 +219,7 @@
     });
     window.lokiP2pAPI.on('online', ConversationController._handleOnline);
     window.lokiP2pAPI.on('offline', ConversationController._handleOffline);
+    initialisedAPI = true;
   };
 
   function mapOldThemeToNew(theme) {
@@ -232,6 +237,9 @@
   }
 
   function startLocalLokiServer() {
+    if (window.localLokiServer) {
+      return;
+    }
     const pems = window.getSelfSignedCert();
     window.localLokiServer = new window.LocalLokiServer(pems);
   }


### PR DESCRIPTION
This PR should fix `SQL unique constraints` errors on seen message hashes (bug specific to multi-device branch)
Basically every time the secondary device registration process is triggered, new instances of the API objects are created. But the old objects aren't automatically garbage collected, especially if they were waiting on network events (long polling).
This was basically creating multiple instances of the lokiMessageAPI, which each their own JobQueue, so the calls to save a hash and retrieve the hashes was not atomic across the two JobQueues.
This PR ensures we only instantiate those objects once.