### PR TITLE
[multi-device] Save device mappings upon accepting friend request + various fixes

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -12,7 +12,6 @@
   Whisper,
   clipboard,
   libloki,
-  lokiFileServerAPI,
 */
 
 /* eslint-disable more/no-then */

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -12,6 +12,7 @@
   Whisper,
   clipboard,
   libloki,
+  lokiFileServerAPI,
 */
 
 /* eslint-disable more/no-then */
@@ -444,6 +445,8 @@
       await window.Signal.Data.saveMessage(this.attributes, {
         Message: Whisper.Message,
       });
+      const pubKey = this.get('conversationId');
+      await libloki.storage.saveAllPairingAuthorisationsFor(pubKey);
       conversation.onAcceptFriendRequest();
     },
     async declineFriendRequest() {

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -594,6 +594,9 @@ function signatureToBase64(signature) {
     return dcodeIO.ByteBuffer.wrap(signature).toString('base64');
   } else if (isArrayBuffer(signature)) {
     return arrayBufferToBase64(signature);
+  } else if (typeof signature === 'string') {
+    // assume it's already base64
+    return signature;
   }
   throw new Error(
     'Invalid signature provided in createOrUpdatePairingAuthorisation. Needs to be either ArrayBuffer or ByteBuffer.'

--- a/js/modules/loki_file_server_api.js
+++ b/js/modules/loki_file_server_api.js
@@ -19,9 +19,10 @@ class LokiFileServerAPI {
 
   async getUserDeviceMapping(pubKey) {
     const annotations = await this._server.getUserAnnotations(pubKey);
-    return annotations.find(
+    const deviceMapping = annotations.find(
       annotation => annotation.type === DEVICE_MAPPING_ANNOTATION_KEY
     );
+    return deviceMapping ? deviceMapping.value : null;
   }
 
   async updateOurDeviceMapping() {


### PR DESCRIPTION
- small refactor here and there
- when a device accepts a friend request, save all the device mappings related to the other device's primary device
- fixes for bugs discovered during testing