### PR TITLE
[multi-device] Fix secondary nickname

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -722,7 +722,7 @@
     });
 
     Whisper.events.on('onEditProfile', async () => {
-      const ourNumber = textsecure.storage.user.getNumber();
+      const ourNumber = window.storage.get('primaryDevicePubKey');
       const conversation = await ConversationController.getOrCreateAndWait(
         ourNumber,
         'private'

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1111,7 +1111,7 @@ MessageReceiver.prototype.extend({
         Whisper.events.trigger('secondaryDeviceRegistration');
         // Update profile name
         if (dataMessage && dataMessage.profile) {
-          const ourNumber = textsecure.storage.user.getNumber();
+          const ourNumber = window.storage.get('primaryDevicePubKey');
           const me = window.ConversationController.get(ourNumber);
           if (me) {
             me.setLokiProfile(dataMessage.profile);


### PR DESCRIPTION
The nickname/display name doesn't currently work on secondary devices.
This is because the nickname received from the primary device is applied to the "real" secondary conversation, but the UI receives `ourNumber` which is set to the primary pubkey, and looks up teh primary device's conversation to get the nickname, which is empty.
Basically the inbox UI could keep our "real" number, but having the `phoneNumber` field always show the `primaryDevicePubKey`.
This is a bit spaghetti soup so suggestions welcome.