### PR TITLE
Prevent prekeys to be deleted when re-sending pairing request

### DIFF
--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -444,12 +444,18 @@
 
       window.log.info('clearing all sessions, prekeys, and signed prekeys');
       await Promise.all([
-        store.clearPreKeyStore(),
         store.clearContactPreKeysStore(),
-        store.clearSignedPreKeysStore(),
         store.clearContactSignedPreKeysStore(),
         store.clearSessionStore(),
       ]);
+      // During secondary device registration we need to keep our prekeys sent
+      // to other pubkeys
+      if (textsecure.storage.get('secondaryDeviceStatus') !== 'ongoing') {
+        await Promise.all([
+          store.clearPreKeyStore(),
+          store.clearSignedPreKeysStore(),
+        ]);
+      }
     },
     // Takes the same object returned by generateKeys
     async confirmKeys(keys) {


### PR DESCRIPTION
This PR fixes the following use-case:

Mobile primary. Desktop secondary.
During pairing, Desktop needs to re-send the request (e.g. because Mobile wasn't accepting requests) by cancelling and re-sending the request.
The request arrives on Mobile, and is accepted.
Desktop would then print
`Error: Received a preKeyWhisperMessage (friend request accept) from an unknown source`

The reason for this is that when the user cancels the pairing request, it deletes all the prekey bundles stored in the database. But on mobile, although the first pairing request was ignored (because the linking modal was not open), the prekey bundle was still stored. Then when the second pairing request arrives, the second prekey bundle doesn't overwrite the first one. So when the pairing is accepted, the first prekey bundle is used to start the session instead of the second one.

The fix is this PR is to prevent deleting prekey bundles during secondary device pairing.
Then when re-sending the pairing request, the same (first) prekey bundle will be re-used automatically.