### PR TITLE
Fix recurring memory leak in mentions

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -103,6 +103,7 @@ module.exports = {
   getAllRssFeedConversations,
   getAllPublicConversations,
   getPublicConversationsByServer,
+  getPubkeysInPublicConversation,
   getPubKeysWithFriendStatus,
   getAllConversationIds,
   getAllPrivateConversations,
@@ -1738,6 +1739,19 @@ async function getPublicConversationsByServer(server) {
   );
 
   return map(rows, row => jsonToObject(row.json));
+}
+
+async function getPubkeysInPublicConversation(id) {
+  const rows = await db.all(
+    `SELECT DISTINCT source FROM messages WHERE
+      conversationId = $conversationId
+     ORDER BY id ASC;`,
+    {
+      $conversationId: id,
+    }
+  );
+
+  return map(rows, row => row.source);
 }
 
 async function getAllGroupsInvolvingId(id) {

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -1,4 +1,4 @@
-/* global window, setTimeout, IDBKeyRange */
+/* global window, setTimeout, clearTimeout, IDBKeyRange */
 
 const electron = require('electron');
 
@@ -124,6 +124,7 @@ module.exports = {
   getAllRssFeedConversations,
   getAllPublicConversations,
   getPublicConversationsByServer,
+  getPubkeysInPublicConversation,
   savePublicServerToken,
   getPublicServerTokenByServerUrl,
   getAllGroupsInvolvingId,
@@ -312,6 +313,11 @@ function _removeJob(id) {
     return;
   }
 
+  if (_jobs[id].timer) {
+    clearTimeout(_jobs[id].timer);
+    _jobs[id].timer = null;
+  }
+
   delete _jobs[id];
 
   if (_shutdownCallback) {
@@ -363,7 +369,7 @@ function makeChannel(fnName) {
         args: _DEBUG ? args : null,
       });
 
-      setTimeout(
+      _jobs[jobId].timer = setTimeout(
         () =>
           reject(new Error(`SQL channel job ${jobId} (${fnName}) timed out`)),
         DATABASE_UPDATE_TIMEOUT
@@ -762,6 +768,10 @@ async function getAllPrivateConversations({ ConversationCollection }) {
   const collection = new ConversationCollection();
   collection.add(conversations);
   return collection;
+}
+
+async function getPubkeysInPublicConversation(id) {
+  return channels.getPubkeysInPublicConversation(id);
 }
 
 async function savePublicServerToken(data) {

--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -22,6 +22,7 @@ class LokiAppDotNetAPI extends EventEmitter {
     this.ourKey = ourKey;
     this.servers = [];
     this.myPrivateKey = false;
+    this.allMembers = [];
   }
 
   async getPrivateKey() {
@@ -785,8 +786,8 @@ class LokiPublicChannelAPI {
       log.warn(`Error while polling for public chat messages: ${e}`);
     }
     if (this.running) {
-      setTimeout(() => {
-        this.timers.message = this.pollForMessages();
+      this.timers.message = setTimeout(() => {
+        this.pollForMessages();
       }, PUBLICCHAT_MSG_POLL_EVERY);
     }
   }

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -341,16 +341,19 @@
       this.selectMember = this.selectMember.bind(this);
 
       const updateMemberList = async () => {
-        const maxToFetch = 1000;
-        const allMessages = await window.Signal.Data.getMessagesByConversation(
-          this.model.id,
-          {
-            limit: maxToFetch,
-            MessageCollection: Whisper.MessageCollection,
-          }
+        const allPubKeys = await window.Signal.Data.getPubkeysInPublicConversation(
+          this.model.id
         );
 
-        const allMembers = allMessages.models.map(d => d.propsForMessage);
+        const allMembers = await Promise.all(
+          allPubKeys.map(async pubKey => ({
+            id: pubKey,
+            authorPhoneNumber: pubKey,
+            authorProfileName: await ConversationController.get(
+              pubKey
+            ).getProfileName(),
+          }))
+        );
         window.lokiPublicChatAPI.setListOfMembers(allMembers);
       };
 

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -346,13 +346,18 @@
         );
 
         const allMembers = await Promise.all(
-          allPubKeys.map(async pubKey => ({
-            id: pubKey,
-            authorPhoneNumber: pubKey,
-            authorProfileName: await ConversationController.get(
-              pubKey
-            ).getProfileName(),
-          }))
+          allPubKeys.map(async pubKey => {
+            const conv = ConversationController.get(pubKey);
+            let profileName = 'Anonymous';
+            if (conv) {
+              profileName = await conv.getProfileName();
+            }
+            return {
+              id: pubKey,
+              authorPhoneNumber: pubKey,
+              authorProfileName: profileName,
+            };
+          })
         );
         window.lokiPublicChatAPI.setListOfMembers(allMembers);
       };


### PR DESCRIPTION
Still not sure why the code was leaky.
~~But the solution was easy: the conversation view already has a reference to the conversation model via `this.model` which already has a `.messageCollection` which has `.models`...~~
Solved by adding a new SQL function to get all unique pubkeys in a public conversation.
Then get profile name from their respective conversation. The id is only used as a unique identifier by React, so using the pubkey works.
Other changes are self explanatory.

There still might be other leaky parts of the code. Still investigating.


EDIT: memory comparison:

BEFORE
![Screen Shot 2019-11-13 at 3 57 49 pm](https://user-images.githubusercontent.com/40749766/68734436-71755a80-062e-11ea-9230-852493321975.png)
note the horizontal grey line shows 500KB
AFTER
![Screen Shot 2019-11-13 at 3 55 39 pm](https://user-images.githubusercontent.com/40749766/68734444-75a17800-062e-11ea-8df3-176a213f9088.png)
note the horizontal grey line shows 10KB
