### PR TITLE
Prevent instantiating a new BulkEdit react component with every click

### DIFF
--- a/js/views/bulk_edit_view.js
+++ b/js/views/bulk_edit_view.js
@@ -8,12 +8,18 @@
 
   Whisper.BulkEditView = Whisper.View.extend({
     initialize(options) {
+      this.memberView = null;
       this.props = {
         onCancel: options.onCancel,
         onDelete: options.onDelete,
         messageCount: 0,
       };
-
+    },
+    render() {
+      if (this.memberView) {
+        this.memberView.update(this.props);
+        return;
+      }
       this.memberView = new Whisper.ReactWrapperView({
         className: 'bulk-edit-view',
         Component: window.Signal.Components.BulkEdit,
@@ -21,9 +27,6 @@
       });
 
       this.$el.append(this.memberView.el);
-    },
-    render() {
-      this.memberView.update(this.props);
     },
 
     update(selectionSize) {

--- a/js/views/bulk_edit_view.js
+++ b/js/views/bulk_edit_view.js
@@ -8,33 +8,26 @@
 
   Whisper.BulkEditView = Whisper.View.extend({
     initialize(options) {
-      this.selectedMessages = new Set();
-      this.render();
-      this.onCancel = options.onCancel;
-      this.onDelete = options.onDelete;
-    },
-    render() {
-      if (this.memberView) {
-        this.memberView.remove();
-        this.memberView = null;
-      }
+      this.props = {
+        onCancel: options.onCancel,
+        onDelete: options.onDelete,
+        messageCount: 0,
+      };
 
       this.memberView = new Whisper.ReactWrapperView({
         className: 'bulk-edit-view',
         Component: window.Signal.Components.BulkEdit,
-        props: {
-          messageCount: this.selectedMessages.size,
-          onCancel: this.onCancel,
-          onDelete: this.onDelete,
-        },
+        props: this.props,
       });
 
       this.$el.append(this.memberView.el);
-      return this;
+    },
+    render() {
+      this.memberView.update(this.props);
     },
 
-    update(selectedMessages) {
-      this.selectedMessages = selectedMessages;
+    update(selectionSize) {
+      this.props.messageCount = selectionSize;
       this.render();
     },
   });

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -1797,7 +1797,7 @@
         $('.compose').show();
       }
 
-      this.bulkEditView.update(this.model.selectedMessages);
+      this.bulkEditView.update(selectionSize);
     },
 
     resetMessageSelection() {


### PR DESCRIPTION
The react component tied to the bulk edit view can be instantiated once at init, then have its props (the number of selected messages) updated on request, instead of re-instantiating a new react component in the render function.