### PR TITLE
Encrypted profile pic

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -933,7 +933,8 @@
           avatarColor: conversation.getColor(),
           onOk: async (newName, avatar) => {
             let newAvatarPath = '';
-
+            let url = null;
+            let profileKey = null;
             if (avatar) {
               const data = await readFile({ file: avatar });
 
@@ -945,19 +946,30 @@
               conversation.setLokiProfile({ displayName: newName });
               conversation.set('avatar', tempUrl);
 
-              const avatarPointer = await textsecure.messaging.uploadAvatar(
-                data
+              // Encrypt with a new key every time
+              profileKey = libsignal.crypto.getRandomBytes(32);
+              const encryptedData = await textsecure.crypto.encryptProfile(
+                data.data,
+                profileKey
               );
 
-              conversation.set('avatarPointer', avatarPointer.url);
-
-              const downloaded = await messageReceiver.downloadAttachment({
-                url: avatarPointer.url,
-                isRaw: true,
+              const avatarPointer = await textsecure.messaging.uploadAvatar({
+                ...data,
+                data: encryptedData,
+                size: encryptedData.byteLength,
               });
-              const upgraded = await Signal.Migrations.processNewAttachment(
-                downloaded
-              );
+
+              ({ url } = avatarPointer);
+
+              storage.put('profileKey', profileKey);
+
+              conversation.set('avatarPointer', url);
+
+              const upgraded = await Signal.Migrations.processNewAttachment({
+                isRaw: true,
+                data: data.data,
+                url,
+              });
               newAvatarPath = upgraded.path;
             }
 

--- a/js/background.js
+++ b/js/background.js
@@ -985,6 +985,12 @@
             // so we could disable this here
             // or least it enable for the quickest response
             window.lokiPublicChatAPI.setProfileName(newName);
+            window
+              .getConversations()
+              .filter(convo => convo.isPublic() && !convo.isRss())
+              .forEach(convo =>
+                convo.trigger('ourAvatarChanged', { url, profileKey })
+              );
           },
         });
       }

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -2312,9 +2312,8 @@
         });
       }
 
-      if (newProfile.avatar) {
-        await this.setProfileAvatar({ path: newProfile.avatar });
-      }
+      // if set to null, it will show a jazzIcon
+      await this.setProfileAvatar({ path: newProfile.avatar });
 
       await this.updateProfileName();
     },

--- a/js/modules/loki_file_server_api.js
+++ b/js/modules/loki_file_server_api.js
@@ -17,6 +17,10 @@ class LokiFileServerInstance {
     this._adnApi = new LokiAppDotNetAPI(ourKey);
     this.avatarMap = {};
   }
+
+  // FIXME: this is not file-server specific
+  // and is currently called by LokiAppDotNetAPI.
+  // LokiAppDotNetAPI (base) should not know about LokiFileServer.
   async establishConnection(serverUrl) {
     // FIXME: we don't always need a token...
     this._server = await this._adnApi.findOrCreateServer(serverUrl);

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -202,11 +202,17 @@
     if (isGrant) {
       // Send profile name to secondary device
       const lokiProfile = ourConversation.getLokiProfile();
+      // profile.avatar is the path to the local image
+      // replace with the avatar URL
+      const avatarPointer = ourConversation.get('avatarPointer');
+      lokiProfile.avatar = avatarPointer;
       const profile = new textsecure.protobuf.DataMessage.LokiProfile(
         lokiProfile
       );
+      const profileKey = window.storage.get('profileKey');
       const dataMessage = new textsecure.protobuf.DataMessage({
         profile,
+        profileKey,
       });
       // Attach contact list
       const conversations = await window.Signal.Data.getConversationsWithFriendStatus(

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -172,7 +172,11 @@ MessageReceiver.prototype.extend({
         message.source,
         'private'
       );
-      await this.updateProfile(conversation, message.message.profile);
+      await this.updateProfile(
+        conversation,
+        message.message.profile,
+        message.message.profileKey
+      );
     }
 
     const ev = new Event('message');
@@ -1295,7 +1299,7 @@ MessageReceiver.prototype.extend({
           } catch (e) {
             window.log.error(`Could not decrypt profile image: ${e}`);
           }
-      }
+        }
         newProfile.avatar = path;
       }
     } else {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1127,12 +1127,13 @@ MessageReceiver.prototype.extend({
         );
         primaryConversation.trigger('change');
         Whisper.events.trigger('secondaryDeviceRegistration');
-        // Update profile name
-        if (dataMessage && dataMessage.profile) {
+        // Update profile
+        if (dataMessage) {
+          const { profile, profileKey } = dataMessage;
           const ourNumber = window.storage.get('primaryDevicePubKey');
           const me = window.ConversationController.get(ourNumber);
           if (me) {
-            me.setLokiProfile(dataMessage.profile);
+            this.updateProfile(me, profile, profileKey);
           }
         }
         // Update contact list
@@ -1238,7 +1239,7 @@ MessageReceiver.prototype.extend({
     return true;
   },
 
-  async updateProfile(conversation, profile) {
+  async updateProfile(conversation, profile, profileKey) {
     // Retain old values unless changed:
     const newProfile = conversation.get('profile') || {};
 
@@ -1252,17 +1253,40 @@ MessageReceiver.prototype.extend({
 
       if (needsUpdate) {
         conversation.set('avatarPointer', profile.avatar);
+        conversation.set('profileKey', profileKey);
 
         const downloaded = await this.downloadAttachment({
           url: profile.avatar,
           isRaw: true,
         });
 
-        const upgraded = await Signal.Migrations.processNewAttachment(
-          downloaded
-        );
-        newProfile.avatar = upgraded.path;
+        // null => use jazzicon
+        let path = null;
+        if (profileKey) {
+          // Convert profileKey to ArrayBuffer, if needed
+          const encoding = typeof profileKey === 'string' ? 'base64' : null;
+          try {
+            const profileKeyArrayBuffer = dcodeIO.ByteBuffer.wrap(
+              profileKey,
+              encoding
+            ).toArrayBuffer();
+            const decryptedData = await textsecure.crypto.decryptProfile(
+              downloaded.data,
+              profileKeyArrayBuffer
+            );
+            const upgraded = await Signal.Migrations.processNewAttachment({
+              ...downloaded,
+              data: decryptedData,
+            });
+            ({ path } = upgraded);
+          } catch (e) {
+            window.log.error(`Could not decrypt profile image: ${e}`);
+          }
       }
+        newProfile.avatar = path;
+      }
+    } else {
+      newProfile.avatar = null;
     }
 
     await conversation.setLokiProfile(newProfile);
@@ -1361,7 +1385,11 @@ MessageReceiver.prototype.extend({
         // Check if we need to update any profile names
         if (!isMe && conversation) {
           if (message.profile) {
-            await this.updateProfile(conversation, message.profile);
+            await this.updateProfile(
+              conversation,
+              message.profile,
+              message.profileKey
+            );
           }
         }
 

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -924,7 +924,9 @@ MessageSender.prototype = {
 
   getOurProfile() {
     try {
-      const ourNumber = textsecure.storage.user.getNumber();
+      // Secondary devices have their profile stored
+      // in their primary device's conversation
+      const ourNumber = window.storage.get('primaryDevicePubKey');
       const conversation = window.ConversationController.get(ourNumber);
       return conversation.getLokiProfile();
     } catch (e) {

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -191,8 +191,7 @@ MessageSender.prototype = {
   async makeAttachmentPointer(
     attachment,
     publicServer = null,
-    isRaw = false,
-    isAvatar = false
+    { isRaw = false, isAvatar = false }
   ) {
     if (typeof attachment !== 'object' || attachment == null) {
       return Promise.resolve(undefined);
@@ -211,13 +210,7 @@ MessageSender.prototype = {
 
     const proto = new textsecure.protobuf.AttachmentPointer();
     let attachmentData;
-    let server;
-
-    if (publicServer) {
-      server = publicServer;
-    } else {
-      ({ server } = this);
-    }
+    const server = publicServer || this.server;
 
     if (publicServer || isRaw) {
       attachmentData = attachment.data;
@@ -572,7 +565,12 @@ MessageSender.prototype = {
   },
 
   uploadAvatar(attachment) {
-    return this.makeAttachmentPointer(attachment, null, true, true);
+    // isRaw is true since the data is already encrypted
+    // and doesn't need to be encrypted again
+    return this.makeAttachmentPointer(attachment, null, {
+      isRaw: true,
+      isAvatar: true,
+    });
   },
 
   sendRequestConfigurationSyncMessage(options) {

--- a/ts/components/MainHeader.tsx
+++ b/ts/components/MainHeader.tsx
@@ -334,13 +334,6 @@ export class MainHeader extends React.Component<Props, any> {
         onClick: onCopyPublicKey,
       },
       {
-        id: 'editProfile',
-        name: i18n('editProfile'),
-        onClick: () => {
-          trigger('onEditProfile');
-        },
-      },
-      {
         id: 'showSeed',
         name: i18n('showSeed'),
         onClick: () => {
@@ -396,6 +389,14 @@ export class MainHeader extends React.Component<Props, any> {
     }
 
     if (!isSecondaryDevice) {
+      // insert as second element
+      menuItems.splice(1, 0, {
+        id: 'editProfile',
+        name: i18n('editProfile'),
+        onClick: () => {
+          trigger('onEditProfile');
+        },
+      });
       menuItems.push({
         id: 'pairNewDevice',
         name: 'Device Pairing',


### PR DESCRIPTION
- Encrypt/decrypt picture when uploading/downloading
- Prevent downloading our own picture right after having uploaded it (we already have the bytes)
- ~~set `profileSharing` on every conversation to true to enable sending the `profileKey` with every message~~

~~Note that the public chat side of things will come in the next PR.~~
~~EDIT: changes for public chat added in this PR but in a separate commit~~


- set `profileSharing`  to true only before sending a friend request (FR), or after becoming friend, for private chats
- add logic in the AppDotNet API to store our profileKey in the user annotation
- ~~share our profileKey on the public chat only upon sending a message the first time~~
- ~~share our profileKey on the public chat every time it changes, unless we've never sent any messages~~

EDIT2: Major re-org of this PR, please review commit by commit :)