### PR TITLE
clickable profile

### DIFF
--- a/background.html
+++ b/background.html
@@ -821,6 +821,7 @@
   <script type='text/javascript' src='js/views/create_group_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/edit_profile_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/invite_friends_dialog_view.js'></script>
+  <script type='text/javascript' src='js/views/user_details_dialog_view.js'></script>
 
   <script type='text/javascript' src='js/wall_clock_listener.js'></script>
   <script type='text/javascript' src='js/rotate_signed_prekey_listener.js'></script>

--- a/js/background.js
+++ b/js/background.js
@@ -978,6 +978,30 @@
       }
     });
 
+    Whisper.events.on('onShowUserDetails', async ({ userPubKey }) => {
+      const conversation = await ConversationController.getOrCreateAndWait(
+        userPubKey,
+        'private'
+      );
+
+      const avatarPath = conversation.getAvatarPath();
+      const profile = conversation.getLokiProfile();
+      const displayName = profile && profile.displayName;
+
+      if (appView) {
+        appView.showUserDetailsDialog({
+          profileName: displayName,
+          pubkey: userPubKey,
+          avatarPath,
+          avatarColor: conversation.getColor(),
+          onOk: async () => {},
+          onStartConversation: async () => {
+            window.Whisper.events.trigger('showConversation', userPubKey);
+          },
+        });
+      }
+    });
+
     Whisper.events.on('showToast', options => {
       if (
         appView &&

--- a/js/background.js
+++ b/js/background.js
@@ -994,9 +994,8 @@
           pubkey: userPubKey,
           avatarPath,
           avatarColor: conversation.getColor(),
-          onOk: async () => {},
-          onStartConversation: async () => {
-            window.Whisper.events.trigger('showConversation', userPubKey);
+          onStartConversation: () => {
+            Whisper.events.trigger('showConversation', userPubKey);
           },
         });
       }

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -706,6 +706,10 @@
             message: this,
             isDangerous,
           }),
+        onShowUserDetails: pubkey =>
+          window.Whisper.events.trigger('onShowUserDetails', {
+            userPubKey: pubkey,
+          }),
       };
     },
     createNonBreakingLastSeparator(text) {

--- a/js/modules/signal.js
+++ b/js/modules/signal.js
@@ -49,6 +49,8 @@ const {
   CreateGroupDialog,
 } = require('../../ts/components/conversation/CreateGroupDialog');
 const { EditProfileDialog } = require('../../ts/components/EditProfileDialog');
+const { UserDetailsDialog } = require('../../ts/components/UserDetailsDialog');
+
 const {
   UpdateGroupDialog,
 } = require('../../ts/components/conversation/UpdateGroupDialog');
@@ -236,6 +238,7 @@ exports.setup = (options = {}) => {
     MemberList,
     CreateGroupDialog,
     EditProfileDialog,
+    UserDetailsDialog,
     ConfirmDialog,
     UpdateGroupDialog,
     InviteFriendsDialog,

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -180,6 +180,10 @@
       const dialog = new Whisper.EditProfileDialogView(options);
       this.el.append(dialog.el);
     },
+    showUserDetailsDialog(options) {
+      const dialog = new Whisper.UserDetailsDialogView(options);
+      this.el.append(dialog.el);
+    },
     showNicknameDialog({ pubKey, title, message, nickname, onOk, onCancel }) {
       const _title = title || `Change nickname for ${pubKey}`;
       const dialog = new Whisper.NicknameDialogView({

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -291,7 +291,7 @@
             window.Whisper.events.trigger('inviteFriends', this.model);
           },
 
-          onShowUserDetails: (pubkey) => {
+          onShowUserDetails: pubkey => {
             if (this.model.isPrivate()) {
               window.Whisper.events.trigger('onShowUserDetails', {
                 userPubKey: pubkey,

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -290,6 +290,14 @@
           onInviteFriends: () => {
             window.Whisper.events.trigger('inviteFriends', this.model);
           },
+
+          onShowUserDetails: (pubkey) => {
+            if (this.model.isPrivate()) {
+              window.Whisper.events.trigger('onShowUserDetails', {
+                userPubKey: pubkey,
+              });
+            }
+          },
         };
       };
       this.titleView = new Whisper.ReactWrapperView({

--- a/js/views/user_details_dialog_view.js
+++ b/js/views/user_details_dialog_view.js
@@ -1,0 +1,53 @@
+/* global i18n, Whisper */
+
+// eslint-disable-next-line func-names
+(function() {
+  'use strict';
+
+  window.Whisper = window.Whisper || {};
+
+  Whisper.UserDetailsDialogView = Whisper.View.extend({
+    className: 'loki-dialog modal',
+    initialize({
+      profileName,
+      avatarPath,
+      avatarColor,
+      pubkey,
+      onOk,
+      onStartConversation,
+    }) {
+      this.close = this.close.bind(this);
+
+      this.profileName = profileName;
+      this.pubkey = pubkey;
+      this.avatarPath = avatarPath;
+      this.avatarColor = avatarColor;
+      this.onOk = onOk;
+      this.onStartConversation = onStartConversation;
+
+      this.$el.focus();
+      this.render();
+    },
+    render() {
+      this.dialogView = new Whisper.ReactWrapperView({
+        className: 'edit-profile-dialog',
+        Component: window.Signal.Components.UserDetailsDialog,
+        props: {
+          onOk: this.onOk,
+          onClose: this.close,
+          onStartConversation: this.onStartConversation,
+          profileName: this.profileName,
+          pubkey: this.pubkey,
+          avatarPath: this.avatarPath,
+          i18n,
+        },
+      });
+
+      this.$el.append(this.dialogView.el);
+      return this;
+    },
+    close() {
+      this.remove();
+    },
+  });
+})();

--- a/js/views/user_details_dialog_view.js
+++ b/js/views/user_details_dialog_view.js
@@ -30,7 +30,7 @@
     },
     render() {
       this.dialogView = new Whisper.ReactWrapperView({
-        className: 'edit-profile-dialog',
+        className: 'user-details-dialog',
         Component: window.Signal.Components.UserDetailsDialog,
         props: {
           onOk: this.onOk,

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -272,12 +272,10 @@
       }
     }
   }
-
 }
 
 .dark-theme {
   .group-invitation {
-
     background-color: #242424;
     border-color: #303030;
     box-shadow: 2px 2px #4f4f4f;

--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -10,7 +10,8 @@
   overflow: hidden;
 }
 
-.edit-profile-dialog {
+.edit-profile-dialog,
+.user-details-dialog {
   .content {
     max-width: 100% !important;
   }

--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -42,12 +42,12 @@
     margin-bottom: 1em;
   }
 
-  .avatar-upload {
+  .avatar-center {
     display: flex;
     justify-content: center;
   }
 
-  .avatar-upload-inner {
+  .avatar-center-inner {
     display: flex;
   }
 

--- a/ts/components/Avatar.tsx
+++ b/ts/components/Avatar.tsx
@@ -175,6 +175,7 @@ export class Avatar extends React.PureComponent<Props, State> {
           !hasImage ? `module-avatar--${color}` : null
         )}
         onClick={this.onAvatarClickBound}
+        role="button"
       >
         {hasImage ? this.renderAvatarOrIdenticon() : this.renderNoImage()}
       </div>
@@ -183,7 +184,7 @@ export class Avatar extends React.PureComponent<Props, State> {
 
   private onAvatarClick() {
     if (this.props.onAvatarClick) {
-      this.props.onAvatarClick()
+      this.props.onAvatarClick();
     }
   }
 

--- a/ts/components/Avatar.tsx
+++ b/ts/components/Avatar.tsx
@@ -26,7 +26,7 @@ interface State {
 
 export class Avatar extends React.PureComponent<Props, State> {
   public handleImageErrorBound: () => void;
-  public onAvatarClickBound: () => void;
+  public onAvatarClickBound: (e: any) => void;
 
   public constructor(props: Props) {
     super(props);
@@ -174,7 +174,9 @@ export class Avatar extends React.PureComponent<Props, State> {
           hasImage ? 'module-avatar--with-image' : 'module-avatar--no-image',
           !hasImage ? `module-avatar--${color}` : null
         )}
-        onClick={this.onAvatarClickBound}
+        onClick={e => {
+          this.onAvatarClickBound(e);
+        }}
         role="button"
       >
         {hasImage ? this.renderAvatarOrIdenticon() : this.renderNoImage()}
@@ -182,8 +184,9 @@ export class Avatar extends React.PureComponent<Props, State> {
     );
   }
 
-  private onAvatarClick() {
+  private onAvatarClick(e: any) {
     if (this.props.onAvatarClick) {
+      e.stopPropagation();
       this.props.onAvatarClick();
     }
   }

--- a/ts/components/Avatar.tsx
+++ b/ts/components/Avatar.tsx
@@ -17,6 +17,7 @@ interface Props {
   size: number;
   borderColor?: string;
   borderWidth?: number;
+  onAvatarClick?: () => void;
 }
 
 interface State {
@@ -25,11 +26,13 @@ interface State {
 
 export class Avatar extends React.PureComponent<Props, State> {
   public handleImageErrorBound: () => void;
+  public onAvatarClickBound: () => void;
 
   public constructor(props: Props) {
     super(props);
 
     this.handleImageErrorBound = this.handleImageError.bind(this);
+    this.onAvatarClickBound = this.onAvatarClick.bind(this);
 
     this.state = {
       imageBroken: false,
@@ -171,10 +174,17 @@ export class Avatar extends React.PureComponent<Props, State> {
           hasImage ? 'module-avatar--with-image' : 'module-avatar--no-image',
           !hasImage ? `module-avatar--${color}` : null
         )}
+        onClick={this.onAvatarClickBound}
       >
         {hasImage ? this.renderAvatarOrIdenticon() : this.renderNoImage()}
       </div>
     );
+  }
+
+  private onAvatarClick() {
+    if (this.props.onAvatarClick) {
+      this.props.onAvatarClick()
+    }
   }
 
   private renderAvatarOrIdenticon() {

--- a/ts/components/EditProfileDialog.tsx
+++ b/ts/components/EditProfileDialog.tsx
@@ -64,8 +64,8 @@ export class EditProfileDialog extends React.Component<Props, State> {
 
     return (
       <div className="content">
-        <div className="avatar-upload">
-          <div className="avatar-upload-inner">
+        <div className="avatar-center">
+          <div className="avatar-center-inner">
             {this.renderAvatar()}
             <div className="upload-btn-background">
               <input

--- a/ts/components/UserDetailsDialog.tsx
+++ b/ts/components/UserDetailsDialog.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Avatar } from './Avatar';
+
+declare global {
+  interface Window {
+    displayNameRegex: any;
+  }
+}
+
+interface Props {
+  i18n: any;
+  profileName: string;
+  avatarPath: string;
+  avatarColor: string;
+  pubkey: string;
+  onClose: any;
+  onStartConversation: any;
+}
+
+export class UserDetailsDialog extends React.Component<Props> {
+  constructor(props: any) {
+    super(props);
+
+    this.closeDialog = this.closeDialog.bind(this);
+    this.onKeyUp = this.onKeyUp.bind(this);
+    this.onClickStartConversation = this.onClickStartConversation.bind(this);
+    window.addEventListener('keyup', this.onKeyUp);
+  }
+
+  public render() {
+    const i18n = this.props.i18n;
+
+    const cancelText = i18n('cancel');
+    const startConversation = i18n('startConversation');
+
+    return (
+      <div className="content">
+        {this.renderAvatar()}
+        <span className="profile-name">{this.props.profileName}</span>
+        <div className="message">{this.props.pubkey}</div>
+
+        <div className="buttons">
+          <button className="cancel" tabIndex={0} onClick={this.closeDialog}>
+            {cancelText}
+          </button>
+
+          <button
+            className="ok"
+            tabIndex={0}
+            onClick={this.onClickStartConversation}
+          >
+            {startConversation}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  private renderAvatar() {
+    const avatarPath = this.props.avatarPath;
+    const color = this.props.avatarColor;
+
+    return (
+      <Avatar
+        avatarPath={avatarPath}
+        color={color}
+        conversationType="direct"
+        i18n={this.props.i18n}
+        name={this.props.profileName}
+        phoneNumber={this.props.pubkey}
+        profileName={this.props.profileName}
+        size={80}
+      />
+    );
+  }
+
+  private onKeyUp(event: any) {
+    switch (event.key) {
+      case 'Enter':
+        this.onClickStartConversation();
+        break;
+      case 'Esc':
+      case 'Escape':
+        this.closeDialog();
+        break;
+      default:
+    }
+  }
+
+  private closeDialog() {
+    window.removeEventListener('keyup', this.onKeyUp);
+    this.props.onClose();
+  }
+
+  private onClickStartConversation() {
+    this.props.onStartConversation();
+    this.closeDialog();
+  }
+}

--- a/ts/components/UserDetailsDialog.tsx
+++ b/ts/components/UserDetailsDialog.tsx
@@ -35,8 +35,12 @@ export class UserDetailsDialog extends React.Component<Props> {
 
     return (
       <div className="content">
-        {this.renderAvatar()}
-        <span className="profile-name">{this.props.profileName}</span>
+        <div className="avatar-center">
+          <div className="avatar-center-inner">
+            {this.renderAvatar()}
+          </div>
+        </div>
+        <div className="profile-name">{this.props.profileName}</div>
         <div className="message">{this.props.pubkey}</div>
 
         <div className="buttons">

--- a/ts/components/UserDetailsDialog.tsx
+++ b/ts/components/UserDetailsDialog.tsx
@@ -36,9 +36,7 @@ export class UserDetailsDialog extends React.Component<Props> {
     return (
       <div className="content">
         <div className="avatar-center">
-          <div className="avatar-center-inner">
-            {this.renderAvatar()}
-          </div>
+          <div className="avatar-center-inner">{this.renderAvatar()}</div>
         </div>
         <div className="profile-name">{this.props.profileName}</div>
         <div className="message">{this.props.pubkey}</div>

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -68,12 +68,14 @@ interface Props {
   onLeaveGroup: () => void;
 
   onInviteFriends: () => void;
+  onShowUserDetails?: (userPubKey: string) => void;
 
   i18n: LocalizerType;
 }
 
 export class ConversationHeader extends React.Component<Props> {
   public showMenuBound: (event: React.MouseEvent<HTMLDivElement>) => void;
+  public onShowUserDetailsBound: (userPubKey: string) => void;
   public menuTriggerRef: React.RefObject<any>;
 
   public constructor(props: Props) {
@@ -81,6 +83,7 @@ export class ConversationHeader extends React.Component<Props> {
 
     this.menuTriggerRef = React.createRef();
     this.showMenuBound = this.showMenu.bind(this);
+    this.onShowUserDetailsBound = this.onShowUserDetails.bind(this);
   }
 
   public showMenu(event: React.MouseEvent<HTMLDivElement>) {
@@ -180,6 +183,9 @@ export class ConversationHeader extends React.Component<Props> {
           size={28}
           borderColor={borderColor}
           borderWidth={2}
+          onAvatarClick={() => {
+            this.onShowUserDetailsBound(phoneNumber);
+          }}
         />
       </span>
     );
@@ -396,5 +402,10 @@ export class ConversationHeader extends React.Component<Props> {
         {archiveConversationMenuItem}
       </React.Fragment>
     );
+  }
+
+  public onShowUserDetails(userPubKey: string) {
+    if (this.props.onShowUserDetails)
+      this.props.onShowUserDetails(userPubKey);
   }
 }

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -298,6 +298,12 @@ export class ConversationHeader extends React.Component<Props> {
     );
   }
 
+  public onShowUserDetails(userPubKey: string) {
+    if (this.props.onShowUserDetails) {
+      this.props.onShowUserDetails(userPubKey);
+    }
+  }
+
   private renderMemberCount() {
     const memberCount = this.props.members.length;
 
@@ -402,10 +408,5 @@ export class ConversationHeader extends React.Component<Props> {
         {archiveConversationMenuItem}
       </React.Fragment>
     );
-  }
-
-  public onShowUserDetails(userPubKey: string) {
-    if (this.props.onShowUserDetails)
-      this.props.onShowUserDetails(userPubKey);
   }
 }

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -674,12 +674,7 @@ export class Message extends React.PureComponent<Props, State> {
 
     return (
       <div
-        className="module-message__author-avatar"
-        role="button"
-        onClick={() => {
-          onShowUserDetails(authorPhoneNumber);
-        }}
-      >
+        className="module-message__author-avatar">
         <Avatar
           avatarPath={authorAvatarPath}
           color={authorColor}
@@ -689,6 +684,9 @@ export class Message extends React.PureComponent<Props, State> {
           phoneNumber={authorPhoneNumber}
           profileName={authorProfileName}
           size={36}
+          onAvatarClick={() => {
+            onShowUserDetails(authorPhoneNumber);
+          }}
         />
         {isModerator && (
           <div className="module-avatar__icon--crown-wrapper">

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -673,7 +673,13 @@ export class Message extends React.PureComponent<Props, State> {
     }
 
     return (
-      <div className="module-message__author-avatar">
+      <div
+        className="module-message__author-avatar"
+        role="button"
+        onClick={() => {
+          onShowUserDetails(authorPhoneNumber);
+        }}
+      >
         <Avatar
           avatarPath={authorAvatarPath}
           color={authorColor}
@@ -1084,17 +1090,7 @@ export class Message extends React.PureComponent<Props, State> {
     const enableContextMenu = !isRss && !multiSelectMode;
 
     return (
-      <div
-        className={classNames(divClasses)}
-        role="button"
-        onClick={() => {
-          const selection = window.getSelection();
-          if (selection && selection.type === 'Range') {
-            return;
-          }
-          this.props.onSelectMessage();
-        }}
-      >
+      <div className={classNames(divClasses)}>
         <ContextMenuTrigger id={rightClickTriggerId}>
           {this.renderCheckBox()}
           {this.renderAvatar()}
@@ -1104,6 +1100,14 @@ export class Message extends React.PureComponent<Props, State> {
               `module-message--${direction}`,
               expiring ? 'module-message--expired' : null
             )}
+            role="button"
+            onClick={() => {
+              const selection = window.getSelection();
+              if (selection && selection.type === 'Range') {
+                return;
+              }
+              this.props.onSelectMessage();
+            }}
           >
             {this.renderError(isIncoming)}
             {isRss ? null : this.renderMenu(!isIncoming, triggerId)}

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -113,6 +113,7 @@ export interface Props {
   onDelete?: () => void;
   onCopyPubKey?: () => void;
   onShowDetail: () => void;
+  onShowUserDetails: (userPubKey: string) => void;
 }
 
 interface State {
@@ -660,6 +661,7 @@ export class Message extends React.PureComponent<Props, State> {
       conversationType,
       direction,
       i18n,
+      onShowUserDetails,
     } = this.props;
 
     if (

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -673,8 +673,7 @@ export class Message extends React.PureComponent<Props, State> {
     }
 
     return (
-      <div
-        className="module-message__author-avatar">
+      <div className="module-message__author-avatar">
         <Avatar
           avatarPath={authorAvatarPath}
           color={authorColor}

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -1087,7 +1087,17 @@ export class Message extends React.PureComponent<Props, State> {
     const enableContextMenu = !isRss && !multiSelectMode;
 
     return (
-      <div className={classNames(divClasses)}>
+      <div
+        className={classNames(divClasses)}
+        role="button"
+        onClick={() => {
+          const selection = window.getSelection();
+          if (selection && selection.type === 'Range') {
+            return;
+          }
+          this.props.onSelectMessage();
+        }}
+      >
         <ContextMenuTrigger id={rightClickTriggerId}>
           {this.renderCheckBox()}
           {this.renderAvatar()}
@@ -1097,14 +1107,6 @@ export class Message extends React.PureComponent<Props, State> {
               `module-message--${direction}`,
               expiring ? 'module-message--expired' : null
             )}
-            role="button"
-            onClick={() => {
-              const selection = window.getSelection();
-              if (selection && selection.type === 'Range') {
-                return;
-              }
-              this.props.onSelectMessage();
-            }}
           >
             {this.renderError(isIncoming)}
             {isRss ? null : this.renderMenu(!isIncoming, triggerId)}


### PR DESCRIPTION
Make the avatars (in the conversation view) clickable to show a modal with details about the user clicked:
Show the name, the avatar and the public key of the user.
A button can be used to start a conversation with this user directly.
Should I add a "Copy pubkey" button? The pubkey is selectable already but still...

This behavior needs to be included to the issue #656 once ready.
Relates #655

Here is a screenshot (in french)
![Capture d’écran_2019-11-28_16-48-10](https://user-images.githubusercontent.com/1544279/69780274-ecc63700-11fe-11ea-86d8-d20c6846d5c4.png)


