### PR TITLE
Delete public chat messages locally if not stored on the server

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -2425,11 +2425,20 @@
       if (!channelAPI) {
         return false;
       }
-      const success = await channelAPI.deleteMessage(message.getServerId());
-      if (success) {
+      const serverId = message.getServerId();
+
+      const success = serverId
+        ? await channelAPI.deleteMessage(serverId)
+        : false;
+
+      const shouldDeleteLocally = success || message.hasErrors() || !serverId;
+      // If the message has errors it is likely not saved
+      // on the server, so we delete it locally unconditionally
+      if (shouldDeleteLocally) {
         this.removeMessage(message.id);
       }
-      return success;
+
+      return shouldDeleteLocally;
     },
 
     removeMessage(messageId) {


### PR DESCRIPTION
- Deleting of failed messages now works and it doesn't ask for user confirmation
- Fixes #587