### PR TITLE
[multi-device] Fix signatures being sent to file server as arraybuffer

### DIFF
--- a/js/modules/loki_file_server_api.js
+++ b/js/modules/loki_file_server_api.js
@@ -1,5 +1,4 @@
 /* global storage: false */
-/* global libloki: false */
 /* global Signal: false */
 
 const LokiAppDotNetAPI = require('./loki_app_dot_net_api');
@@ -34,9 +33,7 @@ class LokiFileServerAPI {
       );
     } else {
       authorisations = [
-        await Signal.Data.getGrantAuthorisationForSecondaryPubKey(
-          this.ourKey
-        ),
+        await Signal.Data.getGrantAuthorisationForSecondaryPubKey(this.ourKey),
       ];
     }
     return this._setOurDeviceMapping(authorisations, isPrimary);

--- a/js/modules/loki_file_server_api.js
+++ b/js/modules/loki_file_server_api.js
@@ -34,7 +34,7 @@ class LokiFileServerAPI {
       );
     } else {
       authorisations = [
-        await libloki.storage.getGrantAuthorisationForSecondaryPubKey(
+        await Signal.Data.getGrantAuthorisationForSecondaryPubKey(
           this.ourKey
         ),
       ];


### PR DESCRIPTION
This is probably technical debt, but `libloki.storage.getGrantAuthorisationForSecondaryPubKey` and `Signal.Data.getGrantAuthorisationForSecondaryPubKey` aren't doing exactly the same.
The latter returns the authorisation from the db as is (signatures as base64) while the secondary converts them to array buffers.
Anyway, in this case we want to send the signatures as base64 to the file server.