### PR TITLE
[multi-device] Display list of paired device in modal

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -926,6 +926,30 @@
   "cancel": {
     "message": "Cancel"
   },
+  "skip": {
+    "message": "Skip"
+  },
+  "close": {
+    "message": "Close"
+  },
+  "pairNewDevice": {
+    "message": "Pair new Device"
+  },
+  "devicePairingAccepted": {
+    "message": "Device Pairing Accepted"
+  },
+  "devicePairingReceived": {
+    "message": "Device Pairing Received"
+  },
+  "waitingForDeviceToRegister": {
+    "message": "Waiting for device to register..."
+  },
+  "pairedDevices": {
+    "message": "Paired Devices"
+  },
+  "allowPairing": {
+    "message": "Allow Pairing"
+  },
   "clear": {
     "message": "Clear"
   },

--- a/background.html
+++ b/background.html
@@ -247,8 +247,21 @@
   </script>
   <script type='text/x-tmpl-mustache' id='device-pairing-dialog'>
     <div class="content">
+
+      <!-- Default view -->
+      <div class="defaultView">
+        <h4>{{ defaultTitle }}</h4>
+        <ul id="pairedPubKeys">
+          <li>No paired devices</li>
+        </ul>
+        <div class='buttons'>
+          <button id='close' tabindex='2'>{{ closeText }}</button>
+          <button id="startPairing" tabindex='1'>{{ startPairingText }}</button>
+        </div>
+      </div>
+
       <!-- Waiting for request -->
-      <div class="waitingForRequestView">
+      <div class="waitingForRequestView" style="display: none;">
         <h4>{{ waitingForRequestTitle }}</h4>
         <div class='buttons'>
           <button class="cancel">{{ cancelText }}</button>
@@ -269,7 +282,6 @@
       <!-- Request accepted -->
       <div class="requestAcceptedView" style="display: none;">
         <h4>{{ requestAcceptedTitle }}</h4>
-        Sending pairing authorisation to:
         <p class="secretWords"></p>
         <p class="transmissionStatus">Please be patient...</p>
         <div class='buttons'>
@@ -660,7 +672,7 @@
                 </br>
                 Open the Loki Messenger App on your Primary Device
               </br>
-                and select "Pair New Device" in the main menu.
+                and select "Device Pairing" in the main menu.
               </p>
               <div class='standalone-secondary-device-inputs'>
                 <input class='form-control' type='text' id='primary-pubkey' placeholder='Primary Account Public Key' autocomplete='off' spellcheck='false' />

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -202,12 +202,17 @@
     },
     showDevicePairingDialog() {
       const dialog = new Whisper.DevicePairingDialogView();
-      // remove all listeners for this events is fine since the
-      // only listener is right below.
-      Whisper.events.off('devicePairingRequestReceived');
-      Whisper.events.on('devicePairingRequestReceived', pubKey =>
-        dialog.requestReceived(pubKey)
-      );
+
+      dialog.on('startReceivingRequests', () => {
+        Whisper.events.on('devicePairingRequestReceived', pubKey =>
+          dialog.requestReceived(pubKey)
+        );
+      });
+
+      dialog.on('stopReceivingRequests', () => {
+        Whisper.events.off('devicePairingRequestReceived');
+      });
+
       dialog.once('devicePairingRequestAccepted', (pubKey, cb) =>
         Whisper.events.trigger('devicePairingRequestAccepted', pubKey, cb)
       );

--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -82,7 +82,7 @@
       // FIFO: pop at the back of the array using pop()
       this.pubKey = this.pubKeyRequests.pop();
     },
-    showView() {
+    async showView() {
       const defaultView = this.$('.defaultView');
       const waitingForRequestView = this.$('.waitingForRequestView');
       const requestReceivedView = this.$('.requestReceivedView');
@@ -93,15 +93,13 @@
         requestReceivedView.hide();
         waitingForRequestView.hide();
         requestAcceptedView.hide();
-        // eslint-disable-next-line more/no-then
-        libloki.storage.getSecondaryDevicesFor(ourPubKey).then(pubKeys => {
-          if (pubKeys && pubKeys.length > 0) {
-            this.$('#pairedPubKeys').empty();
-            pubKeys.forEach(x => {
-              this.$('#pairedPubKeys').append(`<li>${x}</li>`);
-            });
-          }
-        });
+        const pubKeys = await libloki.storage.getSecondaryDevicesFor(ourPubKey);
+        if (pubKeys && pubKeys.length > 0) {
+          this.$('#pairedPubKeys').empty();
+          pubKeys.forEach(x => {
+            this.$('#pairedPubKeys').append(`<li>${x}</li>`);
+          });
+        }
       } else if (this.accepted) {
         defaultView.hide();
         requestReceivedView.hide();

--- a/libloki/storage.js
+++ b/libloki/storage.js
@@ -125,10 +125,13 @@
     return window.Signal.Data.getAuthorisationForPubKey(secondaryPubKey);
   }
 
+  function getSecondaryDevicesFor(primaryDevicePubKey) {
+    return window.Signal.Data.getSecondaryDevicesFor(primaryDevicePubKey);
+  }
+
   async function getAllDevicePubKeysForPrimaryPubKey(primaryDevicePubKey) {
     const secondaryPubKeys =
-      (await window.Signal.Data.getSecondaryDevicesFor(primaryDevicePubKey)) ||
-      [];
+      (await getSecondaryDevicesFor(primaryDevicePubKey)) || [];
     return secondaryPubKeys.concat(primaryDevicePubKey);
   }
 
@@ -141,6 +144,7 @@
     getGrantAuthorisationForSecondaryPubKey,
     getAuthorisationForSecondaryPubKey,
     getAllDevicePubKeysForPrimaryPubKey,
+    getSecondaryDevicesFor,
   };
 
   // Libloki protocol store

--- a/ts/components/MainHeader.tsx
+++ b/ts/components/MainHeader.tsx
@@ -369,7 +369,7 @@ export class MainHeader extends React.Component<Props, any> {
     if (!isSecondaryDevice) {
       menuItems.push({
         id: 'pairNewDevice',
-        name: 'Pair new Device',
+        name: 'Device Pairing',
         onClick: () => {
           trigger('showDevicePairingDialog');
         },


### PR DESCRIPTION
Renamed "Pair new Device" to "Device Pairing" in main menu.
Added a new view in the pairing modal, showing a list of paired devices.
Going through the whole pairing procedure takes the user back to the default view, where the new pubkey can be seen in the list.
Also used locale messages for text.

<img width="908" alt="Screen Shot 2019-09-16 at 6 15 55 pm" src="https://user-images.githubusercontent.com/40749766/64943113-3664de00-d8ae-11e9-852c-631db87c4a90.png">
