### PR TITLE
Add UI elements for searching and selecting members in a group chat

### DIFF
--- a/background.html
+++ b/background.html
@@ -126,6 +126,7 @@
 
       <div class='bottom-bar' id='footer'>
           <div class='emoji-panel-container'></div>
+          <div class='member-list-container'></div>
           <div class='attachment-list'></div>
           <div class='compose'>
             <form class='send clearfix file-input'>
@@ -681,6 +682,7 @@
   <script type='text/javascript' src='js/views/message_view.js'></script>
   <script type='text/javascript' src='js/views/key_verification_view.js'></script>
   <script type='text/javascript' src='js/views/message_list_view.js'></script>
+  <script type='text/javascript' src='js/views/member_list_view.js'></script>
   <script type='text/javascript' src='js/views/group_member_list_view.js'></script>
   <script type='text/javascript' src='js/views/recorder_view.js'></script>
   <script type='text/javascript' src='js/views/conversation_view.js'></script>

--- a/js/modules/signal.js
+++ b/js/modules/signal.js
@@ -43,6 +43,7 @@ const {
 const { Lightbox } = require('../../ts/components/Lightbox');
 const { LightboxGallery } = require('../../ts/components/LightboxGallery');
 const { MainHeader } = require('../../ts/components/MainHeader');
+const { MemberList } = require('../../ts/components/conversation/MemberList');
 const {
   MediaGallery,
 } = require('../../ts/components/conversation/media-gallery/MediaGallery');
@@ -217,6 +218,7 @@ exports.setup = (options = {}) => {
     Lightbox,
     LightboxGallery,
     MainHeader,
+    MemberList,
     MediaGallery,
     Message,
     MessageBody,

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -1583,7 +1583,7 @@
     },
 
     async handleSubmitPressed(e, options = {}) {
-      if (this.memberView.members_shown()) {
+      if (this.memberView.membersShown()) {
         const member = this.memberView.selectedMember();
         this.selectMember(member);
       } else {
@@ -2173,7 +2173,7 @@
 
       const preventDefault = keyPressedUp || keyPressedDown || keyPressedTab;
 
-      if (this.memberView.members_shown() && preventDefault) {
+      if (this.memberView.membersShown() && preventDefault) {
         if (keyPressedDown) {
           this.memberView.selectDown();
         } else if (keyPressedUp) {
@@ -2232,10 +2232,7 @@
           : '';
         const query = caseSensitiveQuery.toLowerCase();
 
-        if (
-          authorPhoneNumber.indexOf(query) !== -1 ||
-          profileName.indexOf(query) !== -1
-        ) {
+        if (authorPhoneNumber.includes(query) || profileName.includes(query)) {
           return true;
         }
         return false;
@@ -2273,14 +2270,14 @@
       allMembers = _.uniq(allMembers, true, d => d.authorPhoneNumber);
 
       let membersToShow = [];
-      if (query === null) {
-        // do nothing
-      } else if (query !== '') {
-        membersToShow = allMembers.filter(filterMembers.bind(null, query));
-      } else {
-        membersToShow = allMembers;
+      if (query) {
+        membersToShow =
+          query !== ''
+            ? allMembers.filter(m => filterMembers(query, m))
+            : allMembers;
       }
-      this.memberView.update_members(membersToShow);
+
+      this.memberView.updateMembers(membersToShow);
     },
 
     forceUpdateMessageFieldSize(event) {

--- a/js/views/member_list_view.js
+++ b/js/views/member_list_view.js
@@ -1,0 +1,65 @@
+/* global _, Whisper, */
+
+// eslint-disable-next-line func-names
+(function() {
+  'use strict';
+
+  window.Whisper = window.Whisper || {};
+
+  Whisper.MemberListView = Whisper.View.extend({
+    initialize(options) {
+      this.member_list = [];
+      this.selected_idx = 0;
+      this.onClicked = options.onClicked;
+
+      this.listenTo(this.model, 'change', this.render);
+    },
+    render() {
+      if (this.memberView) {
+        this.memberView.remove();
+        this.memberView = null;
+      }
+
+      this.memberView = new Whisper.ReactWrapperView({
+        className: 'member-list',
+        Component: window.Signal.Components.MemberList,
+        props: {
+          members: this.member_list,
+          selected: this.selectedMember(),
+          onMemberClicked: this.handleMemberClicked.bind(this),
+        },
+      });
+
+      this.$el.append(this.memberView.el);
+      return this;
+    },
+    handleMemberClicked(member) {
+      this.onClicked(member);
+    },
+    update_members(members) {
+      if (!_.isEqual(this.member_list, members)) {
+        // Whenever the list is updated, we reset the selection
+        this.selected_idx = 0;
+        this.member_list = members;
+        this.render();
+      }
+    },
+    members_shown() {
+      return this.member_list.length !== 0;
+    },
+    selectUp() {
+      this.selected_idx = Math.max(this.selected_idx - 1, 0);
+      this.render();
+    },
+    selectDown() {
+      this.selected_idx = Math.min(
+        this.selected_idx + 1,
+        this.member_list.length - 1
+      );
+      this.render();
+    },
+    selectedMember() {
+      return this.member_list[this.selected_idx];
+    },
+  });
+})();

--- a/js/views/member_list_view.js
+++ b/js/views/member_list_view.js
@@ -35,7 +35,7 @@
     handleMemberClicked(member) {
       this.onClicked(member);
     },
-    update_members(members) {
+    updateMembers(members) {
       if (!_.isEqual(this.member_list, members)) {
         // Whenever the list is updated, we reset the selection
         this.selected_idx = 0;
@@ -43,7 +43,7 @@
         this.render();
       }
     },
-    members_shown() {
+    membersShown() {
       return this.member_list.length !== 0;
     },
     selectUp() {

--- a/js/views/member_list_view.js
+++ b/js/views/member_list_view.js
@@ -11,8 +11,7 @@
       this.member_list = [];
       this.selected_idx = 0;
       this.onClicked = options.onClicked;
-
-      this.listenTo(this.model, 'change', this.render);
+      this.render();
     },
     render() {
       if (this.memberView) {

--- a/stylesheets/_mentions.scss
+++ b/stylesheets/_mentions.scss
@@ -1,0 +1,49 @@
+.member-list-container {
+  margin: 0;
+  padding: 0;
+
+  max-height: 240px;
+  overflow-y: scroll;
+
+  .member-item {
+    padding: 4px;
+    user-select: none;
+
+    &:hover:not(.member-selected) {
+      background-color: $color-light-20;
+    }
+
+    background-color: $color-light-10;
+
+    .name-part {
+      font-weight: 300;
+      margin-left: 6px;
+    }
+
+    .pubkey-part {
+      margin-left: 6px;
+    }
+  }
+
+  .member-selected {
+    background-color: $color-light-35;
+  }
+}
+
+.dark-theme {
+  .member-list-container {
+    .member-item {
+      &:hover:not(.member-selected) {
+        background-color: $color-dark-55;
+      }
+
+      background-color: $color-dark-70;
+
+      color: white;
+    }
+
+    .member-selected {
+      background-color: $color-dark-60;
+    }
+  }
+}

--- a/stylesheets/_variables.scss
+++ b/stylesheets/_variables.scss
@@ -114,6 +114,7 @@ $color-white-08: rgba($color-white, 0.8);
 $color-white-085: rgba($color-white, 0.85);
 $color-light-02: #f9fafa;
 $color-light-10: #eeefef;
+$color-light-20: #c1c5cd;
 $color-light-35: #a4a6a9;
 $color-light-45: #8b8e91;
 $color-light-60: #62656a;

--- a/stylesheets/manifest.scss
+++ b/stylesheets/manifest.scss
@@ -10,6 +10,7 @@
 @import 'lightbox';
 @import 'recorder';
 @import 'emoji';
+@import 'mentions';
 @import 'settings';
 @import 'password';
 

--- a/test/index.html
+++ b/test/index.html
@@ -555,6 +555,7 @@
   <script type='text/javascript' src='../js/views/message_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/key_verification_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/message_list_view.js' data-cover></script>
+  <script type='text/javascript' src='../js/views/member_list_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/group_member_list_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/recorder_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/conversation_view.js' data-cover></script>

--- a/ts/components/conversation/MemberList.tsx
+++ b/ts/components/conversation/MemberList.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import classNames from 'classnames';
+import { Avatar } from '../Avatar';
+
+interface MemberItemProps {
+  member: any;
+  selected: Boolean;
+  onClicked: any;
+}
+
+class MemberItem extends React.Component<MemberItemProps> {
+  constructor(props: any) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  public render() {
+    const name = this.props.member.authorProfileName;
+    const pubkey = this.props.member.authorPhoneNumber;
+    const selected = this.props.selected;
+
+    return (
+      <div
+        role="button"
+        className={classNames(
+          'member-item',
+          selected ? 'member-selected' : null
+        )}
+        onClick={this.handleClick}
+      >
+        {this.renderAvatar()}
+        <span className="name-part">{name}</span>
+        <span className="pubkey-part">{pubkey}</span>
+      </div>
+    );
+  }
+
+  private handleClick() {
+    this.props.onClicked(this.props.member);
+  }
+
+  private renderAvatar() {
+    return (
+      <Avatar
+        avatarPath={this.props.member.authorAvatarPath}
+        color={this.props.member.authorColor}
+        conversationType="direct"
+        i18n={this.props.member.i18n}
+        name={this.props.member.authorName}
+        phoneNumber={this.props.member.authorPhoneNumber}
+        profileName={this.props.member.authorProfileName}
+        size={28}
+      />
+    );
+  }
+}
+
+interface MemberListProps {
+  members: [any];
+  selected: any;
+  onMemberClicked: any;
+}
+
+export class MemberList extends React.Component<MemberListProps> {
+  constructor(props: any) {
+    super(props);
+
+    this.handleMemberClicked = this.handleMemberClicked.bind(this);
+  }
+
+  public render() {
+    const { members } = this.props;
+
+    const itemList = members.map(item => {
+      const selected = item === this.props.selected;
+
+      return (
+        <MemberItem
+          key={item.id}
+          member={item}
+          selected={selected}
+          onClicked={this.handleMemberClicked}
+        />
+      );
+    });
+
+    return <div>{itemList}</div>;
+  }
+
+  private handleMemberClicked(member: any) {
+    this.props.onMemberClicked(member);
+  }
+}


### PR DESCRIPTION
Decided to split the PR for mentions into two. This is part 1 that includes the following:

- typing `@` brings a group member selection element into view (scrollable, can be navigated with up/down arrows)
- the word directly following `@` is considered the search query used for filtering the list of members
- `Tab`, `Enter` or left mouse click selects a member, which replaces the query with the member's pubkey.

In the upcoming PR I will work on the presentation of pubkeys (replace them with Profile names). Probably will need to rework the input element to allow formatting. Also, currently I obtain the list of members from the conversation model. This will need to be changed to use a server endpoint for the full list of members that joined the chat.