### PR TITLE
set active_at to now() for public channels

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -802,12 +802,13 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
   );
 
   const initConversation = async data => {
-    const { id, type, name, friendRequestStatus } = data;
+    // eslint-disable-next-line camelcase
+    const { id, active_at, type, name, friendRequestStatus } = data;
     await instance.run(
       `INSERT INTO conversations (
       id,
       json,
-
+      active_at,
       type,
       members,
       name,
@@ -815,7 +816,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
     ) values (
       $id,
       $json,
-
+      $active_at,
       $type,
       $members,
       $name,
@@ -824,7 +825,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
       {
         $id: id,
         $json: objectToJSON(data),
-
+        $active_at: active_at,
         $type: type,
         $members: null,
         $name: name,
@@ -841,6 +842,7 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
   console.log('lokiPublicServerData', lokiPublicServerData);
 
   const baseData = {
+    active_at: Date.now(),
     friendRequestStatus: 4, // Friends
     sealedSender: 0,
     sessionResetStatus: 0,


### PR DESCRIPTION
The `active_at` field determines if the conversation should be visible or not (when null), and gets assigned a timestamp when receiving messages.
This fixes the edge case where there is no message (e.g. they were all deleted or filtered out due to invalid signatures) which never triggers the creation of the active_at field.
