### PR TITLE
[multi-device] Search returns primary device conversation

### DIFF
--- a/js/modules/data.d.ts
+++ b/js/modules/data.d.ts
@@ -1,2 +1,3 @@
 export function searchMessages(query: string): Promise<Array<any>>;
 export function searchConversations(query: string): Promise<Array<any>>;
+export function getPrimaryDeviceFor(pubKey: string): Promise<string | null>;

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -93,6 +93,8 @@ module.exports = {
   getGrantAuthorisationForPubKey,
   getAuthorisationForPubKey,
   getSecondaryDevicesFor,
+  getPrimaryDeviceFor,
+  getPairedDevicesFor,
 
   createOrUpdateItem,
   getItemById,
@@ -627,8 +629,16 @@ async function getAuthorisationForPubKey(pubKey) {
   };
 }
 
-function getSecondaryDevicesFor(primareyDevicePubKey) {
-  return channels.getSecondaryDevicesFor(primareyDevicePubKey);
+function getSecondaryDevicesFor(primaryDevicePubKey) {
+  return channels.getSecondaryDevicesFor(primaryDevicePubKey);
+}
+
+function getPrimaryDeviceFor(secondaryDevicePubKey) {
+  return channels.getPrimaryDeviceFor(secondaryDevicePubKey);
+}
+
+function getPairedDevicesFor(pubKey) {
+  return channels.getPairedDevicesFor(pubKey);
 }
 
 // Items

--- a/ts/components/MainHeader.tsx
+++ b/ts/components/MainHeader.tsx
@@ -13,6 +13,7 @@ import { ContactName } from './conversation/ContactName';
 
 import { cleanSearchTerm } from '../util/cleanSearchTerm';
 import { LocalizerType } from '../types/Util';
+import { SearchOptions } from '../types/Search';
 import { clipboard } from 'electron';
 
 import { validateNumber } from '../types/PhoneNumber';
@@ -37,18 +38,11 @@ export interface Props {
   verified: boolean;
   profileName?: string;
   avatarPath?: string;
-  isSecondaryDevice?: boolean;
+  isSecondaryDevice: boolean;
 
   i18n: LocalizerType;
   updateSearchTerm: (searchTerm: string) => void;
-  search: (
-    query: string,
-    options: {
-      regionCode: string;
-      ourNumber: string;
-      noteToSelf: string;
-    }
-  ) => void;
+  search: (query: string, options: SearchOptions) => void;
   clearSearch: () => void;
 
   onClick?: () => void;
@@ -110,12 +104,20 @@ export class MainHeader extends React.Component<Props, any> {
   }
 
   public search() {
-    const { searchTerm, search, i18n, ourNumber, regionCode } = this.props;
+    const {
+      searchTerm,
+      search,
+      i18n,
+      ourNumber,
+      regionCode,
+      isSecondaryDevice,
+    } = this.props;
     if (search) {
       search(searchTerm, {
         noteToSelf: i18n('noteToSelf').toLowerCase(),
         ourNumber,
         regionCode,
+        isSecondaryDevice,
       });
     }
   }

--- a/ts/types/Search.ts
+++ b/ts/types/Search.ts
@@ -1,0 +1,6 @@
+export type SearchOptions = {
+  regionCode: string;
+  ourNumber: string;
+  noteToSelf: string;
+  isSecondaryDevice: boolean;
+};


### PR DESCRIPTION
This PR prevents users to send messages directly to their other devices.
They should do it via the "Note to self" (aka their own conversation).
So in case they type one of their other device's pubkey in the searchbar, it actually shows the "Note to Self" conversation.

This works for other contacts too: Searching any paired pubkey will return the primary device conversation only.