### PR TITLE
[multi-device] Secondary device to update device mapping to server after lokiFileSer…

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -255,6 +255,10 @@
     window.lokiP2pAPI.on('online', ConversationController._handleOnline);
     window.lokiP2pAPI.on('offline', ConversationController._handleOffline);
     initialisedAPI = true;
+
+    if (storage.get('isSecondaryDevice')) {
+      window.lokiFileServerAPI.updateOurDeviceMapping();
+    }
   };
 
   function mapOldThemeToNew(theme) {

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -5,7 +5,7 @@
  i18n,
  passwordUtil,
  _,
- lokiFileServerAPI */
+*/
 
 /* eslint-disable more/no-then */
 

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -146,7 +146,6 @@
     },
     async onSecondaryDeviceRegistered() {
       clearInterval(this.pairingInterval);
-      await lokiFileServerAPI.updateOurDeviceMapping();
       // Ensure the left menu is updated
       Whisper.events.trigger('userChanged', { isSecondaryDevice: true });
       // will re-run the background initialisation


### PR DESCRIPTION
With the previous PR initialising the different API objects only after the registration truly completes, we can't use `lokiFileServerAPI.updateOurDeviceMapping();` before we initialise those API objects.