### PR TITLE
[multi-device] Disable sharing of contacts (TEMPORARY) and add start-multi2

### DIFF
--- a/config/development-2.json
+++ b/config/development-2.json
@@ -1,0 +1,12 @@
+{
+  "storageProfile": "development2",
+  "localServerPort": "8083",
+  "seedNodeList": [
+    {
+      "ip": "storage.testnetseed1.loki.network",
+      "port": "38157"
+    }
+  ],
+  "openDevTools": true,
+  "defaultPublicChatServer": "https://chat-dev.lokinet.org/"
+}

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -178,11 +178,12 @@
       profile,
     });
     // Attach contact list
-    const syncMessage = await createContactSyncProtoMessage();
+    // TODO: Reenable sending of the syncmessage for pairing requests
+    // const syncMessage = await createContactSyncProtoMessage();
     const content = new textsecure.protobuf.Content({
       pairingAuthorisation,
       dataMessage,
-      syncMessage,
+      // syncMessage,
     });
     // Send
     const options = { messageType: 'pairing-request' };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "postinstall": "electron-builder install-app-deps && rimraf node_modules/dtrace-provider",
     "start": "electron .",
     "start-multi": "NODE_APP_INSTANCE=1 electron .",
+    "start-multi2": "NODE_APP_INSTANCE=2 electron .",
     "start-prod": "NODE_ENV=production NODE_APP_INSTANCE=devprod LOKI_DEV=1 electron .",
     "start-prod-multi": "NODE_ENV=production NODE_APP_INSTANCE=devprod1 LOKI_DEV=1 electron .",
     "grunt": "grunt",


### PR DESCRIPTION
Decision was made for this release to *not* share contacts with your paired devices because mobile won't get there in time and it is better to remain consistent cross-platform