### PR TITLE
Show mentions as profile names and treat them as indivisible elements

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -2215,15 +2215,7 @@
       const pos = $input.selectionStart;
       const part = isDelete ? text.substr(pos) : text.substr(0, pos);
 
-      let curMention = null;
-      _.forEach(mentions, (val, key) => {
-        let shouldContinue = true;
-        if (predicate(part, key)) {
-          curMention = key;
-          shouldContinue = false;
-        }
-        return shouldContinue;
-      });
+      const curMention = _.keys(mentions).find(key => predicate(part, key));
 
       if (!curMention) {
         return;
@@ -2239,9 +2231,14 @@
         : text.substr(pos);
 
       const resText = beforeMention + afterMention;
+      // NOTE: this doesn't work well with undo/redo, perhaps
+      // we should fix it one day
       this.$messageField.val(resText);
-      $input.selectionStart = pos;
-      $input.selectionEnd = pos;
+
+      const nextPos = isDelete ? pos : pos - curMention.length;
+
+      $input.selectionStart = nextPos;
+      $input.selectionEnd = nextPos;
 
       this.memberView.deleteMention(curMention);
     },
@@ -2269,15 +2266,7 @@
           ? window.Lodash.endsWith
           : window.Lodash.startsWith;
 
-        let curMention = null;
-        _.forEach(mentions, (val, key) => {
-          let shouldContinue = true;
-          if (predicate(part, key)) {
-            curMention = key;
-            shouldContinue = false;
-          }
-          return shouldContinue;
-        });
+        const curMention = _.keys(mentions).find(key => predicate(part, key));
 
         const offset = curMention ? curMention.length : 1;
 

--- a/preload.js
+++ b/preload.js
@@ -22,6 +22,8 @@ if (config.appInstance) {
   title += ` - ${config.appInstance}`;
 }
 
+window.Lodash = require('lodash');
+
 window.platform = process.platform;
 window.getDefaultPoWDifficulty = () => config.defaultPoWDifficulty;
 window.getTitle = () => title;


### PR DESCRIPTION
When a member is selected, we create a mapping from "handle" (usually their profile name) to their pubkey. If multiple members with the same profile names are selected, one of the conflicting handles is augmented with a corresponding shortened pubkey (we use as many characters from the pubkey as necessary to avoid ambiguity). Before a message is sent, all handles are replaced with their corresponding pubkeys, and the mapping is reset.

The input/compose GUI element now has custom handling of arrow, delete and backspace keys. In particular, we make sure that a mention is treated as a single indivisible element, so if any action would result in a caret being positioned inside a mention, it will be moved either to the end or the beginning of the mention (whichever is more natural). We don't, however, handle mouse cursor in any special way yet.