### PR TITLE
[multi-device] Add high-level function to update device mapping

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -828,7 +828,9 @@
 
     Whisper.events.on('devicePairingRequestRejected', async pubKey => {
       await window.libloki.storage.removeContactPreKeyBundle(pubKey);
-      await window.libloki.storage.removePairingAuthorisationForSecondaryPubKey(pubKey);
+      await window.libloki.storage.removePairingAuthorisationForSecondaryPubKey(
+        pubKey
+      );
     });
   }
 

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -91,8 +91,9 @@ module.exports = {
 
   createOrUpdatePairingAuthorisation,
   removePairingAuthorisationForSecondaryPubKey,
-  getGrantAuthorisationForPubKey,
-  getAuthorisationForPubKey,
+  getGrantAuthorisationForSecondaryPubKey,
+  getAuthorisationForSecondaryPubKey,
+  getGrantAuthorisationsForPrimaryPubKey,
   getSecondaryDevicesFor,
   getPrimaryDeviceFor,
   getPairedDevicesFor,
@@ -609,38 +610,24 @@ async function createOrUpdatePairingAuthorisation(data) {
 }
 
 async function removePairingAuthorisationForSecondaryPubKey(pubKey) {
-  if (!pubKey){
+  if (!pubKey) {
     return;
   }
   await channels.removePairingAuthorisationForSecondaryPubKey(pubKey);
 }
 
-async function getGrantAuthorisationForPubKey(pubKey) {
-  const authorisation = await channels.getAuthorisationForPubKey(pubKey, {
+async function getGrantAuthorisationForSecondaryPubKey(pubKey) {
+  return channels.getAuthorisationForSecondaryPubKey(pubKey, {
     granted: true,
   });
-  if (!authorisation) {
-    return null;
-  }
-  return {
-    ...authorisation,
-    requestSignature: base64ToArrayBuffer(authorisation.requestSignature),
-    grantSignature: base64ToArrayBuffer(authorisation.grantSignature),
-  };
 }
 
-async function getAuthorisationForPubKey(pubKey) {
-  const authorisation = await channels.getAuthorisationForPubKey(pubKey);
-  if (!authorisation) {
-    return null;
-  }
-  return {
-    ...authorisation,
-    requestSignature: base64ToArrayBuffer(authorisation.requestSignature),
-    grantSignature: authorisation.grantSignature
-      ? base64ToArrayBuffer(authorisation.grantSignature)
-      : null,
-  };
+async function getGrantAuthorisationsForPrimaryPubKey(pubKey) {
+  return channels.getGrantAuthorisationsForPrimaryPubKey(pubKey);
+}
+
+function getAuthorisationForSecondaryPubKey(pubKey) {
+  return channels.getAuthorisationForSecondaryPubKey(pubKey);
 }
 
 function getSecondaryDevicesFor(primaryDevicePubKey) {

--- a/libloki/storage.js
+++ b/libloki/storage.js
@@ -1,4 +1,4 @@
-/* global window, libsignal, textsecure */
+/* global window, libsignal, textsecure, Signal */
 
 // eslint-disable-next-line func-names
 (function() {
@@ -118,15 +118,47 @@
   }
 
   function removePairingAuthorisationForSecondaryPubKey(pubKey) {
-    return window.Signal.Data.removePairingAuthorisationForSecondaryPubKey(pubKey);
+    return window.Signal.Data.removePairingAuthorisationForSecondaryPubKey(
+      pubKey
+    );
   }
 
-  function getGrantAuthorisationForSecondaryPubKey(secondaryPubKey) {
-    return window.Signal.Data.getGrantAuthorisationForPubKey(secondaryPubKey);
+  // Transforms signatures from base64 to ArrayBuffer!
+  async function getGrantAuthorisationForSecondaryPubKey(secondaryPubKey) {
+    const authorisation = await window.Signal.Data.getGrantAuthorisationForSecondaryPubKey(
+      secondaryPubKey
+    );
+    if (!authorisation) {
+      return null;
+    }
+    return {
+      ...authorisation,
+      requestSignature: Signal.Crypto.base64ToArrayBuffer(
+        authorisation.requestSignature
+      ),
+      grantSignature: Signal.Crypto.base64ToArrayBuffer(
+        authorisation.grantSignature
+      ),
+    };
   }
 
-  function getAuthorisationForSecondaryPubKey(secondaryPubKey) {
-    return window.Signal.Data.getAuthorisationForPubKey(secondaryPubKey);
+  // Transforms signatures from base64 to ArrayBuffer!
+  async function getAuthorisationForSecondaryPubKey(secondaryPubKey) {
+    const authorisation = await window.Signal.Data.getAuthorisationForSecondaryPubKey(
+      secondaryPubKey
+    );
+    if (!authorisation) {
+      return null;
+    }
+    return {
+      ...authorisation,
+      requestSignature: Signal.Crypto.base64ToArrayBuffer(
+        authorisation.requestSignature
+      ),
+      grantSignature: authorisation.grantSignature
+        ? Signal.Crypto.base64ToArrayBuffer(authorisation.grantSignature)
+        : null,
+    };
   }
 
   function getSecondaryDevicesFor(primaryDevicePubKey) {


### PR DESCRIPTION
This PR
- wraps the existing `setOurDeviceMapping(mapping, isPrimary)` around a new function `updateOurDeviceMapping()` which fetches the mapping and call the former.
- Renames a bunch of function `***ForPubKey` to `***ForSecondaryPubKey` to be more explicit
- Adds missing `getGrantAuthorisationForPrimaryPubKey` that will be used in a future PR
- Makes the authorisation getters from `Signa.Datal` return the signatures as is (base64) and makes the getters from `libloki.storage` converts them to ArrayBuffer.