### PR TITLE
Prompting the user to reset session on invalid ciphertext

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2241,5 +2241,18 @@
   },
   "noFriendsToAdd": {
     "message": "no friends to add"
+  },
+  "couldNotDecryptMessage": {
+    "message": "Couldn't decrypt a message"
+  },
+  "confirmSessionRestore": {
+    "message":
+      "Would you like to start a new session with $pubkey$? Only do so if you know this pubkey.",
+    "placeholders": {
+      "pubkey": {
+        "content": "$1",
+        "example": ""
+      }
+    }
   }
 }

--- a/background.html
+++ b/background.html
@@ -819,6 +819,7 @@
   <script type='text/javascript' src='js/views/device_pairing_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/device_pairing_words_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/create_group_dialog_view.js'></script>
+  <script type='text/javascript' src='js/views/confirm_session_reset_view.js'></script>
   <script type='text/javascript' src='js/views/edit_profile_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/invite_friends_dialog_view.js'></script>
 

--- a/js/background.js
+++ b/js/background.js
@@ -1918,7 +1918,7 @@
 
         window.Whisper.events.trigger('showSessionRestoreConfirmation', {
           pubkey,
-          onOk: async () => {
+          onOk: () => {
             convo.sendMessage('', null, null, null, null, {
               sessionRestoration: true,
             });

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1516,11 +1516,7 @@
           messageWithSchema.sourceDevice = 1;
         }
 
-        let sessionRestoration = false;
-
-        if (otherOptions) {
-          sessionRestoration = otherOptions.sessionRestoration || false;
-        }
+        const { sessionRestoration = false } = otherOptions;
 
         const attributes = {
           ...messageWithSchema,

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1423,7 +1423,8 @@
       attachments,
       quote,
       preview,
-      groupInvitation = null
+      groupInvitation = null,
+      otherOptions = {}
     ) {
       this.clearTypingTimers();
 
@@ -1514,9 +1515,17 @@
           messageWithSchema.source = textsecure.storage.user.getNumber();
           messageWithSchema.sourceDevice = 1;
         }
+
+        let sessionRestoration = false;
+
+        if (otherOptions) {
+          sessionRestoration = otherOptions.sessionRestoration || false;
+        }
+
         const attributes = {
           ...messageWithSchema,
           groupInvitation,
+          sessionRestoration,
           id: window.getGuid(),
         };
 
@@ -1597,6 +1606,7 @@
         }
 
         options.groupInvitation = groupInvitation;
+        options.sessionRestoration = sessionRestoration;
 
         const groupNumbers = this.getRecipients();
 

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -102,6 +102,8 @@
           this.propsForResetSessionNotification = this.getPropsForResetSessionNotification();
         } else if (this.isGroupUpdate()) {
           this.propsForGroupNotification = this.getPropsForGroupNotification();
+        } else if (this.isSessionRestoration()) {
+          // do nothing
         } else if (this.isFriendRequest()) {
           this.propsForFriendRequest = this.getPropsForFriendRequest();
         } else if (this.isGroupInvitation()) {
@@ -270,6 +272,13 @@
     isGroupInvitation() {
       return !!this.get('groupInvitation');
     },
+    isSessionRestoration() {
+      const flag = textsecure.protobuf.DataMessage.Flags.SESSION_RESTORE;
+      // eslint-disable-next-line no-bitwise
+      const sessionRestoreFlag = !!(this.get('flags') & flag);
+
+      return !!this.get('sessionRestoration') || sessionRestoreFlag;
+    },
     getNotificationText() {
       const description = this.getDescription();
       if (description) {
@@ -389,6 +398,16 @@
         return;
       }
       const conversation = await this.getSourceDeviceConversation();
+
+      // If we somehow received an old friend request (e.g. after having restored
+      // from seed, we won't be able to accept it, we should initiate our own
+      // friend request to reset the session:
+      if (conversation.get('sessionRestoreSeen')) {
+        conversation.sendMessage('', null, null, null, null, {
+          sessionRestoration: true,
+        });
+        return;
+      }
 
       this.set({ friendStatus: 'accepted' });
       await window.Signal.Data.saveMessage(this.attributes, {
@@ -1921,6 +1940,15 @@
       const backgroundFrReq =
         initialMessage.flags ===
         textsecure.protobuf.DataMessage.Flags.BACKGROUND_FRIEND_REQUEST;
+
+      if (
+        // eslint-disable-next-line no-bitwise
+        initialMessage.flags &
+        textsecure.protobuf.DataMessage.Flags.SESSION_RESTORE
+      ) {
+        // Show that the session reset is "in progress" even though we had a valid session
+        this.set({ endSessionType: 'ongoing' });
+      }
 
       if (message.isFriendRequest() && backgroundFrReq) {
         // Check if the contact is a member in one of our private groups:

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -250,6 +250,10 @@
       const dialog = new Whisper.UpdateGroupDialogView(groupConvo);
       this.el.append(dialog.el);
     },
+    showSessionRestoreConfirmation(options) {
+      const dialog = new Whisper.ConfirmSessionResetView(options);
+      this.el.append(dialog.el);
+    },
     showLeaveGroupDialog(groupConvo) {
       const dialog = new Whisper.LeaveGroupDialogView(groupConvo);
       this.el.append(dialog.el);

--- a/js/views/confirm_session_reset_view.js
+++ b/js/views/confirm_session_reset_view.js
@@ -1,0 +1,50 @@
+/* global Whisper, i18n */
+
+// eslint-disable-next-line func-names
+(function() {
+  'use strict';
+
+  window.Whisper = window.Whisper || {};
+
+  Whisper.ConfirmSessionResetView = Whisper.View.extend({
+    className: 'loki-dialog modal',
+    initialize({ pubkey, onOk }) {
+      this.title = i18n('couldNotDecryptMessage');
+
+      this.onOk = onOk;
+      this.messageText = i18n('confirmSessionRestore', pubkey);
+      this.okText = i18n('yes');
+      this.cancelText = i18n('cancel');
+
+      this.close = this.close.bind(this);
+      this.confirm = this.confirm.bind(this);
+
+      this.$el.focus();
+      this.render();
+    },
+    render() {
+      this.dialogView = new Whisper.ReactWrapperView({
+        className: 'leave-group-dialog',
+        Component: window.Signal.Components.ConfirmDialog,
+        props: {
+          titleText: this.title,
+          messageText: this.messageText,
+          okText: this.okText,
+          cancelText: this.cancelText,
+          onConfirm: this.confirm,
+          onClose: this.close,
+        },
+      });
+
+      this.$el.append(this.dialogView.el);
+      return this;
+    },
+    async confirm() {
+      this.onOk();
+      this.close();
+    },
+    close() {
+      this.remove();
+    },
+  });
+})();

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -69,6 +69,11 @@
           Component: Components.GroupNotification,
           props: this.model.propsForGroupNotification,
         };
+      } else if (this.model.isSessionRestoration()) {
+        return {
+          Component: Components.ResetSessionNotification,
+          props: this.model.getPropsForResetSessionNotification(),
+        };
       } else if (this.model.propsForFriendRequest) {
         return {
           Component: Components.FriendRequest,

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -28,6 +28,7 @@ function Message(options) {
   this.profileKey = options.profileKey;
   this.profile = options.profile;
   this.groupInvitation = options.groupInvitation;
+  this.sessionRestoration = options.sessionRestoration || false;
 
   if (!(this.recipients instanceof Array)) {
     throw new Error('Invalid recipient list');
@@ -169,6 +170,10 @@ Message.prototype = {
           serverName: this.groupInvitation.serverName,
         }
       );
+    }
+
+    if (this.sessionRestoration) {
+      proto.flags = textsecure.protobuf.DataMessage.Flags.SESSION_RESTORE;
     }
 
     this.dataMessage = proto;
@@ -952,7 +957,7 @@ MessageSender.prototype = {
       ? textsecure.protobuf.DataMessage.Flags.BACKGROUND_FRIEND_REQUEST
       : undefined;
 
-    const { groupInvitation } = options;
+    const { groupInvitation, sessionRestoration } = options;
 
     return this.sendMessage(
       {
@@ -968,6 +973,7 @@ MessageSender.prototype = {
         profile,
         flags,
         groupInvitation,
+        sessionRestoration,
       },
       options
     );

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -105,6 +105,7 @@ message DataMessage {
     END_SESSION               = 1;
     EXPIRATION_TIMER_UPDATE   = 2;
     PROFILE_KEY_UPDATE        = 4;
+    SESSION_RESTORE           = 64;
     UNPAIRING_REQUEST         = 128;
     BACKGROUND_FRIEND_REQUEST = 256;
   }

--- a/test/index.html
+++ b/test/index.html
@@ -576,6 +576,7 @@
   <script type='text/javascript' src='../js/views/banner_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/clear_data_view.js'></script>
   <script type='text/javascript' src='../js/views/create_group_dialog_view.js'></script>
+  <script type='text/javascript' src='../js/views/confirm_session_reset_view.js'></script>
   <script type='text/javascript' src='../js/views/invite_friends_dialog_view.js'></script>
   <script type='text/javascript' src='../js/views/beta_release_disclaimer_view.js'></script>
 


### PR DESCRIPTION
- On first message that we can't decrypt we show the prompt and record that we've done that (so we don't show the same dialog for every message)
- On submit, we send an empty message with a `SESSION_RESTORE` flag, so we can display the message accordingly (the session reset will happen in the background in that case)
- If some old friend request is still in the database after we restore from seed, we leave it as is (we can't really distinguish between new and old FR, and old FR won't work anymore), but perform session restoration as above rather than responding to that FR in case we've also received some undecipherable messages from that pubkey.
- I don't use "showConfirmationDialog" because it is ugly (and would require some size tweaking to fit pubkey in one line)