### PR TITLE
Public chat duplicate message fix

### DIFF
--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -9,6 +9,7 @@ const PUBLICCHAT_MSG_POLL_EVERY = 1.5 * 1000; // 1.5s
 const PUBLICCHAT_CHAN_POLL_EVERY = 20 * 1000; // 20s
 const PUBLICCHAT_DELETION_POLL_EVERY = 5 * 1000; // 5s
 const PUBLICCHAT_MOD_POLL_EVERY = 30 * 1000; // 30s
+const PUBLICCHAT_MIN_TIME_BETWEEN_DUPLICATE_MESSAGES = 10 * 1000; // 10s
 
 // singleton to relay events to libtextsecure/message_receiver
 class LokiPublicChatAPI extends EventEmitter {
@@ -585,7 +586,8 @@ class LokiPublicChannelAPI {
           const sameText = message.text === adnMessage.text;
           // Don't filter out messages that are too far apart from each other
           const timestampsSimilar =
-            Math.abs(message.timestamp - timestamp) <= 10000;
+            Math.abs(message.timestamp - timestamp) <=
+            PUBLICCHAT_MIN_TIME_BETWEEN_DUPLICATE_MESSAGES;
 
           return sameUsername && sameText && timestampsSimilar;
         };

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -580,6 +580,7 @@ class LokiPublicChannelAPI {
 
         // Duplicate check
         const isDuplicate = message => {
+          // The username in this case is the users pubKey
           const sameUsername = message.username === adnMessage.user.username;
           const sameText = message.text === adnMessage.text;
           // Don't filter out messages that are too far apart from each other


### PR DESCRIPTION
This PR makes it so any similar messages fetched through the public chat will be ignored if:
The same author posted the message, The message has the same text AND the message was sent within 10 seconds.

This will alleviate the display of spam somewhat but is not the perfect counter measure as someone could spam the same message every 10 seconds.

Fixes #504 