### PR TITLE
[multi-device] Reset pairing view after error

### DIFF
--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -11,12 +11,14 @@
     templateName: 'device-pairing-dialog',
     initialize() {
       this.pubKeyRequests = [];
+      this.reset();
+      this.render();
+      this.showView();
+    },
+    reset() {
       this.pubKey = null;
       this.accepted = false;
       this.isListening = false;
-      this.view = '';
-      this.render();
-      this.showView();
     },
     events: {
       'click #startPairing': 'startReceivingRequests',
@@ -47,7 +49,7 @@
     },
     stopReceivingRequests() {
       this.trigger('stopReceivingRequests');
-      this.isListening = false;
+      this.reset();
       this.showView();
     },
     requestReceived(secondaryDevicePubKey) {


### PR DESCRIPTION
I noticed a bug after a failed pairing, the primary device would keep showing the error message when trying again to receive a new pairing request. Turned out some the internal state was not reset.