### PR TITLE
Use first 3 mnemonic words instead of the last 3 when displaying secret words.

### DIFF
--- a/libloki/modules/mnemonic.js
+++ b/libloki/modules/mnemonic.js
@@ -195,6 +195,6 @@ for (var i in mn_words) {
 function pubkey_to_secret_words(pubKey) {
   return mn_encode(pubKey.slice(2), 'english')
     .split(' ')
-    .slice(-3)
+    .slice(0, 3)
     .join(' ');
 }


### PR DESCRIPTION
This fixes the issue where the words on mobile and desktop were different.