### PR TITLE
Fixed multi select by preventing select on clicking audio element in …

### DIFF
--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -384,6 +384,10 @@ export class Message extends React.PureComponent<Props, State> {
     } else if (!firstAttachment.pending && isAudio(attachments)) {
       return (
         <audio
+          role="button"
+          onClick={(e: any) => {
+            e.stopPropagation();
+          }}
           controls={true}
           className={classNames(
             'module-message__audio-attachment',


### PR DESCRIPTION
Previously on clicking an audio element in the message list, the message would be selected.
This prevents the message from being selected while still allowing the audio element to be interacted with.