### PR TITLE
Ensure primaryDevicePubKey is always defined in storage

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -305,6 +305,13 @@
       storage.put('PoWDifficulty', window.getDefaultPoWDifficulty());
     }
 
+    // Ensure accounts created prior to 1.0.0-beta8 do have their
+    // 'primaryDevicePubKey' defined.
+    const primaryDevicePubKey = storage.get('primaryDevicePubKey', null);
+    if (!primaryDevicePubKey) {
+      storage.put('primaryDevicePubKey', textsecure.storage.user.getNumber());
+    }
+
     // These make key operations available to IPC handlers created in preload.js
     window.Events = {
       getDeviceName: () => textsecure.storage.user.getDeviceName(),

--- a/js/background.js
+++ b/js/background.js
@@ -307,8 +307,7 @@
 
     // Ensure accounts created prior to 1.0.0-beta8 do have their
     // 'primaryDevicePubKey' defined.
-    const primaryDevicePubKey = storage.get('primaryDevicePubKey', null);
-    if (!primaryDevicePubKey) {
+    if (Whisper.Registration.isDone() && !storage.get('primaryDevicePubKey', null)) {
       storage.put('primaryDevicePubKey', textsecure.storage.user.getNumber());
     }
 


### PR DESCRIPTION
`primaryDevicePubKey` is currently set only at registration time.
This PR ensures that this value exists in storage even if the account was already created with an older version of the messenger.