### PR TITLE
[multi-device] Start all the receivers only after the secondary registration is fini…

### DIFF
--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -19,6 +19,10 @@ class LokiAppDotNetAPI extends EventEmitter {
     this.myPrivateKey = false;
   }
 
+  async close() {
+    await Promise.all(this.servers.map(server => server.close()));
+  }
+
   async getPrivateKey() {
     if (!this.myPrivateKey) {
       const myKeyPair = await textsecure.storage.protocol.getIdentityKeyPair();
@@ -87,6 +91,13 @@ class LokiAppDotNetServerAPI {
       ref.token = await ref.getOrRefreshServerToken();
       log.info(`set token ${ref.token}`);
     })();
+  }
+
+  async close() {
+    this.channels.forEach(channel => channel.stop());
+    if (this.tokenPromise) {
+      await this.tokenPromise;
+    }
   }
 
   // channel getter/factory

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -141,6 +141,8 @@
       clearInterval(this.pairingInterval);
       // Ensure the left menu is updated
       Whisper.events.trigger('userChanged', { isSecondaryDevice: true });
+      // will re-run the background initialisation
+      Whisper.events.trigger('registration_done');
       this.$el.trigger('openInbox');
     },
     async resetRegistration() {


### PR DESCRIPTION
Fixes #529 
Basically we used to initialise all the receivers (public chat, normal messages, p2p) during the secondary registration process. In production mode, I could see public chat notifications while waiting for the primary device to accept the request...
So this PR makes sure we only initialise the loki message api receiver for secondary device registration. Once the registration is accepted, we basically re-run the whole `connect()` function. 