### PR TITLE
Fix unnecessary link preview fetches.

### DIFF
--- a/js/link_previews_helper.js
+++ b/js/link_previews_helper.js
@@ -13,6 +13,9 @@
   window.Signal = window.Signal || {};
   window.Signal.LinkPreviews = window.Signal.LinkPreviews || {};
 
+  // A cache mapping url to fetched previews
+  const previewCache = {};
+
   async function makeChunkedRequest(url) {
     const PARALLELISM = 3;
     const size = await textsecure.messaging.getProxiedSize(url);
@@ -68,7 +71,21 @@
     return StringView.arrayBufferToHex(digest);
   }
 
-  async function getPreview(url) {
+  // Wrapper function which utilizes cache
+  async function getPreview(url, skipCache = false) {
+    // If we have a request cached then use that
+    if (!skipCache && url in previewCache) {
+      return previewCache[url];
+    }
+
+    // Start the request
+    const promise = _getPreview(url);
+    previewCache[url] = promise;
+
+    return promise;
+  }
+
+  async function _getPreview(url) {
     let html;
     try {
       html = await textsecure.messaging.makeProxiedRequest(url);

--- a/js/link_previews_helper.js
+++ b/js/link_previews_helper.js
@@ -79,7 +79,16 @@
     }
 
     // Start the request
-    const promise = _getPreview(url);
+    const promise = _getPreview(url).catch(e => {
+      window.log.error(e);
+
+      // If we get an error then we can purge the cache
+      if (url in previewCache) {
+        delete previewCache[url];
+      }
+
+      return null;
+    });
     previewCache[url] = promise;
 
     return promise;
@@ -91,7 +100,7 @@
       html = await textsecure.messaging.makeProxiedRequest(url);
     } catch (error) {
       if (error.code >= 300) {
-        return null;
+        throw new Error(`Failed to fetch html: ${error}`);
       }
     }
 

--- a/ts/components/JazzIcon/JazzIcon.tsx
+++ b/ts/components/JazzIcon/JazzIcon.tsx
@@ -94,7 +94,11 @@ export class JazzIcon extends React.PureComponent<Props> {
   private hueShift(colors: Array<string>, generator: RNG) {
     const amount = generator.random() * 30 - wobble / 2;
 
-    return colors.map(hex => Color(hex).rotate(amount).hex());
+    return colors.map(hex =>
+      Color(hex)
+        .rotate(amount)
+        .hex()
+    );
   }
 
   private genShape(


### PR DESCRIPTION
Since signal moved to React, any update to the message component triggers a link preview fetch if it didn't exist. This meant that for every link preview we generating about 3 or 4 requests which then save the image to disk. So for each link preview we had 3-4 images on disk.

To fix this we just create a local memory cache and return already fetched requests from there.