### PR TITLE
[multi-device] No secondary timeout

### DIFF
--- a/background.html
+++ b/background.html
@@ -681,6 +681,7 @@
               <div id='pubkey' class='collapse'></div>
               <div id='error' class='collapse'></div>
               <button type='button' class='button' id='register-secondary-device'>Link</button>
+              <button type='button' class='button' id='cancel-secondary-device' style="display: none;">Cancel</button>
             </div>
           </div>
 


### PR DESCRIPTION
As discussed with Mik and Niels, when registering the secondary device, the timeout on desktop is not necessary and will actually lead to a mismatched pairing more easily (i.e. primary thinks the pairing is successful while the secondary actually had reset after a timeout).
Instead, we now show a cancel button that allows the user to manually cancel and then retry.