### PR TITLE
[multi-device]Cap paired devices to 1

### DIFF
--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -159,6 +159,7 @@
         const pubKeys = await libloki.storage.getSecondaryDevicesFor(ourPubKey);
         this.$('#pairedPubKeys').empty();
         if (pubKeys && pubKeys.length > 0) {
+          this.$('#startPairing').attr('disabled', true);
           pubKeys.forEach(x => {
             const name = this.getPubkeyName(x);
             const li = $('<li>').html(name);
@@ -173,6 +174,7 @@
             this.$('#pairedPubKeys').append(li);
           });
         } else {
+          this.$('#startPairing').removeAttr('disabled');
           this.$('#pairedPubKeys').append('<li>No paired devices</li>');
         }
       } else if (this.accepted) {


### PR DESCRIPTION
Cap number of devices to 1 by disabling the "pair new device" button:
<img width="652" alt="Screen Shot 2019-11-18 at 11 47 27 am" src="https://user-images.githubusercontent.com/40749766/69017456-42c6fd80-09fb-11ea-84e0-c2732af67ce7.png">
