### PR TITLE
[multi-device]Allow primary device to assign local aliases to paired devices

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -955,6 +955,9 @@
   "allowPairing": {
     "message": "Allow Pairing"
   },
+  "provideDeviceAlias": {
+    "message": "Please provide an alias for this paired device"
+  },
   "clear": {
     "message": "Clear"
   },

--- a/background.html
+++ b/background.html
@@ -285,7 +285,10 @@
         <h4>{{ requestAcceptedTitle }}</h4>
         <p class="secretWords"></p>
         <p class="transmissionStatus">Please be patient...</p>
-        <div class='buttons'>
+        <div id="deviceAliasView" style="display: none;" >
+          <input id="deviceAlias" type="text" placeholder="Device Alias" required>
+        </div>
+          <div class='buttons'>
           <button class="ok" style="display: none;">{{ okText }}</button>
         </div>
       </div>

--- a/background.html
+++ b/background.html
@@ -288,7 +288,7 @@
         <div id="deviceAliasView" style="display: none;" >
           <input id="deviceAlias" type="text" placeholder="Device Alias" required>
         </div>
-          <div class='buttons'>
+        <div class='buttons'>
           <button class="ok" style="display: none;">{{ okText }}</button>
         </div>
       </div>

--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -79,7 +79,7 @@
       if (!errors) {
         this.$('.transmissionStatus').text(i18n('provideDeviceAlias'));
         this.$('#deviceAliasView').show();
-        this.$('#deviceAlias').on('keydown', (e) => {
+        this.$('#deviceAlias').on('keydown', e => {
           if (e.target.value.trim()) {
             this.$('.requestAcceptedView .ok').removeAttr('disabled');
           } else {
@@ -124,7 +124,9 @@
             if (conv) {
               deviceAlias = conv.getNickname();
             }
-            this.$('#pairedPubKeys').append(`<li>${deviceAlias} (${secretWords})</li>`);
+            this.$('#pairedPubKeys').append(
+              `<li>${deviceAlias} (${secretWords})</li>`
+            );
           });
         }
       } else if (this.accepted) {


### PR DESCRIPTION
<img width="738" alt="Screen Shot 2019-11-01 at 4 24 05 pm" src="https://user-images.githubusercontent.com/40749766/68004084-2f5e2780-fcc4-11e9-95f6-63d3cbbde652.png">
<img width="720" alt="Screen Shot 2019-11-01 at 4 24 28 pm" src="https://user-images.githubusercontent.com/40749766/68004090-338a4500-fcc4-11e9-8f29-c8bcad0688c3.png">
Note that the alias is mandatory and that the "ok" button is disabled if the input field is empty.
