### PR TITLE
[multi-device]show pairing words on paired device list

### DIFF
--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -99,7 +99,8 @@
         if (pubKeys && pubKeys.length > 0) {
           this.$('#pairedPubKeys').empty();
           pubKeys.forEach(x => {
-            this.$('#pairedPubKeys').append(`<li>${x}</li>`);
+            const secretWords = window.mnemonic.pubkey_to_secret_words(x);
+            this.$('#pairedPubKeys').append(`<li>(${secretWords})</li>`);
           });
         }
       } else if (this.accepted) {
@@ -108,11 +109,7 @@
         waitingForRequestView.hide();
         requestAcceptedView.show();
       } else if (this.pubKey) {
-        const secretWords = window.mnemonic
-          .mn_encode(this.pubKey.slice(2), 'english')
-          .split(' ')
-          .slice(-3)
-          .join(' ');
+        const secretWords = window.mnemonic.pubkey_to_secret_words(this.pubKey);
         this.$('.secretWords').text(secretWords);
         requestReceivedView.show();
         waitingForRequestView.hide();

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -268,11 +268,7 @@
         );
         await this.accountManager.requestPairing(primaryPubKey);
         const pubkey = textsecure.storage.user.getNumber();
-        const words = window.mnemonic
-          .mn_encode(pubkey.slice(2), 'english')
-          .split(' ')
-          .slice(-3)
-          .join(' ');
+        const words = window.mnemonic.pubkey_to_secret_words(pubkey);
 
         this.$('.standalone-secondary-device #pubkey').text(
           `Here is your secret:\n${words}`

--- a/libloki/modules/mnemonic.js
+++ b/libloki/modules/mnemonic.js
@@ -6,6 +6,7 @@ module.exports = {
   mn_decode,
   sc_reduce32,
   get_languages,
+  pubkey_to_secret_words,
 };
 class MnemonicError extends Error {}
 
@@ -189,4 +190,11 @@ for (var i in mn_words) {
       );
     }
   }
+}
+
+function pubkey_to_secret_words(pubKey) {
+  return mn_encode(pubKey.slice(2), 'english')
+    .split(' ')
+    .slice(-3)
+    .join(' ');
 }


### PR DESCRIPTION
Since the user has no ways to know the paired device's pubkeys, show the secret words instead.
Also, refactor the creation of the secret words into its own function.
The next step is allowing the primary device to define an alias for those secondary devices.