### PR TITLE
Sending and handling of special UNPAIRING_REQUEST message

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1025,6 +1025,15 @@
         pubKey
       );
     });
+
+    Whisper.events.on('deviceUnpairingRequested', async pubKey => {
+      await libloki.storage.removePairingAuthorisationForSecondaryPubKey(
+        pubKey
+      );
+      await window.lokiFileServerAPI.updateOurDeviceMapping();
+      // TODO: we should ensure the message was sent and retry automatically if not
+      await libloki.api.sendUnpairingMessageToSecondary(pubKey);
+    });
   }
 
   window.getSyncRequest = () =>

--- a/js/modules/loki_file_server_api.js
+++ b/js/modules/loki_file_server_api.js
@@ -224,6 +224,10 @@ class LokiFileServerAPI {
   uploadPrivateAttachment(data) {
     return this._server.uploadData(data);
   }
+
+  clearOurDeviceMappingAnnotations() {
+    return this._server.setSelfAnnotation(DEVICE_MAPPING_ANNOTATION_KEY, null);
+  }
 }
 
 module.exports = LokiFileServerAPI;

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -223,6 +223,9 @@
       dialog.on('devicePairingRequestRejected', pubKey =>
         Whisper.events.trigger('devicePairingRequestRejected', pubKey)
       );
+      dialog.on('deviceUnpairingRequested', pubKey =>
+        Whisper.events.trigger('deviceUnpairingRequested', pubKey)
+      );
       dialog.once('close', () => {
         Whisper.events.off('devicePairingRequestReceived');
       });

--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -117,10 +117,7 @@
       this.pubKey = this.pubKeyRequests.pop();
     },
     async confirmUnpairDevice() {
-      await libloki.storage.removePairingAuthorisationForSecondaryPubKey(
-        this.pubKeyToUnpair
-      );
-      await lokiFileServerAPI.updateOurDeviceMapping();
+      this.trigger('deviceUnpairingRequested', this.pubKeyToUnpair);
       this.reset();
       this.showView();
     },

--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -5,7 +5,6 @@
   textsecure,
   ConversationController,
   $,
-  lokiFileServerAPI
 */
 
 // eslint-disable-next-line func-names

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -107,6 +107,27 @@
       secondaryDevicePubKey,
     });
   }
+
+  function sendUnpairingMessageToSecondary(pubKey) {
+    const flags = textsecure.protobuf.DataMessage.Flags.UNPAIRING_REQUEST;
+    const dataMessage = new textsecure.protobuf.DataMessage({
+      flags,
+    });
+    const content = new textsecure.protobuf.Content({
+      dataMessage,
+    });
+    const options = { messageType: 'device-unpairing' };
+    const outgoingMessage = new textsecure.OutgoingMessage(
+      null, // server
+      Date.now(), // timestamp,
+      [pubKey], // numbers
+      content, // message
+      true, // silent
+      () => null, // callback
+      options
+    );
+    return outgoingMessage.sendToNumber(pubKey);
+  }
   // Serialise as <Element0.length><Element0><Element1.length><Element1>...
   // This is an implementation of the reciprocal of contacts_parser.js
   function serialiseByteBuffers(buffers) {
@@ -226,6 +247,7 @@
     broadcastOnlineStatus,
     sendPairingAuthorisation,
     createPairingAuthorisationProtoMessage,
+    sendUnpairingMessageToSecondary,
     createContactSyncProtoMessage,
   };
 })();

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1299,7 +1299,7 @@ MessageReceiver.prototype.extend({
         // eslint-disable-next-line no-bitwise
         const isUnpairingRequest = Boolean(message.flags & UNPAIRING_REQUEST);
 
-        if (isUnpairingRequest) {
+        if (!friendRequest && isUnpairingRequest) {
           // TODO: move high-level pairing logic to libloki.multidevice.xx
 
           const unpairingRequestIsLegit = async () => {
@@ -1328,11 +1328,7 @@ MessageReceiver.prototype.extend({
             );
 
             // our pubkey should NOT be in the primary device mapping
-            if (found) {
-              return false;
-            }
-
-            return true;
+            return !found;
           };
 
           const legit = await unpairingRequestIsLegit();

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -443,6 +443,8 @@ OutgoingMessage.prototype = {
           switch (type) {
             case 'friend-request':
               return 4 * 24 * 60 * 60 * 1000; // 4 days for friend request message
+            case 'device-unpairing':
+              return 4 * 24 * 60 * 60 * 1000; // 4 days for device unpairing
             case 'onlineBroadcast':
               return 60 * 1000; // 1 minute for online broadcast message
             case 'typing':

--- a/preload.js
+++ b/preload.js
@@ -469,6 +469,6 @@ window.pubkeyPattern = /@[a-fA-F0-9]{64,66}\b/g;
 window.SMALL_GROUP_SIZE_LIMIT = 10;
 
 window.lokiFeatureFlags = {
-  multiDeviceUnpairing: false,
+  multiDeviceUnpairing: true,
   privateGroupChats: false,
 };

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -105,6 +105,7 @@ message DataMessage {
     END_SESSION               = 1;
     EXPIRATION_TIMER_UPDATE   = 2;
     PROFILE_KEY_UPDATE        = 4;
+    UNPAIRING_REQUEST         = 128;
     BACKGROUND_FRIEND_REQUEST = 256;
   }
 


### PR DESCRIPTION
The existing unpairing code only updated the primary device mapping locally and on the file server.
This PR adds logic to send a special message with a UNPAIRING_REQUEST flag to the secondary device (4days TTL), as well as the handling logic on the receiving end.
Upon receiving the unpairing message, we check if it's legit and then clear our mapping from the file server and then run the "clear all data" code.

What is missing here is the flag to trigger the message at the next startup, explaining why the account was erased.