### PR TITLE
Show pubkey QR code in primary pairing dialog

### DIFF
--- a/background.html
+++ b/background.html
@@ -263,6 +263,9 @@
       <!-- Waiting for request -->
       <div class="waitingForRequestView" style="display: none;">
         <h4>{{ waitingForRequestTitle }}</h4>
+        <div class="qr-dialog">
+          <div id="qr"></div>
+        </div>
         <div class='buttons'>
           <button class="cancel">{{ cancelText }}</button>
         </div>

--- a/js/views/device_pairing_dialog_view.js
+++ b/js/views/device_pairing_dialog_view.js
@@ -5,7 +5,8 @@
   textsecure,
   ConversationController,
   $,
-  lokiFileServerAPI
+  lokiFileServerAPI,
+  QRCode,
 */
 
 // eslint-disable-next-line func-names
@@ -22,6 +23,10 @@
       this.reset();
       this.render();
       this.showView();
+      this.qr = new QRCode(this.$('#qr')[0], {
+        correctLevel: QRCode.CorrectLevel.L,
+      });
+      this.qr.makeCode(textsecure.storage.user.getNumber());
     },
     reset() {
       this.pubKey = null;
@@ -198,6 +203,7 @@
     },
     close() {
       this.remove();
+      this.qr.clear();
       if (this.pubKey && !this.accepted) {
         this.trigger('devicePairingRequestRejected', this.pubKey);
       }


### PR DESCRIPTION
Added QR code in the dialog view when waiting for secondary device message.
I decided not to show it prior to ensure the secondary device sends the request only when the primary device is listening for them.

![Screen Shot 2019-11-22 at 10 09 44 am](https://user-images.githubusercontent.com/40749766/69385821-c0994a80-0d14-11ea-83fd-87c7a7a09b0c.png)
I checked that the QR code is correct by comparing it with the one shown via "Show QR code" in the menu.
Wrapped the div around `<div class="qr-dialog">` to get it centered in the dialog.