### PR TITLE
Jump words with Ctrl and arrow keys

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -2418,7 +2418,7 @@
 
       // Alt would normally make the cursor go until the next whitespace,
       // but we need to take the presence of a mention into account
-      if (event.altKey) {
+      if (event.altKey || event.ctrlKey) {
         const searchFrom = isLeft ? posToChange - 1 : posToChange + 1;
         const toSearch = isLeft
           ? text.substr(0, searchFrom)


### PR DESCRIPTION
Might need to test this on Windows/Linux but it should work (works on MacOS if I disable its default behaviour for Ctrl).