### PR TITLE
[multi-device] Remove private convs only

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -115,6 +115,7 @@ module.exports = {
   getAllPrivateConversations,
   getAllGroupsInvolvingId,
   removeAllConversations,
+  removeAllPrivateConversations,
 
   searchConversations,
   searchMessages,
@@ -2655,6 +2656,10 @@ async function removeAllConfiguration() {
 
 async function removeAllConversations() {
   await removeAllFromTable(CONVERSATIONS_TABLE);
+}
+
+async function removeAllPrivateConversations() {
+  await db.run(`DELETE FROM ${CONVERSATIONS_TABLE} WHERE type = 'private'`);
 }
 
 async function getMessagesNeedingUpgrade(limit, { maxVersion }) {

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -188,6 +188,7 @@ module.exports = {
   removeAll,
   removeAllConfiguration,
   removeAllConversations,
+  removeAllPrivateConversations,
 
   removeOtherData,
   cleanupOrphanedAttachments,
@@ -1201,6 +1202,10 @@ async function removeAllConfiguration() {
 
 async function removeAllConversations() {
   await channels.removeAllConversations();
+}
+
+async function removeAllPrivateConversations() {
+  await channels.removeAllPrivateConversations();
 }
 
 async function cleanupOrphanedAttachments() {

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -145,7 +145,7 @@
     },
     async resetRegistration() {
       await window.Signal.Data.removeAllIdentityKeys();
-      await window.Signal.Data.removeAllConversations();
+      await window.Signal.Data.removeAllPrivateConversations();
       Whisper.Registration.remove();
       // Do not remove all items since they are only set
       // at startup.


### PR DESCRIPTION
During second device registration, the logic has to reset the database after any failures.
But since the sql migrations only runs the very first time, we can't remove the public conversations that we want to keep.