### PR TITLE
Private Group Chat Essentials

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -309,6 +309,11 @@
     "description":
       "Displayed when a user can't send a message because they have left the group"
   },
+  "youGotKickedFromGroup": {
+    "message": "You were removed from the group",
+    "description":
+      "Displayed when a user can't send a message because they have left the group"
+  },
   "scrollDown": {
     "message": "Scroll to bottom of conversation",
     "description":
@@ -1839,6 +1844,28 @@
       }
     }
   },
+  "kickedFromTheGroup": {
+    "message": "$name$ was removed from the group",
+    "description":
+      "Shown in the conversation history when a single person is removed from the group",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Alice"
+      }
+    }
+  },
+  "multipleKickedFromTheGroup": {
+    "message": "$names$ were removed from the group",
+    "description":
+      "Shown in the conversation history when more than one person is removed from the group",
+    "placeholders": {
+      "names": {
+        "content": "$1",
+        "example": "Alice, Bob"
+      }
+    }
+  },
   "friendRequestPending": {
     "message": "Friend request",
     "description":
@@ -2128,5 +2155,8 @@
   },
   "maxGroupMembersError": {
     "message": "Max number of members for small group chats is: "
+  },
+  "nonAdminDeleteMember": {
+    "message": "Only group admin can remove members!"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1917,6 +1917,10 @@
       "Button action that the user can click to copy their public keys"
   },
 
+  "copyChatId": {
+    "message": "Copy Chat ID"
+  },
+
   "updateGroup": {
     "message": "Update Group",
     "description":

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1989,6 +1989,12 @@
       "Title for the dialog box used to connect to a new public server"
   },
 
+  "createPrivateGroup": {
+    "message": "Create Private Group",
+    "description":
+      "Button action that the user can click to show a dialog for creating a new private group chat"
+  },
+
   "seedViewTitle": {
     "message":
       "Please save the seed below in a safe location. They can be used to restore your account if you lose access or migrate to a new device.",
@@ -2119,5 +2125,8 @@
   "emptyGroupNameError": {
     "message": "Group Name cannot be empty",
     "description": "Error message displayed on empty group name"
+  },
+  "maxGroupMembersError": {
+    "message": "Max number of members for small group chats is: "
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1929,6 +1929,12 @@
     "description":
       "Button action that the user can click to edit their display name"
   },
+
+  "createGroupDialogTitle": {
+    "message": "Creating a Private Group Chat",
+    "description": "Title for the dialog box used to create a new private group"
+  },
+
   "showSeed": {
     "message": "Show seed",
     "description":

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -928,6 +928,9 @@
   "ok": {
     "message": "OK"
   },
+  "yes": {
+    "message": "Yes"
+  },
   "cancel": {
     "message": "Cancel"
   },
@@ -993,6 +996,9 @@
     "message": "Hi there! This is <insert name here> !",
     "description":
       "Placeholder text in the message entry field when it is the first message sent to that contact"
+  },
+  "sendMessageLeftGroup": {
+    "message": "You left this group"
   },
   "groupMembers": {
     "message": "Group members"
@@ -1915,6 +1921,17 @@
     "message": "Update Group",
     "description":
       "Button action that the user can click to rename the group or add a new member"
+  },
+
+  "leaveGroup": {
+    "message": "Leave Group",
+    "description": "Button action that the user can click to leave the group"
+  },
+
+  "leaveGroupDialogTitle": {
+    "message": "Are you sure you want to leave this group?",
+    "description":
+      "Title shown to the user to confirm they want to leave the group"
   },
 
   "copiedPublicKey": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1910,6 +1910,13 @@
     "description":
       "Button action that the user can click to copy their public keys"
   },
+
+  "updateGroup": {
+    "message": "Update Group",
+    "description":
+      "Button action that the user can click to rename the group or add a new member"
+  },
+
   "copiedPublicKey": {
     "message": "Copied public key",
     "description": "A toast message telling the user that the key was copied"
@@ -1933,6 +1940,12 @@
   "createGroupDialogTitle": {
     "message": "Creating a Private Group Chat",
     "description": "Title for the dialog box used to create a new private group"
+  },
+
+  "updateGroupDialogTitle": {
+    "message": "Updating a Private Group Chat",
+    "description":
+      "Title for the dialog box used to update an existing private group"
   },
 
   "showSeed": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2094,5 +2094,9 @@
   "notFriends": {
     "message": "not friends",
     "description": "Indicates that a conversation is not friends with us"
+  },
+  "emptyGroupNameError": {
+    "message": "Group Name cannot be empty",
+    "description": "Error message displayed on empty group name"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2158,5 +2158,8 @@
   },
   "nonAdminDeleteMember": {
     "message": "Only group admin can remove members!"
+  },
+  "groupNamePlaceholder": {
+    "message": "Group Name"
   }
 }

--- a/background.html
+++ b/background.html
@@ -725,6 +725,7 @@
   <script type='text/javascript' src='js/views/app_view.js'></script>
   <script type='text/javascript' src='js/views/import_view.js'></script>
   <script type='text/javascript' src='js/views/clear_data_view.js'></script>
+  <script type='text/javascript' src='js/views/create_group_dialog_view.js'></script>
 
   <script type='text/javascript' src='js/wall_clock_listener.js'></script>
   <script type='text/javascript' src='js/rotate_signed_prekey_listener.js'></script>

--- a/js/background.js
+++ b/js/background.js
@@ -763,6 +763,12 @@
       }
     });
 
+    Whisper.events.on('leaveGroup', async groupConvo => {
+      if (appView) {
+        appView.showLeaveGroupDialog(groupConvo);
+      }
+    });
+
     Whisper.events.on('deleteConversation', async conversation => {
       await conversation.destroyMessages();
       await window.Signal.Data.removeConversation(conversation.id, {

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -2728,7 +2728,7 @@
         const knownMembers = this.get('members');
 
         if (knownMembers) {
-          const fromMember = knownMembers.indexOf(sender) !== -1;
+          const fromMember = knownMembers.includes(sender);
 
           if (!fromMember) {
             window.log.warn(

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -671,6 +671,11 @@
         this.trigger('disable:input', true);
         return;
       }
+      if (!this.isPrivate() && this.get('left')) {
+        this.trigger('disable:input', true);
+        this.trigger('change:placeholder', 'left-group');
+        return;
+      }
       switch (this.get('friendRequestStatus')) {
         case FriendRequestStatusEnum.none:
         case FriendRequestStatusEnum.requestExpired:
@@ -1962,6 +1967,8 @@
             textsecure.messaging.leaveGroup(this.id, groupNumbers, options)
           )
         );
+
+        this.updateTextInputState();
       }
     },
 

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -573,8 +573,12 @@
           ? expireTimerStart + expirationLength
           : null;
 
+      // TODO: investigate why conversation is undefined
+      // for the public group chat
       const conversation = this.getConversation();
-      const isGroup = conversation && !conversation.isPrivate();
+
+      const convoId = conversation ? conversation.id : undefined;
+      const isGroup = !!conversation && !conversation.isPrivate();
 
       const attachments = this.get('attachments') || [];
       const firstAttachment = attachments[0];
@@ -592,6 +596,7 @@
         authorProfileName: contact.profileName,
         authorPhoneNumber: contact.phoneNumber,
         conversationType: isGroup ? 'group' : 'direct',
+        convoId,
         attachments: attachments
           .filter(attachment => !attachment.error)
           .map(attachment => this.getPropsForAttachment(attachment)),

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -2178,7 +2178,8 @@
             if (
               !message.get('body') &&
               !message.get('attachments').length &&
-              !message.get('preview').length
+              !message.get('preview').length &&
+              !message.get('group_update')
             ) {
               return;
             }

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1744,7 +1744,7 @@
       const knownMembers = conversation.get('members');
 
       if (!newGroup && knownMembers) {
-        const fromMember = knownMembers.indexOf(source) !== -1;
+        const fromMember = knownMembers.includes(source);
 
         if (!fromMember) {
           window.log.warn(`Ignoring group message from non-member: ${source}`);
@@ -1766,8 +1766,7 @@
           );
         }
 
-        const fromAdmin =
-          conversation.get('groupAdmins').indexOf(source) !== -1;
+        const fromAdmin = conversation.get('groupAdmins').includes(source);
 
         if (!fromAdmin) {
           // Make sure the message is not removing members / renaming the group
@@ -1832,12 +1831,11 @@
 
       if (message.isFriendRequest() && backgroundFrReq) {
         // Check if the contact is a member in one of our private groups:
-        const groupMember =
-          window
-            .getConversations()
-            .models.filter(c => c.get('members'))
-            .reduce((acc, x) => window.Lodash.concat(acc, x.get('members')), [])
-            .indexOf(source) !== -1;
+        const groupMember = window
+          .getConversations()
+          .models.filter(c => c.get('members'))
+          .reduce((acc, x) => window.Lodash.concat(acc, x.get('members')), [])
+          .includes(source);
 
         if (groupMember) {
           window.log.info(
@@ -1914,9 +1912,7 @@
 
               if (removedMembers.length > 0) {
                 if (
-                  removedMembers.indexOf(
-                    textsecure.storage.user.getNumber()
-                  ) !== -1
+                  removedMembers.includes(textsecure.storage.user.getNumber())
                 ) {
                   groupUpdate.kicked = 'You';
                   attributes.isKickedFromGroup = true;

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1816,6 +1816,8 @@
                 groupUpdate.joined = difference;
               }
               if (conversation.get('left')) {
+                // TODO: Maybe we shouldn't assume this message adds us:
+                // we could maybe still get this message by mistake
                 window.log.warn('re-added to a left group');
                 attributes.left = false;
               }
@@ -1884,6 +1886,9 @@
           }
           attributes.active_at = now;
           conversation.set(attributes);
+
+          // Re-enable typing if re-joined the group
+          conversation.updateTextInputState();
 
           if (message.isExpirationTimerUpdate()) {
             message.set({

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1699,6 +1699,14 @@
       const GROUP_TYPES = textsecure.protobuf.GroupContext.Type;
 
       const conversation = ConversationController.get(conversationId);
+
+      if (initialMessage.group) {
+        // TODO: call this only once!
+        conversation.setFriendRequestStatus(
+          window.friends.friendRequestStatusEnum.friends
+        );
+      }
+
       return conversation.queueJob(async () => {
         window.log.info(
           `Starting handleDataMessage for message ${message.idForLogging()} in conversation ${conversation.idForLogging()}`

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -3,7 +3,7 @@
 const electron = require('electron');
 
 // TODO: this results in poor readability, would be
-// much better to implicitly call with `_`.
+// much better to explicitly call with `_`.
 const {
   cloneDeep,
   forEach,

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -2,6 +2,8 @@
 
 const electron = require('electron');
 
+// TODO: this results in poor readability, would be
+// much better to implicitly call with `_`.
 const {
   cloneDeep,
   forEach,
@@ -9,10 +11,11 @@ const {
   isFunction,
   isObject,
   map,
-  merge,
   set,
   omit,
 } = require('lodash');
+
+const _ = require('lodash');
 
 const { base64ToArrayBuffer, arrayBufferToBase64 } = require('./crypto');
 const MessageType = require('./types/message');
@@ -662,17 +665,6 @@ async function getAllSessions(id) {
 
 // Conversation
 
-function setifyProperty(data, propertyName) {
-  if (!data) {
-    return data;
-  }
-  const returnData = { ...data };
-  if (Array.isArray(returnData[propertyName])) {
-    returnData[propertyName] = new Set(returnData[propertyName]);
-  }
-  return returnData;
-}
-
 async function getSwarmNodesByPubkey(pubkey) {
   return channels.getSwarmNodesByPubkey(pubkey);
 }
@@ -701,13 +693,14 @@ async function updateConversation(id, data, { Conversation }) {
   if (!existing) {
     throw new Error(`Conversation ${id} does not exist!`);
   }
-  const setData = setifyProperty(data, 'swarmNodes');
-  const setExisting = setifyProperty(existing.attributes, 'swarmNodes');
 
-  const merged = merge({}, setExisting, setData);
-  if (merged.swarmNodes instanceof Set) {
-    merged.swarmNodes = Array.from(merged.swarmNodes);
-  }
+  const merged = _.merge({}, existing.attributes, data);
+
+  // Merging is a really bad idea and not what we want here, e.g.
+  // it will take a union of old and new members and that's not
+  // what we want for member deletion, so:
+  merged.members = data.members;
+  merged.swarmNodes = data.swarmNodes;
 
   // Don't save the online status of the object
   const cleaned = omit(merged, 'isOnline');

--- a/js/modules/signal.js
+++ b/js/modules/signal.js
@@ -50,6 +50,7 @@ const {
 const {
   UpdateGroupDialog,
 } = require('../../ts/components/conversation/UpdateGroupDialog');
+const { ConfirmDialog } = require('../../ts/components/ConfirmDialog');
 const {
   MediaGallery,
 } = require('../../ts/components/conversation/media-gallery/MediaGallery');
@@ -226,6 +227,7 @@ exports.setup = (options = {}) => {
     MainHeader,
     MemberList,
     CreateGroupDialog,
+    ConfirmDialog,
     UpdateGroupDialog,
     MediaGallery,
     Message,

--- a/js/modules/signal.js
+++ b/js/modules/signal.js
@@ -45,6 +45,9 @@ const { LightboxGallery } = require('../../ts/components/LightboxGallery');
 const { MainHeader } = require('../../ts/components/MainHeader');
 const { MemberList } = require('../../ts/components/conversation/MemberList');
 const {
+  CreateGroupDialog,
+} = require('../../ts/components/conversation/CreateGroupDialog');
+const {
   MediaGallery,
 } = require('../../ts/components/conversation/media-gallery/MediaGallery');
 const { Message } = require('../../ts/components/conversation/Message');
@@ -219,6 +222,7 @@ exports.setup = (options = {}) => {
     LightboxGallery,
     MainHeader,
     MemberList,
+    CreateGroupDialog,
     MediaGallery,
     Message,
     MessageBody,

--- a/js/modules/signal.js
+++ b/js/modules/signal.js
@@ -48,6 +48,9 @@ const {
   CreateGroupDialog,
 } = require('../../ts/components/conversation/CreateGroupDialog');
 const {
+  UpdateGroupDialog,
+} = require('../../ts/components/conversation/UpdateGroupDialog');
+const {
   MediaGallery,
 } = require('../../ts/components/conversation/media-gallery/MediaGallery');
 const { Message } = require('../../ts/components/conversation/Message');
@@ -223,6 +226,7 @@ exports.setup = (options = {}) => {
     MainHeader,
     MemberList,
     CreateGroupDialog,
+    UpdateGroupDialog,
     MediaGallery,
     Message,
     MessageBody,

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -204,5 +204,12 @@
       const dialog = new Whisper.AddServerDialogView();
       this.el.append(dialog.el);
     },
+    showCreateGroup() {
+      // TODO: make it impossible to open 2 dialogs as once
+      // Curretnly, if the button is in focus, it is possible to
+      // create a new dialog by pressing 'Enter'
+      const dialog = new Whisper.CreateGroupDialogView();
+      this.el.append(dialog.el);
+    },
   });
 })();

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -211,5 +211,9 @@
       const dialog = new Whisper.CreateGroupDialogView();
       this.el.append(dialog.el);
     },
+    showUpdateGroupDialog(groupConvo) {
+      const dialog = new Whisper.UpdateGroupDialogView(groupConvo);
+      this.el.append(dialog.el);
+    },
   });
 })();

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -215,5 +215,9 @@
       const dialog = new Whisper.UpdateGroupDialogView(groupConvo);
       this.el.append(dialog.el);
     },
+    showLeaveGroupDialog(groupConvo) {
+      const dialog = new Whisper.LeaveGroupDialogView(groupConvo);
+      this.el.append(dialog.el);
+    },
   });
 })();

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -268,6 +268,10 @@
           onMoveToInbox: () => {
             this.model.setArchived(false);
           },
+
+          onUpdateGroup: () => {
+            window.Whisper.events.trigger('updateGroup', this.model);
+          },
         };
       };
       this.titleView = new Whisper.ReactWrapperView({

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -2548,11 +2548,12 @@
           .models.filter(d => d.isPrivate());
         const memberConvos = members
           .map(m => privateConvos.find(c => c.id === m))
-          .filter(c => !!c);
-        allMembers = memberConvos.map(m => ({
-          id: m.id,
-          authorPhoneNumber: m.id,
-          authorProfileName: m.getLokiProfile().displayName,
+          .filter(c => !!c && c.getLokiProfile());
+
+        allMembers = memberConvos.map(c => ({
+          id: c.id,
+          authorPhoneNumber: c.id,
+          authorProfileName: c.getLokiProfile().displayName,
         }));
       }
 

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -2533,9 +2533,10 @@
       let allMembers;
 
       if (this.model.isPublic()) {
-        let members = window.lokiPublicChatAPI.getListOfMembers();
-        members = members.filter(d => !!d);
-        members = members.filter(d => d.authorProfileName !== 'Anonymous');
+        const members = window.lokiPublicChatAPI
+          .getListOfMembers()
+          .filter(d => !!d)
+          .filter(d => d.authorProfileName !== 'Anonymous');
         allMembers = _.uniq(members, true, d => d.authorPhoneNumber);
       } else {
         const members = this.model.get('members');

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -272,6 +272,10 @@
           onUpdateGroup: () => {
             window.Whisper.events.trigger('updateGroup', this.model);
           },
+
+          onLeaveGroup: () => {
+            window.Whisper.events.trigger('leaveGroup', this.model);
+          },
         };
       };
       this.titleView = new Whisper.ReactWrapperView({
@@ -439,6 +443,9 @@
           break;
         case 'disabled':
           placeholder = i18n('sendMessageDisabled');
+          break;
+        case 'left-group':
+          placeholder = i18n('sendMessageLeftGroup');
           break;
         default:
           placeholder = i18n('sendMessage');

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -196,6 +196,8 @@
           ? Whisper.ExpirationTimerOptions.getName(expireTimer || 0)
           : null;
 
+        const members = this.model.get('members') || [];
+
         return {
           id: this.model.id,
           name: this.model.getName(),
@@ -213,7 +215,7 @@
           isOnline: this.model.isOnline(),
           isArchived: this.model.get('isArchived'),
           isPublic: this.model.isPublic(),
-
+          members,
           expirationSettingName,
           showBackButton: Boolean(this.panels && this.panels.length),
           timerOptions: Whisper.ExpirationTimerOptions.map(item => ({

--- a/js/views/create_group_dialog_view.js
+++ b/js/views/create_group_dialog_view.js
@@ -1,0 +1,47 @@
+/* global Whisper, i18n, getInboxCollection _ */
+
+// eslint-disable-next-line func-names
+(function() {
+  'use strict';
+
+  window.Whisper = window.Whisper || {};
+
+  Whisper.CreateGroupDialogView = Whisper.View.extend({
+    templateName: 'group-creation-template',
+    className: 'loki-dialog modal',
+    initialize() {
+      this.titleText = i18n('createGroupDialogTitle');
+      this.okText = i18n('ok');
+      this.cancelText = i18n('cancel');
+      this.close = this.close.bind(this);
+      this.$el.focus();
+      this.render();
+    },
+    render() {
+      const convos = getInboxCollection().models;
+
+      let allMembers = convos.filter(d => !!d);
+      allMembers = allMembers.filter(d => d.isFriend());
+      allMembers = allMembers.filter(d => d.isPrivate());
+      allMembers = _.uniq(allMembers, true, d => d.id);
+
+      this.dialogView = new Whisper.ReactWrapperView({
+        className: 'create-group-dialog',
+        Component: window.Signal.Components.CreateGroupDialog,
+        props: {
+          titleText: this.titleText,
+          okText: this.okText,
+          cancelText: this.cancelText,
+          friendList: allMembers,
+          onClose: this.close,
+        },
+      });
+
+      this.$el.append(this.dialogView.el);
+      return this;
+    },
+    close() {
+      this.remove();
+    },
+  });
+})();

--- a/js/views/create_group_dialog_view.js
+++ b/js/views/create_group_dialog_view.js
@@ -102,7 +102,7 @@
 
       const ourPK = textsecure.storage.user.getNumber();
 
-      this.isAdmin = groupConvo.get('groupAdmins').indexOf(ourPK) !== -1;
+      this.isAdmin = groupConvo.get('groupAdmins').includes(ourPK);
 
       const convos = window.getConversations().models;
 

--- a/js/views/create_group_dialog_view.js
+++ b/js/views/create_group_dialog_view.js
@@ -112,6 +112,8 @@
         d => !_.some(existingMembers, x => x === d.id)
       );
 
+      this.existingMembers = existingMembers;
+
       this.$el.focus();
       this.render();
     },
@@ -124,6 +126,7 @@
           groupName: this.groupName,
           okText: this.okText,
           cancelText: this.cancelText,
+          existingMembers: this.existingMembers,
           friendList: this.membersToShow,
           onClose: this.close,
           onSubmit: this.onSubmit,

--- a/js/views/create_group_dialog_view.js
+++ b/js/views/create_group_dialog_view.js
@@ -16,9 +16,8 @@
 
       const convos = window.getConversations().models;
 
-      let allMembers = convos.filter(d => !!d);
-      allMembers = allMembers.filter(
-        d => d.isFriend() && d.isPrivate() && !d.isMe()
+      let allMembers = convos.filter(
+        d => !!d && d.isFriend() && d.isPrivate() && !d.isMe()
       );
       allMembers = _.uniq(allMembers, true, d => d.id);
 

--- a/js/views/create_group_dialog_view.js
+++ b/js/views/create_group_dialog_view.js
@@ -7,24 +7,25 @@
   window.Whisper = window.Whisper || {};
 
   Whisper.CreateGroupDialogView = Whisper.View.extend({
-    templateName: 'group-creation-template',
     className: 'loki-dialog modal',
     initialize() {
       this.titleText = i18n('createGroupDialogTitle');
       this.okText = i18n('ok');
       this.cancelText = i18n('cancel');
       this.close = this.close.bind(this);
+
+      const convos = window.getConversations().models;
+
+      let allMembers = convos.filter(d => !!d);
+      allMembers = allMembers.filter(d => d.isFriend() && d.isPrivate());
+      allMembers = _.uniq(allMembers, true, d => d.id);
+
+      this.membersToShow = allMembers;
+
       this.$el.focus();
       this.render();
     },
     render() {
-      const convos = getInboxCollection().models;
-
-      let allMembers = convos.filter(d => !!d);
-      allMembers = allMembers.filter(d => d.isFriend());
-      allMembers = allMembers.filter(d => d.isPrivate());
-      allMembers = _.uniq(allMembers, true, d => d.id);
-
       this.dialogView = new Whisper.ReactWrapperView({
         className: 'create-group-dialog',
         Component: window.Signal.Components.CreateGroupDialog,
@@ -32,13 +33,74 @@
           titleText: this.titleText,
           okText: this.okText,
           cancelText: this.cancelText,
-          friendList: allMembers,
+          friendList: this.membersToShow,
           onClose: this.close,
         },
       });
 
       this.$el.append(this.dialogView.el);
       return this;
+    },
+    close() {
+      this.remove();
+    },
+  });
+
+  Whisper.UpdateGroupDialogView = Whisper.View.extend({
+    templateName: 'group-creation-template',
+    className: 'loki-dialog modal',
+    initialize(groupConvo) {
+      this.groupName = groupConvo.get('name');
+
+      this.conversation = groupConvo;
+      this.titleText = `${i18n('updateGroupDialogTitle')}: ${this.groupName}`;
+      this.okText = i18n('ok');
+      this.cancelText = i18n('cancel');
+      this.close = this.close.bind(this);
+      this.onSubmit = this.onSubmit.bind(this);
+
+      const convos = getInboxCollection().models;
+
+      let allMembers = convos.filter(d => !!d);
+      allMembers = allMembers.filter(d => d.isFriend());
+      allMembers = allMembers.filter(d => d.isPrivate());
+      allMembers = _.uniq(allMembers, true, d => d.id);
+
+      // only give members that are not already in the group
+      const existingMembers = groupConvo.get('members');
+      this.membersToShow = allMembers.filter(
+        d => !_.some(existingMembers, x => x === d.id)
+      );
+
+      this.$el.focus();
+      this.render();
+    },
+    render() {
+      this.dialogView = new Whisper.ReactWrapperView({
+        className: 'create-group-dialog',
+        Component: window.Signal.Components.UpdateGroupDialog,
+        props: {
+          titleText: this.titleText,
+          groupName: this.groupName,
+          okText: this.okText,
+          cancelText: this.cancelText,
+          friendList: this.membersToShow,
+          onClose: this.close,
+          onSubmit: this.onSubmit,
+        },
+      });
+
+      this.$el.append(this.dialogView.el);
+      return this;
+    },
+    onSubmit(newGroupName, newMembers) {
+      const allMembers = window.Lodash.concat(
+        newMembers,
+        this.conversation.get('members')
+      );
+      const groupId = this.conversation.get('id');
+
+      window.doUpdateGroup(groupId, newGroupName, allMembers);
     },
     close() {
       this.remove();

--- a/js/views/create_group_dialog_view.js
+++ b/js/views/create_group_dialog_view.js
@@ -46,8 +46,48 @@
     },
   });
 
+  Whisper.LeaveGroupDialogView = Whisper.View.extend({
+    className: 'loki-dialog modal',
+    initialize(groupConvo) {
+      this.groupConvo = groupConvo;
+      this.titleText = groupConvo.get('name');
+      this.messageText = i18n('leaveGroupDialogTitle');
+      this.okText = i18n('yes');
+      this.cancelText = i18n('cancel');
+
+      this.close = this.close.bind(this);
+      this.confirm = this.confirm.bind(this);
+
+      this.$el.focus();
+      this.render();
+    },
+    render() {
+      this.dialogView = new Whisper.ReactWrapperView({
+        className: 'leave-group-dialog',
+        Component: window.Signal.Components.ConfirmDialog,
+        props: {
+          titleText: this.titleText,
+          messageText: this.messageText,
+          okText: this.okText,
+          cancelText: this.cancelText,
+          onConfirm: this.confirm,
+          onClose: this.close,
+        },
+      });
+
+      this.$el.append(this.dialogView.el);
+      return this;
+    },
+    async confirm() {
+      await this.groupConvo.leaveGroup();
+      this.close();
+    },
+    close() {
+      this.remove();
+    },
+  });
+
   Whisper.UpdateGroupDialogView = Whisper.View.extend({
-    templateName: 'group-creation-template',
     className: 'loki-dialog modal',
     initialize(groupConvo) {
       this.groupName = groupConvo.get('name');

--- a/js/views/group_update_view.js
+++ b/js/views/group_update_view.js
@@ -6,6 +6,7 @@
 
   window.Whisper = window.Whisper || {};
 
+  // TODO: remove this as unused?
   Whisper.GroupUpdateView = Backbone.View.extend({
     tagName: 'div',
     className: 'group-update',

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -294,7 +294,8 @@
     async openConversation(id, messageId) {
       const conversationExists = await ConversationController.get(id);
 
-      // why does this have to be 'private'???
+      // If we call this to create a new conversation, it can only be private
+      // (group conversations are created elsewhere)
       const conversation = await ConversationController.getOrCreateAndWait(
         id,
         'private'

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -293,6 +293,8 @@
     },
     async openConversation(id, messageId) {
       const conversationExists = await ConversationController.get(id);
+
+      // why does this have to be 'private'???
       const conversation = await ConversationController.getOrCreateAndWait(
         id,
         'private'

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1081,10 +1081,9 @@ MessageReceiver.prototype.extend({
           let profile = null;
           if (message.profile) {
             profile = JSON.parse(message.profile.encodeJSON());
+            // Update the conversation
+            await conversation.setLokiProfile(profile);
           }
-
-          // Update the conversation
-          await conversation.setLokiProfile(profile);
         }
 
         if (friendRequest && isMe) {
@@ -1542,6 +1541,8 @@ MessageReceiver.prototype.extend({
     } else if (decrypted.flags & FLAGS.PROFILE_KEY_UPDATE) {
       decrypted.body = null;
       decrypted.attachments = [];
+    } else if (decrypted.flags & FLAGS.BACKGROUND_FRIEND_REQUEST) {
+      // do nothing
     } else if (decrypted.flags !== 0) {
       throw new Error('Unknown flags in message');
     }

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -1009,15 +1009,11 @@ MessageSender.prototype = {
     proto.group.members = targetNumbers;
     proto.group.name = name;
 
-    return this.makeAttachmentPointer(avatar).then(attachment => {
-      proto.group.avatar = attachment;
-      return this.sendGroupProto(
-        targetNumbers,
-        proto,
-        Date.now(),
-        options
-      ).then(() => proto.group.id);
-    });
+    // TODO: Add adding attachmentPointer once we support avatars
+    // (see git history)
+    return this.sendGroupProto(targetNumbers, proto, Date.now(), options).then(
+      () => proto.group.id
+    );
   },
 
   updateGroup(groupId, name, avatar, targetNumbers, options) {

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -1022,25 +1022,25 @@ MessageSender.prototype = {
     return this.sendMessage(attrs, options);
   },
 
-  updateGroup(groupId, name, avatar, targetNumbers, options) {
+  updateGroup(groupId, name, avatar, members, recipients, options) {
     const proto = new textsecure.protobuf.DataMessage();
     proto.group = new textsecure.protobuf.GroupContext();
 
     proto.group.id = stringToArrayBuffer(groupId);
     proto.group.type = textsecure.protobuf.GroupContext.Type.UPDATE;
     proto.group.name = name;
-    proto.group.members = targetNumbers;
+    proto.group.members = members;
+
+    const ourPK = textsecure.storage.user.getNumber();
+    proto.group.admins = [ourPK];
 
     return this.makeAttachmentPointer(avatar).then(attachment => {
       proto.group.avatar = attachment;
       // TODO: re-enable this once we have attachments
       proto.group.avatar = null;
-      return this.sendGroupProto(
-        targetNumbers,
-        proto,
-        Date.now(),
-        options
-      ).then(() => proto.group.id);
+      return this.sendGroupProto(recipients, proto, Date.now(), options).then(
+        () => proto.group.id
+      );
     });
   },
 

--- a/preload.js
+++ b/preload.js
@@ -459,3 +459,6 @@ if (config.environment === 'test') {
 window.shortenPubkey = pubkey => `(...${pubkey.substring(pubkey.length - 6)})`;
 
 window.pubkeyPattern = /@[a-fA-F0-9]{64,66}\b/g;
+
+// Limited due to the proof-of-work requirement
+window.SMALL_GROUP_SIZE_LIMIT = 10;

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -94,9 +94,10 @@ message CallMessage {
 
 message DataMessage {
   enum Flags {
-    END_SESSION             = 1;
-    EXPIRATION_TIMER_UPDATE = 2;
-    PROFILE_KEY_UPDATE      = 4;
+    END_SESSION               = 1;
+    EXPIRATION_TIMER_UPDATE   = 2;
+    PROFILE_KEY_UPDATE        = 4;
+    BACKGROUND_FRIEND_REQUEST = 256;
   }
 
   message Quote {

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -337,6 +337,7 @@ message GroupContext {
   optional string            name    = 3;
   repeated string            members = 4;
   optional AttachmentPointer avatar  = 5;
+  repeated string            admins  = 6;
 }
 
 message ContactDetails {

--- a/stylesheets/_mentions.scss
+++ b/stylesheets/_mentions.scss
@@ -1,3 +1,47 @@
+.create-group-dialog {
+  .content {
+    max-width: 100% !important;
+  }
+
+  .buttons {
+    margin: 8px;
+  }
+
+  .group-name {
+    font-size: larger;
+  }
+
+  .titleText {
+    font-size: large;
+    text-align: center;
+  }
+}
+
+.friend-selection-list {
+  max-height: 240px;
+  overflow-y: scroll;
+
+  .check-mark {
+    float: right;
+    text-align: center;
+    color: darkslategrey;
+    margin: 4px;
+    min-width: 20px;
+  }
+
+  .hidden {
+    visibility: hidden;
+  }
+}
+
+.dark-theme {
+  .friend-selection-list {
+    .check-mark {
+      color: rgb(230, 230, 230);
+    }
+  }
+}
+
 .member-list-container {
   margin: 0;
   padding: 0;
@@ -5,6 +49,13 @@
   max-height: 240px;
   overflow-y: scroll;
 
+  .check-mark {
+    display: none;
+  }
+}
+
+.member-list-container,
+.create-group-dialog {
   .member-item {
     padding: 4px;
     user-select: none;
@@ -55,7 +106,8 @@
 }
 
 .dark-theme {
-  .member-list-container {
+  .member-list-container,
+  .create-group-dialog {
     .member-item {
       &:hover:not(.member-selected) {
         background-color: $color-dark-55;

--- a/stylesheets/_mentions.scss
+++ b/stylesheets/_mentions.scss
@@ -75,6 +75,7 @@
 .friend-selection-list {
   max-height: 240px;
   overflow-y: scroll;
+  margin: 4px;
 
   .check-mark {
     float: right;
@@ -86,6 +87,14 @@
 
   .invisible {
     visibility: hidden;
+  }
+
+  .existing-member {
+    color: green;
+  }
+
+  .existing-member-kicked {
+    color: red;
   }
 }
 

--- a/stylesheets/_mentions.scss
+++ b/stylesheets/_mentions.scss
@@ -23,6 +23,22 @@
   .hidden {
     display: none;
   }
+
+  .error-message {
+    text-align: center;
+    color: red;
+    margin-bottom: 0.5em;
+  }
+
+  .error-faded {
+    opacity: 0;
+    transition: all 100ms linear;
+  }
+
+  .error-shown {
+    opacity: 1;
+    transition: all 250ms linear;
+  }
 }
 
 .friend-selection-list {

--- a/stylesheets/_mentions.scss
+++ b/stylesheets/_mentions.scss
@@ -15,6 +15,14 @@
     font-size: large;
     text-align: center;
   }
+
+  .no-friends {
+    text-align: center;
+  }
+
+  .hidden {
+    display: none;
+  }
 }
 
 .friend-selection-list {
@@ -29,7 +37,7 @@
     min-width: 20px;
   }
 
-  .hidden {
+  .invisible {
     visibility: hidden;
   }
 }

--- a/stylesheets/_mentions.scss
+++ b/stylesheets/_mentions.scss
@@ -1,3 +1,30 @@
+.leave-group-dialog {
+  .content {
+    max-width: 100% !important;
+  }
+
+  .titleText {
+    font-size: large;
+    text-align: center;
+    margin: 2px;
+  }
+
+  .ok {
+    background-color: orangered;
+    min-width: 70px;
+    border: none;
+
+    &:hover {
+      background-color: red;
+    }
+  }
+
+  .cancel {
+    border: none;
+    min-width: 70px;
+  }
+}
+
 .create-group-dialog {
   .content {
     max-width: 100% !important;

--- a/stylesheets/_mentions.scss
+++ b/stylesheets/_mentions.scss
@@ -25,6 +25,10 @@
   }
 }
 
+.member-preview {
+  margin-left: 10px;
+}
+
 .create-group-dialog {
   .content {
     max-width: 100% !important;

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -8,6 +8,17 @@
   overflow-x: hidden;
 }
 
+.create-group-button {
+  background-color: #383c46;
+  color: #ffffff;
+  margin: 4px;
+  padding: 4px;
+}
+
+.create-group-button:focus {
+  outline: 0;
+}
+
 .module-contact-name span {
   text-overflow: ellipsis;
   overflow-x: hidden;

--- a/test/backup_test.js
+++ b/test/backup_test.js
@@ -574,6 +574,8 @@ describe('Backup', () => {
           'profileAvatar',
           'swarmNodes',
           'friendRequestStatus',
+          'groupAdmins',
+          'isKickedFromGroup',
           'unlockTimestamp',
           'sessionResetStatus',
           'isOnline',

--- a/test/index.html
+++ b/test/index.html
@@ -574,6 +574,7 @@
   <script type='text/javascript' src='../js/views/scroll_down_button_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/banner_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/clear_data_view.js'></script>
+  <script type='text/javascript' src='../js/views/create_group_dialog_view.js'></script>
   <script type='text/javascript' src='../js/views/beta_release_disclaimer_view.js'></script>
 
 

--- a/ts/components/ConfirmDialog.tsx
+++ b/ts/components/ConfirmDialog.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface Props {
+  titleText: string;
+  messageText: string;
+  okText: string;
+  cancelText: string;
+  onConfirm: any;
+  onClose: any;
+}
+
+export class ConfirmDialog extends React.Component<Props> {
+  constructor(props: any) {
+    super(props);
+  }
+
+  public render() {
+    return (
+      <div className="content">
+        <p className="titleText">{this.props.titleText}</p>
+        <p className="messageText">{this.props.messageText}</p>
+        <div className="buttons">
+          <button className="cancel" tabIndex={0} onClick={this.props.onClose}>
+            {this.props.cancelText}
+          </button>
+          <button className="ok" tabIndex={0} onClick={this.props.onConfirm}>
+            {this.props.okText}
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/ts/components/LeftPane.tsx
+++ b/ts/components/LeftPane.tsx
@@ -26,6 +26,9 @@ export interface Props {
     query: string,
     options: { regionCode: string }
   ) => void;
+
+  createNewGroup: () => void;
+
   openConversationInternal: (id: string, messageId?: string) => void;
   showArchivedConversations: () => void;
   showInbox: () => void;
@@ -262,6 +265,12 @@ export class LeftPane extends React.Component<Props, any> {
         <div className="module-left-pane__header">
           {showArchived ? this.renderArchivedHeader() : renderMainHeader()}
         </div>
+        <input
+          className="create-group-button"
+          type="button"
+          value="Create Group"
+          onClick={this.props.createNewGroup}
+        />
         {this.renderList()}
       </div>
     );

--- a/ts/components/LeftPane.tsx
+++ b/ts/components/LeftPane.tsx
@@ -27,8 +27,6 @@ export interface Props {
     options: { regionCode: string }
   ) => void;
 
-  createNewGroup: () => void;
-
   openConversationInternal: (id: string, messageId?: string) => void;
   showArchivedConversations: () => void;
   showInbox: () => void;
@@ -265,12 +263,6 @@ export class LeftPane extends React.Component<Props, any> {
         <div className="module-left-pane__header">
           {showArchived ? this.renderArchivedHeader() : renderMainHeader()}
         </div>
-        <input
-          className="create-group-button"
-          type="button"
-          value="Create Group"
-          onClick={this.props.createNewGroup}
-        />
         {this.renderList()}
       </div>
     );

--- a/ts/components/MainHeader.tsx
+++ b/ts/components/MainHeader.tsx
@@ -341,6 +341,13 @@ export class MainHeader extends React.Component<Props, any> {
           trigger('showAddServerDialog');
         },
       },
+      {
+        id: 'createPrivateGroup',
+        name: i18n('createPrivateGroup'),
+        onClick: () => {
+          trigger('createNewGroup');
+        },
+      },
     ];
 
     const passItem = (type: string) => ({

--- a/ts/components/conversation/AddMentions.tsx
+++ b/ts/components/conversation/AddMentions.tsx
@@ -89,6 +89,13 @@ class Mention extends React.Component<MentionProps, MentionState> {
       return d.id === this.props.convoId;
     });
 
+    if (!thisConvo) {
+      // If this gets triggered, is is likely because we deleted the conversation
+      this.clearOurInterval();
+
+      return;
+    }
+
     if (thisConvo.isPublic()) {
       // TODO: make this work for other public chats as well
       groupMembers = window.lokiPublicChatAPI
@@ -106,10 +113,14 @@ class Mention extends React.Component<MentionProps, MentionState> {
         .map((m: any) => privateConvos.find((c: any) => c.id === m))
         .filter((c: any) => !!c);
       groupMembers = memberConversations.map((m: any) => {
+        const name = m.getLokiProfile()
+          ? m.getLokiProfile().displayName
+          : m.attributes.displayName;
+
         return {
           id: m.id,
           authorPhoneNumber: m.id,
-          authorProfileName: m.getLokiProfile().displayName,
+          authorProfileName: name,
         };
       });
     }

--- a/ts/components/conversation/AddNewLines.tsx
+++ b/ts/components/conversation/AddNewLines.tsx
@@ -6,6 +6,7 @@ interface Props {
   text: string;
   /** Allows you to customize now non-newlines are rendered. Simplest is just a <span>. */
   renderNonNewLine?: RenderTextCallbackType;
+  convoId: string;
 }
 
 export class AddNewLines extends React.Component<Props> {
@@ -14,7 +15,7 @@ export class AddNewLines extends React.Component<Props> {
   };
 
   public render() {
-    const { text, renderNonNewLine } = this.props;
+    const { text, renderNonNewLine, convoId } = this.props;
     const results: Array<any> = [];
     const FIND_NEWLINES = /\n/g;
 
@@ -29,14 +30,14 @@ export class AddNewLines extends React.Component<Props> {
     let count = 1;
 
     if (!match) {
-      return renderNonNewLine({ text, key: 0 });
+      return renderNonNewLine({ text, key: 0, convoId });
     }
 
     while (match) {
       if (last < match.index) {
         const textWithNoNewline = text.slice(last, match.index);
         results.push(
-          renderNonNewLine({ text: textWithNoNewline, key: count++ })
+          renderNonNewLine({ text: textWithNoNewline, key: count++, convoId })
         );
       }
 
@@ -48,7 +49,9 @@ export class AddNewLines extends React.Component<Props> {
     }
 
     if (last < text.length) {
-      results.push(renderNonNewLine({ text: text.slice(last), key: count++ }));
+      results.push(
+        renderNonNewLine({ text: text.slice(last), key: count++, convoId })
+      );
     }
 
     return results;

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -31,6 +31,8 @@ interface Props {
   isArchived: boolean;
   isPublic: boolean;
 
+  members: Array<any>;
+
   expirationSettingName?: string;
   showBackButton: boolean;
   timerOptions: Array<TimerOption>;
@@ -262,8 +264,10 @@ export class ConversationHeader extends React.Component<Props> {
   }
 
   public render() {
-    const { id } = this.props;
+    const { id, isGroup, isPublic } = this.props;
     const triggerId = `conversation-${id}`;
+
+    const isPrivateGroup = isGroup && !isPublic;
 
     return (
       <div className="module-conversation-header">
@@ -272,12 +276,27 @@ export class ConversationHeader extends React.Component<Props> {
           <div className="module-conversation-header__title-flex">
             {this.renderAvatar()}
             {this.renderTitle()}
+            {isPrivateGroup ? this.renderMemberCount() : null}
           </div>
         </div>
         {this.renderExpirationLength()}
         {this.renderGear(triggerId)}
         {this.renderMenu(triggerId)}
       </div>
+    );
+  }
+
+  private renderMemberCount() {
+    const memberCount = this.props.members.length;
+
+    if (memberCount === 0) {
+      return null;
+    }
+
+    const wordForm = memberCount === 1 ? 'member' : 'members';
+
+    return (
+      <span className="member-preview">{`(${memberCount} ${wordForm})`}</span>
     );
   }
 

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -63,6 +63,7 @@ interface Props {
   onCopyPublicKey: () => void;
 
   onUpdateGroup: () => void;
+  onLeaveGroup: () => void;
 
   i18n: LocalizerType;
 }
@@ -225,6 +226,7 @@ export class ConversationHeader extends React.Component<Props> {
       onDeleteContact,
       onCopyPublicKey,
       onUpdateGroup,
+      onLeaveGroup,
     } = this.props;
 
     return (
@@ -233,6 +235,7 @@ export class ConversationHeader extends React.Component<Props> {
         <MenuItem onClick={onCopyPublicKey}>{i18n('copyPublicKey')}</MenuItem>
         <MenuItem onClick={onDeleteMessages}>{i18n('deleteMessages')}</MenuItem>
         <MenuItem onClick={onUpdateGroup}>{i18n('updateGroup')}</MenuItem>
+        <MenuItem onClick={onLeaveGroup}>{i18n('leaveGroup')}</MenuItem>
         {!isMe && isClosable ? (
           !isPublic ? (
             <MenuItem onClick={onDeleteContact}>

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -222,6 +222,7 @@ export class ConversationHeader extends React.Component<Props> {
       isMe,
       isClosable,
       isPublic,
+      isGroup,
       onDeleteMessages,
       onDeleteContact,
       onCopyPublicKey,
@@ -229,14 +230,23 @@ export class ConversationHeader extends React.Component<Props> {
       onLeaveGroup,
     } = this.props;
 
+    const isPrivateGroup = isGroup && !isPublic;
+
+    const copyIdLabel = isGroup ? i18n('copyChatId') : i18n('copyPublicKey');
+
     return (
       <ContextMenu id={triggerId}>
         {this.renderPublicMenuItems()}
-        <MenuItem onClick={onCopyPublicKey}>{i18n('copyPublicKey')}</MenuItem>
+        <MenuItem onClick={onCopyPublicKey}>{copyIdLabel}</MenuItem>
         <MenuItem onClick={onDeleteMessages}>{i18n('deleteMessages')}</MenuItem>
-        <MenuItem onClick={onUpdateGroup}>{i18n('updateGroup')}</MenuItem>
-        <MenuItem onClick={onLeaveGroup}>{i18n('leaveGroup')}</MenuItem>
-        {!isMe && isClosable ? (
+        {isPrivateGroup ? (
+          <MenuItem onClick={onUpdateGroup}>{i18n('updateGroup')}</MenuItem>
+        ) : null}
+        {isPrivateGroup ? (
+          <MenuItem onClick={onLeaveGroup}>{i18n('leaveGroup')}</MenuItem>
+        ) : null}
+        {/* TODO: add delete group */}
+        {!isMe && isClosable && !isPrivateGroup ? (
           !isPublic ? (
             <MenuItem onClick={onDeleteContact}>
               {i18n('deleteContact')}
@@ -329,13 +339,14 @@ export class ConversationHeader extends React.Component<Props> {
     const resetSessionMenuItem = !isGroup && (
       <MenuItem onClick={onResetSession}>{i18n('resetSession')}</MenuItem>
     );
-    const blockHandlerMenuItem = !isMe && (
-      <MenuItem onClick={blockHandler}>{blockTitle}</MenuItem>
-    );
-    const changeNicknameMenuItem = !isMe && (
-      <MenuItem onClick={onChangeNickname}>{i18n('changeNickname')}</MenuItem>
-    );
+    const blockHandlerMenuItem = !isMe &&
+      !isGroup && <MenuItem onClick={blockHandler}>{blockTitle}</MenuItem>;
+    const changeNicknameMenuItem = !isMe &&
+      !isGroup && (
+        <MenuItem onClick={onChangeNickname}>{i18n('changeNickname')}</MenuItem>
+      );
     const clearNicknameMenuItem = !isMe &&
+      !isGroup &&
       hasNickname && (
         <MenuItem onClick={onClearNickname}>{i18n('clearNickname')}</MenuItem>
       );

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -62,6 +62,8 @@ interface Props {
 
   onCopyPublicKey: () => void;
 
+  onUpdateGroup: () => void;
+
   i18n: LocalizerType;
 }
 
@@ -222,6 +224,7 @@ export class ConversationHeader extends React.Component<Props> {
       onDeleteMessages,
       onDeleteContact,
       onCopyPublicKey,
+      onUpdateGroup,
     } = this.props;
 
     return (
@@ -229,6 +232,7 @@ export class ConversationHeader extends React.Component<Props> {
         {this.renderPublicMenuItems()}
         <MenuItem onClick={onCopyPublicKey}>{i18n('copyPublicKey')}</MenuItem>
         <MenuItem onClick={onDeleteMessages}>{i18n('deleteMessages')}</MenuItem>
+        <MenuItem onClick={onUpdateGroup}>{i18n('updateGroup')}</MenuItem>
         {!isMe && isClosable ? (
           !isPublic ? (
             <MenuItem onClick={onDeleteContact}>

--- a/ts/components/conversation/CreateGroupDialog.tsx
+++ b/ts/components/conversation/CreateGroupDialog.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { Contact, MemberList } from './MemberList';
 
 declare global {
@@ -20,6 +21,7 @@ interface Props {
 interface State {
   friendList: Array<Contact>;
   groupName: string;
+  errorDisplayed: boolean;
 }
 
 export class CreateGroupDialog extends React.Component<Props, State> {
@@ -53,6 +55,7 @@ export class CreateGroupDialog extends React.Component<Props, State> {
     this.state = {
       friendList: friends,
       groupName: '',
+      errorDisplayed: false,
     };
 
     window.addEventListener('keyup', this.onKeyUp);
@@ -64,8 +67,8 @@ export class CreateGroupDialog extends React.Component<Props, State> {
       .map(d => d.id);
 
     if (!this.state.groupName.trim()) {
-      // TODO: show error message
-      // console.error('Group name cannot be empty!');
+      this.onShowError();
+
       return;
     }
 
@@ -79,9 +82,16 @@ export class CreateGroupDialog extends React.Component<Props, State> {
     const okText = this.props.okText;
     const cancelText = this.props.cancelText;
 
+    const errorMsg = this.props.i18n('emptyGroupNameError');
+    const errorMessageClasses = classNames(
+      'error-message',
+      this.state.errorDisplayed ? 'error-shown' : 'error-faded'
+    );
+
     return (
       <div className="content">
         <p className="titleText">{titleText}</p>
+        <p className={errorMessageClasses}>{errorMsg}</p>
         <input
           type="text"
           id="group-name"
@@ -112,6 +122,22 @@ export class CreateGroupDialog extends React.Component<Props, State> {
         </div>
       </div>
     );
+  }
+
+  private onShowError() {
+    if (this.state.errorDisplayed) {
+      return;
+    }
+
+    this.setState({
+      errorDisplayed: true,
+    });
+
+    setTimeout(() => {
+      this.setState({
+        errorDisplayed: false,
+      });
+    }, 3000);
   }
 
   private onGroupNameChanged(event: any) {

--- a/ts/components/conversation/CreateGroupDialog.tsx
+++ b/ts/components/conversation/CreateGroupDialog.tsx
@@ -30,8 +30,6 @@ export class CreateGroupDialog extends React.Component<Props, State> {
   constructor(props: any) {
     super(props);
 
-    // const _ = window.Lodash;
-
     this.onMemberClicked = this.onMemberClicked.bind(this);
     this.onClickOK = this.onClickOK.bind(this);
     this.onKeyUp = this.onKeyUp.bind(this);
@@ -101,7 +99,7 @@ export class CreateGroupDialog extends React.Component<Props, State> {
           type="text"
           id="group-name"
           className="group-name"
-          placeholder="Group Name"
+          placeholder={this.props.i18n('groupNamePlaceholder')}
           value={this.state.groupName}
           onChange={this.onGroupNameChanged}
           tabIndex={0}

--- a/ts/components/conversation/CreateGroupDialog.tsx
+++ b/ts/components/conversation/CreateGroupDialog.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { MemberList, Contact } from './MemberList';
+
+declare global {
+  interface Window {
+    Lodash: any;
+    doCreateGroup: any;
+  }
+}
+
+interface Props {
+  titleText: string;
+  okText: string;
+  cancelText: string;
+  friendList: any[];
+  i18n: any;
+  onClose: any;
+}
+
+interface State {
+  friendList: Contact[];
+  groupName: string;
+}
+
+export class CreateGroupDialog extends React.Component<Props, State> {
+  constructor(props: any) {
+    super(props);
+
+    // const _ = window.Lodash;
+
+    this.onMemberClicked = this.onMemberClicked.bind(this);
+    this.onClickOK = this.onClickOK.bind(this);
+    this.onKeyUp = this.onKeyUp.bind(this);
+    this.closeDialog = this.closeDialog.bind(this);
+    this.onGroupNameChanged = this.onGroupNameChanged.bind(this);
+
+    let friends = this.props.friendList;
+    friends = friends.map(d => {
+      const lokiProfile = d.getLokiProfile();
+      const name = lokiProfile ? lokiProfile.displayName : 'Anonymous';
+
+      return {
+        id: d.id,
+        authorPhoneNumber: d.id,
+        authorProfileName: name,
+        selected: false,
+        authorName: name, // different from ProfileName?
+        authorColor: d.getColor(),
+        checkmarked: false,
+      };
+    });
+
+    this.state = {
+      friendList: friends,
+      groupName: '',
+    };
+
+    window.addEventListener('keyup', this.onKeyUp);
+  }
+
+  private onKeyUp(event: any) {
+    switch (event.key) {
+      case 'Enter':
+        this.onClickOK();
+        break;
+      case 'Esc':
+      case 'Escape':
+        this.closeDialog();
+        break;
+      default:
+        break;
+    }
+  }
+
+  private closeDialog() {
+    window.removeEventListener('keyup', this.onKeyUp);
+
+    this.props.onClose();
+  }
+
+  private onMemberClicked(selected: any) {
+    this.setState(state => {
+      const updatedFriends = this.state.friendList.map(member => {
+        if (member.id === selected.id) {
+          return { ...member, checkmarked: !member.checkmarked };
+        } else {
+          return member;
+        }
+      });
+
+      return {
+        ...state,
+        friendList: updatedFriends,
+      };
+    });
+  }
+
+  public onClickOK() {
+    const members = this.state.friendList
+      .filter(d => d.checkmarked)
+      .map(d => d.id);
+
+    if (!this.state.groupName.trim()) {
+      console.error('Group name cannot be empty!');
+      return;
+    }
+
+    window.doCreateGroup(this.state.groupName, members);
+
+    this.closeDialog();
+  }
+
+  private onGroupNameChanged(event: any) {
+    event.persist();
+
+    this.setState(state => {
+      return {
+        ...state,
+        groupName: event.target.value,
+      };
+    });
+  }
+
+  public render() {
+    const titleText = this.props.titleText;
+    const okText = this.props.okText;
+    const cancelText = this.props.cancelText;
+
+    return (
+      <div className="content">
+        <p className="titleText">{titleText}</p>
+        <input
+          type="text"
+          id="group-name"
+          className="group-name"
+          placeholder="Group Name"
+          value={this.state.groupName}
+          onChange={this.onGroupNameChanged}
+          tabIndex={0}
+          required
+          autoFocus
+        />
+        <div className="friend-selection-list">
+          <MemberList
+            members={this.state.friendList}
+            selected={{}}
+            i18n={this.props.i18n}
+            onMemberClicked={this.onMemberClicked}
+          />
+        </div>
+        <div className="buttons">
+          <button className="cancel" tabIndex={2} onClick={this.closeDialog}>
+            {cancelText}
+          </button>
+          <button className="ok" tabIndex={1} onClick={this.onClickOK}>
+            {okText}
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/ts/components/conversation/Emojify.tsx
+++ b/ts/components/conversation/Emojify.tsx
@@ -56,17 +56,25 @@ interface Props {
   /** Allows you to customize now non-newlines are rendered. Simplest is just a <span>. */
   renderNonEmoji?: RenderTextCallbackType;
   i18n: LocalizerType;
-  isPublic?: boolean;
+  isGroup?: boolean;
+  convoId: string;
 }
 
 export class Emojify extends React.Component<Props> {
   public static defaultProps: Partial<Props> = {
     renderNonEmoji: ({ text }) => text || '',
-    isPublic: false,
+    isGroup: false,
   };
 
   public render() {
-    const { text, sizeClass, renderNonEmoji, i18n, isPublic } = this.props;
+    const {
+      text,
+      sizeClass,
+      renderNonEmoji,
+      i18n,
+      isGroup,
+      convoId,
+    } = this.props;
     const results: Array<any> = [];
     const regex = getRegex();
 
@@ -81,14 +89,19 @@ export class Emojify extends React.Component<Props> {
     let count = 1;
 
     if (!match) {
-      return renderNonEmoji({ text, key: 0, isPublic });
+      return renderNonEmoji({ text, key: 0, isGroup, convoId });
     }
 
     while (match) {
       if (last < match.index) {
         const textWithNoEmoji = text.slice(last, match.index);
         results.push(
-          renderNonEmoji({ text: textWithNoEmoji, key: count++, isPublic })
+          renderNonEmoji({
+            text: textWithNoEmoji,
+            key: count++,
+            isGroup,
+            convoId,
+          })
         );
       }
 
@@ -100,7 +113,12 @@ export class Emojify extends React.Component<Props> {
 
     if (last < text.length) {
       results.push(
-        renderNonEmoji({ text: text.slice(last), key: count++, isPublic })
+        renderNonEmoji({
+          text: text.slice(last),
+          key: count++,
+          isGroup,
+          convoId,
+        })
       );
     }
 

--- a/ts/components/conversation/GroupNotification.tsx
+++ b/ts/components/conversation/GroupNotification.tsx
@@ -15,7 +15,7 @@ interface Contact {
 }
 
 interface Change {
-  type: 'add' | 'remove' | 'name' | 'general';
+  type: 'add' | 'remove' | 'name' | 'general' | 'kicked';
   isMe: boolean;
   newName?: string;
   contacts?: Array<Contact>;
@@ -78,6 +78,21 @@ export class GroupNotification extends React.Component<Props> {
           contacts.length > 1 ? 'multipleLeftTheGroup' : 'leftTheGroup';
 
         return <Intl i18n={i18n} id={leftKey} components={[people]} />;
+      case 'kicked':
+        if (isMe) {
+          return i18n('youGotKickedFromGroup');
+        }
+
+        if (!contacts || !contacts.length) {
+          throw new Error('Group update is missing contacts');
+        }
+
+        const kickedKey =
+          contacts.length > 1
+            ? 'multipleKickedFromTheGroup'
+            : 'kickedFromTheGroup';
+
+        return <Intl i18n={i18n} id={kickedKey} components={[people]} />;
       case 'general':
         return i18n('updatedTheGroup');
       default:

--- a/ts/components/conversation/MemberList.tsx
+++ b/ts/components/conversation/MemberList.tsx
@@ -2,10 +2,22 @@ import React from 'react';
 import classNames from 'classnames';
 import { Avatar } from '../Avatar';
 
+export interface Contact {
+  id: string;
+  selected: boolean;
+  authorProfileName: string;
+  authorPhoneNumber: string;
+  authorName: string;
+  authorColor: any;
+  authorAvatarPath: string;
+  checkmarked: boolean;
+}
 interface MemberItemProps {
-  member: any;
-  selected: Boolean;
+  member: Contact;
+  selected: boolean;
   onClicked: any;
+  i18n: any;
+  checkmarked: boolean;
 }
 
 class MemberItem extends React.Component<MemberItemProps> {
@@ -19,6 +31,10 @@ class MemberItem extends React.Component<MemberItemProps> {
     const pubkey = this.props.member.authorPhoneNumber;
     const selected = this.props.selected;
 
+    const checkMarkClass = this.props.checkmarked
+      ? 'check-mark'
+      : classNames('check-mark', 'hidden');
+
     return (
       <div
         role="button"
@@ -31,6 +47,7 @@ class MemberItem extends React.Component<MemberItemProps> {
         {this.renderAvatar()}
         <span className="name-part">{name}</span>
         <span className="pubkey-part">{pubkey}</span>
+        <span className={checkMarkClass}>✓</span>
       </div>
     );
   }
@@ -45,7 +62,7 @@ class MemberItem extends React.Component<MemberItemProps> {
         avatarPath={this.props.member.authorAvatarPath}
         color={this.props.member.authorColor}
         conversationType="direct"
-        i18n={this.props.member.i18n}
+        i18n={this.props.i18n}
         name={this.props.member.authorName}
         phoneNumber={this.props.member.authorPhoneNumber}
         profileName={this.props.member.authorProfileName}
@@ -56,9 +73,10 @@ class MemberItem extends React.Component<MemberItemProps> {
 }
 
 interface MemberListProps {
-  members: [any];
+  members: Contact[];
   selected: any;
   onMemberClicked: any;
+  i18n: any;
 }
 
 export class MemberList extends React.Component<MemberListProps> {
@@ -79,6 +97,8 @@ export class MemberList extends React.Component<MemberListProps> {
           key={item.id}
           member={item}
           selected={selected}
+          checkmarked={item.checkmarked}
+          i18n={this.props.i18n}
           onClicked={this.handleMemberClicked}
         />
       );

--- a/ts/components/conversation/MemberList.tsx
+++ b/ts/components/conversation/MemberList.tsx
@@ -11,10 +11,12 @@ export interface Contact {
   authorColor: any;
   authorAvatarPath: string;
   checkmarked: boolean;
+  existingMember: boolean;
 }
 interface MemberItemProps {
   member: Contact;
   selected: boolean;
+  existingMember: boolean;
   onClicked: any;
   i18n: any;
   checkmarked: boolean;
@@ -30,10 +32,41 @@ class MemberItem extends React.Component<MemberItemProps> {
     const name = this.props.member.authorProfileName;
     const pubkey = this.props.member.authorPhoneNumber;
     const selected = this.props.selected;
+    const existingMember = this.props.existingMember;
 
-    const checkMarkClass = this.props.checkmarked
-      ? 'check-mark'
-      : classNames('check-mark', 'invisible');
+    let markType: 'none' | 'kicked' | 'added' | 'existing' = 'none';
+
+    if (this.props.checkmarked) {
+      if (existingMember) {
+        markType = 'kicked';
+      } else {
+        markType = 'added';
+      }
+    } else {
+      if (existingMember) {
+        markType = 'existing';
+      } else {
+        markType = 'none';
+      }
+    }
+
+    const markClasses = ['check-mark'];
+
+    switch (markType) {
+      case 'none':
+        markClasses.push('invisible');
+        break;
+      case 'existing':
+        markClasses.push('existing-member');
+        break;
+      case 'kicked':
+        markClasses.push('existing-member-kicked');
+        break;
+      default:
+      // do nothing
+    }
+
+    const mark = markType === 'kicked' ? '✘' : '✔';
 
     return (
       <div
@@ -47,7 +80,7 @@ class MemberItem extends React.Component<MemberItemProps> {
         {this.renderAvatar()}
         <span className="name-part">{name}</span>
         <span className="pubkey-part">{pubkey}</span>
-        <span className={checkMarkClass}>✓</span>
+        <span className={classNames(markClasses)}>{mark}</span>
       </div>
     );
   }
@@ -98,6 +131,7 @@ export class MemberList extends React.Component<MemberListProps> {
           member={item}
           selected={selected}
           checkmarked={item.checkmarked}
+          existingMember={item.existingMember}
           i18n={this.props.i18n}
           onClicked={this.handleMemberClicked}
         />

--- a/ts/components/conversation/MemberList.tsx
+++ b/ts/components/conversation/MemberList.tsx
@@ -33,7 +33,7 @@ class MemberItem extends React.Component<MemberItemProps> {
 
     const checkMarkClass = this.props.checkmarked
       ? 'check-mark'
-      : classNames('check-mark', 'hidden');
+      : classNames('check-mark', 'invisible');
 
     return (
       <div
@@ -73,7 +73,7 @@ class MemberItem extends React.Component<MemberItemProps> {
 }
 
 interface MemberListProps {
-  members: Contact[];
+  members: Array<Contact>;
   selected: any;
   onMemberClicked: any;
   i18n: any;

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -93,6 +93,7 @@ export interface Props {
   isExpired: boolean;
   expirationLength?: number;
   expirationTimestamp?: number;
+  convoId: string;
   isP2p?: boolean;
   isPublic?: boolean;
   isRss?: boolean;
@@ -590,6 +591,7 @@ export class Message extends React.PureComponent<Props, State> {
       i18n,
       quote,
       isPublic,
+      convoId,
     } = this.props;
 
     if (!quote) {
@@ -614,6 +616,8 @@ export class Message extends React.PureComponent<Props, State> {
         text={quote.text}
         attachment={quote.attachment}
         isIncoming={direction === 'incoming'}
+        conversationType={conversationType}
+        convoId={convoId}
         isPublic={isPublic}
         authorPhoneNumber={displayedPubkey}
         authorProfileName={quote.authorProfileName}
@@ -718,7 +722,16 @@ export class Message extends React.PureComponent<Props, State> {
   }
 
   public renderText() {
-    const { text, textPending, i18n, direction, status, isRss } = this.props;
+    const {
+      text,
+      textPending,
+      i18n,
+      direction,
+      status,
+      isRss,
+      conversationType,
+      convoId,
+    } = this.props;
 
     const contents =
       direction === 'incoming' && status === 'error'
@@ -745,7 +758,8 @@ export class Message extends React.PureComponent<Props, State> {
           isRss={isRss}
           i18n={i18n}
           textPending={textPending}
-          isPublic={this.props.isPublic}
+          isGroup={conversationType === 'group'}
+          convoId={convoId}
         />
       </div>
     );

--- a/ts/components/conversation/MessageBody.tsx
+++ b/ts/components/conversation/MessageBody.tsx
@@ -20,7 +20,7 @@ interface Props {
   i18n: LocalizerType;
   convoId: string;
 }
-// eslint-disable-next-line
+
 const renderMentions: RenderTextCallbackType = ({ text, key, convoId }) => (
   <AddMentions key={key} text={text} convoId={convoId} />
 );

--- a/ts/components/conversation/MessageBody.tsx
+++ b/ts/components/conversation/MessageBody.tsx
@@ -16,12 +16,13 @@ interface Props {
   disableJumbomoji?: boolean;
   /** If set, links will be left alone instead of turned into clickable `<a>` tags. */
   disableLinks?: boolean;
-  isPublic?: boolean;
+  isGroup?: boolean;
   i18n: LocalizerType;
+  convoId: string;
 }
-
-const renderMentions: RenderTextCallbackType = ({ text, key }) => (
-  <AddMentions key={key} text={text} />
+// eslint-disable-next-line
+const renderMentions: RenderTextCallbackType = ({ text, key, convoId }) => (
+  <AddMentions key={key} text={text} convoId={convoId} />
 );
 
 const renderDefault: RenderTextCallbackType = ({ text }) => text;
@@ -29,15 +30,17 @@ const renderDefault: RenderTextCallbackType = ({ text }) => text;
 const renderNewLines: RenderTextCallbackType = ({
   text: textWithNewLines,
   key,
-  isPublic,
+  isGroup,
+  convoId,
 }) => {
-  const renderOther = isPublic ? renderMentions : renderDefault;
+  const renderOther = isGroup ? renderMentions : renderDefault;
 
   return (
     <AddNewLines
       key={key}
       text={textWithNewLines}
       renderNonNewLine={renderOther}
+      convoId={convoId}
     />
   );
 };
@@ -48,14 +51,16 @@ const renderEmoji = ({
   key,
   sizeClass,
   renderNonEmoji,
-  isPublic,
+  isGroup,
+  convoId,
 }: {
   i18n: LocalizerType;
   text: string;
   key: number;
   sizeClass?: SizeClassType;
   renderNonEmoji: RenderTextCallbackType;
-  isPublic?: boolean;
+  isGroup?: boolean;
+  convoId?: string;
 }) => (
   <Emojify
     i18n={i18n}
@@ -63,7 +68,8 @@ const renderEmoji = ({
     text={text}
     sizeClass={sizeClass}
     renderNonEmoji={renderNonEmoji}
-    isPublic={isPublic}
+    isGroup={isGroup}
+    convoId={convoId}
   />
 );
 
@@ -75,7 +81,7 @@ const renderEmoji = ({
  */
 export class MessageBody extends React.Component<Props> {
   public static defaultProps: Partial<Props> = {
-    isPublic: false,
+    isGroup: false,
   };
 
   public addDownloading(jsx: JSX.Element): JSX.Element {
@@ -102,7 +108,8 @@ export class MessageBody extends React.Component<Props> {
       disableLinks,
       isRss,
       i18n,
-      isPublic,
+      isGroup,
+      convoId,
     } = this.props;
     const sizeClass = disableJumbomoji ? undefined : getSizeClass(text);
     const textWithPending = textPending ? `${text}...` : text;
@@ -115,7 +122,8 @@ export class MessageBody extends React.Component<Props> {
           sizeClass,
           key: 0,
           renderNonEmoji: renderNewLines,
-          isPublic,
+          isGroup,
+          convoId,
         })
       );
     }
@@ -131,7 +139,8 @@ export class MessageBody extends React.Component<Props> {
             sizeClass,
             key,
             renderNonEmoji: renderNewLines,
-            isPublic,
+            isGroup,
+            convoId,
           });
         }}
       />

--- a/ts/components/conversation/Quote.tsx
+++ b/ts/components/conversation/Quote.tsx
@@ -19,6 +19,8 @@ interface Props {
   i18n: LocalizerType;
   isFromMe: boolean;
   isIncoming: boolean;
+  conversationType: 'group' | 'direct';
+  convoId: string;
   isPublic?: boolean;
   withContentAbove: boolean;
   onClick?: () => void;
@@ -215,7 +217,14 @@ export class Quote extends React.Component<Props, State> {
   }
 
   public renderText() {
-    const { i18n, text, attachment, isIncoming, isPublic } = this.props;
+    const {
+      i18n,
+      text,
+      attachment,
+      isIncoming,
+      conversationType,
+      convoId,
+    } = this.props;
 
     if (text) {
       return (
@@ -227,7 +236,8 @@ export class Quote extends React.Component<Props, State> {
           )}
         >
           <MessageBody
-            isPublic={isPublic}
+            isGroup={conversationType === 'group'}
+            convoId={convoId}
             text={text}
             disableLinks={true}
             i18n={i18n}

--- a/ts/components/conversation/UpdateGroupDialog.tsx
+++ b/ts/components/conversation/UpdateGroupDialog.tsx
@@ -112,7 +112,7 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
           type="text"
           id="group-name"
           className="group-name"
-          placeholder="Group Name"
+          placeholder={this.props.i18n('groupNamePlaceholder')}
           value={this.state.groupName}
           disabled={!this.props.isAdmin}
           onChange={this.onGroupNameChanged}

--- a/ts/components/conversation/UpdateGroupDialog.tsx
+++ b/ts/components/conversation/UpdateGroupDialog.tsx
@@ -45,7 +45,7 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
       const lokiProfile = d.getLokiProfile();
       const name = lokiProfile ? lokiProfile.displayName : 'Anonymous';
 
-      const existingMember = this.props.existingMembers.indexOf(d.id) !== -1;
+      const existingMember = this.props.existingMembers.includes(d.id);
 
       return {
         id: d.id,

--- a/ts/components/conversation/UpdateGroupDialog.tsx
+++ b/ts/components/conversation/UpdateGroupDialog.tsx
@@ -1,19 +1,15 @@
 import React from 'react';
+import classNames from 'classnames';
 import { Contact, MemberList } from './MemberList';
-
-declare global {
-  interface Window {
-    Lodash: any;
-    doCreateGroup: any;
-  }
-}
 
 interface Props {
   titleText: string;
+  groupName: string;
   okText: string;
   cancelText: string;
   friendList: Array<any>;
   i18n: any;
+  onSubmit: any;
   onClose: any;
 }
 
@@ -22,11 +18,9 @@ interface State {
   groupName: string;
 }
 
-export class CreateGroupDialog extends React.Component<Props, State> {
+export class UpdateGroupDialog extends React.Component<Props, State> {
   constructor(props: any) {
     super(props);
-
-    // const _ = window.Lodash;
 
     this.onMemberClicked = this.onMemberClicked.bind(this);
     this.onClickOK = this.onClickOK.bind(this);
@@ -52,7 +46,7 @@ export class CreateGroupDialog extends React.Component<Props, State> {
 
     this.state = {
       friendList: friends,
-      groupName: '',
+      groupName: this.props.groupName,
     };
 
     window.addEventListener('keyup', this.onKeyUp);
@@ -65,11 +59,11 @@ export class CreateGroupDialog extends React.Component<Props, State> {
 
     if (!this.state.groupName.trim()) {
       // TODO: show error message
-      // console.error('Group name cannot be empty!');
+      // window.log.error('Group name cannot be empty!');
       return;
     }
 
-    window.doCreateGroup(this.state.groupName, members);
+    this.props.onSubmit(this.state.groupName, members);
 
     this.closeDialog();
   }
@@ -78,6 +72,11 @@ export class CreateGroupDialog extends React.Component<Props, State> {
     const titleText = this.props.titleText;
     const okText = this.props.okText;
     const cancelText = this.props.cancelText;
+
+    const noFriendsClasses =
+      this.state.friendList.length === 0
+        ? 'no-friends'
+        : classNames('no-friends', 'hidden');
 
     return (
       <div className="content">
@@ -91,8 +90,8 @@ export class CreateGroupDialog extends React.Component<Props, State> {
           onChange={this.onGroupNameChanged}
           tabIndex={0}
           required={true}
-          autoFocus={true}
           aria-required={true}
+          autoFocus={true}
         />
         <div className="friend-selection-list">
           <MemberList
@@ -102,6 +101,7 @@ export class CreateGroupDialog extends React.Component<Props, State> {
             onMemberClicked={this.onMemberClicked}
           />
         </div>
+        <p className={noFriendsClasses}>(no friends to add)</p>
         <div className="buttons">
           <button className="cancel" tabIndex={0} onClick={this.closeDialog}>
             {cancelText}
@@ -112,17 +112,6 @@ export class CreateGroupDialog extends React.Component<Props, State> {
         </div>
       </div>
     );
-  }
-
-  private onGroupNameChanged(event: any) {
-    event.persist();
-
-    this.setState(state => {
-      return {
-        ...state,
-        groupName: event.target.value,
-      };
-    });
   }
 
   private onKeyUp(event: any) {
@@ -157,6 +146,17 @@ export class CreateGroupDialog extends React.Component<Props, State> {
       return {
         ...state,
         friendList: updatedFriends,
+      };
+    });
+  }
+
+  private onGroupNameChanged(event: any) {
+    event.persist();
+
+    this.setState(state => {
+      return {
+        ...state,
+        groupName: event.target.value,
       };
     });
   }

--- a/ts/components/conversation/UpdateGroupDialog.tsx
+++ b/ts/components/conversation/UpdateGroupDialog.tsx
@@ -16,6 +16,7 @@ interface Props {
 interface State {
   friendList: Array<Contact>;
   groupName: string;
+  errorDisplayed: boolean;
 }
 
 export class UpdateGroupDialog extends React.Component<Props, State> {
@@ -47,6 +48,7 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
     this.state = {
       friendList: friends,
       groupName: this.props.groupName,
+      errorDisplayed: false,
     };
 
     window.addEventListener('keyup', this.onKeyUp);
@@ -58,8 +60,8 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
       .map(d => d.id);
 
     if (!this.state.groupName.trim()) {
-      // TODO: show error message
-      // window.log.error('Group name cannot be empty!');
+      this.onShowError();
+
       return;
     }
 
@@ -78,9 +80,16 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
         ? 'no-friends'
         : classNames('no-friends', 'hidden');
 
+    const errorMsg = this.props.i18n('emptyGroupNameError');
+    const errorMessageClasses = classNames(
+      'error-message',
+      this.state.errorDisplayed ? 'error-shown' : 'error-faded'
+    );
+
     return (
       <div className="content">
         <p className="titleText">{titleText}</p>
+        <p className={errorMessageClasses}>{errorMsg}</p>
         <input
           type="text"
           id="group-name"
@@ -112,6 +121,22 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
         </div>
       </div>
     );
+  }
+
+  private onShowError() {
+    if (this.state.errorDisplayed) {
+      return;
+    }
+
+    this.setState({
+      errorDisplayed: true,
+    });
+
+    setTimeout(() => {
+      this.setState({
+        errorDisplayed: false,
+      });
+    }, 3000);
   }
 
   private onKeyUp(event: any) {

--- a/ts/state/ducks/conversations.ts
+++ b/ts/state/ducks/conversations.ts
@@ -137,7 +137,6 @@ export const actions = {
   openConversationExternal,
   showInbox,
   showArchivedConversations,
-  createNewGroup,
 };
 
 function conversationAdded(
@@ -228,16 +227,6 @@ function showInbox() {
 function showArchivedConversations() {
   return {
     type: 'SHOW_ARCHIVED_CONVERSATIONS',
-    payload: null,
-  };
-}
-
-function createNewGroup() {
-  // Not sure how much of this is necessary:
-  trigger('createNewGroup');
-
-  return {
-    type: 'CREATE_NEW_GROUP',
     payload: null,
   };
 }

--- a/ts/state/ducks/conversations.ts
+++ b/ts/state/ducks/conversations.ts
@@ -235,6 +235,7 @@ function showArchivedConversations() {
 function createNewGroup() {
   // Not sure how much of this is necessary:
   trigger('createNewGroup');
+
   return {
     type: 'CREATE_NEW_GROUP',
     payload: null,

--- a/ts/state/ducks/conversations.ts
+++ b/ts/state/ducks/conversations.ts
@@ -137,6 +137,7 @@ export const actions = {
   openConversationExternal,
   showInbox,
   showArchivedConversations,
+  createNewGroup,
 };
 
 function conversationAdded(
@@ -227,6 +228,15 @@ function showInbox() {
 function showArchivedConversations() {
   return {
     type: 'SHOW_ARCHIVED_CONVERSATIONS',
+    payload: null,
+  };
+}
+
+function createNewGroup() {
+  // Not sure how much of this is necessary:
+  trigger('createNewGroup');
+  return {
+    type: 'CREATE_NEW_GROUP',
     payload: null,
   };
 }

--- a/ts/types/Util.ts
+++ b/ts/types/Util.ts
@@ -2,7 +2,8 @@ export type RenderTextCallbackType = (
   options: {
     text: string;
     key: number;
-    isPublic?: boolean;
+    isGroup?: boolean;
+    convoId?: string;
   }
 ) => JSX.Element | string;
 


### PR DESCRIPTION
Among other things this PR includes:
- UI for creating a new private group chat (initial members can be selected from existing friends).
- Automatically establishing pairwise signal encryption sessions in the background for members that don't have them already.
- UI for updating existing private group chats: currently everyone can change the name and add new users (but might limit that to the creator of the group in a future PR).