### PR TITLE
Public Server Moderator QoL improvements

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1992,54 +1992,44 @@
     "message": "Note: Your display name will be visible to your contacts",
     "description": "Shown to the user as a warning about setting display name"
   },
-
   "copyPublicKey": {
     "message": "Copy public key",
     "description":
       "Button action that the user can click to copy their public keys"
   },
-
   "banUser": {
     "message": "Ban user",
     "description": "Ban user from public chat by public key."
   },
-
   "banUserConfirm": {
     "message": "Are you sure you want to ban user?",
     "description": "Message shown when confirming user ban."
   },
-
   "userBanned": {
     "message": "User successfully banned",
     "description": "Toast on succesful user ban."
   },
-
   "userBanFailed": {
     "message": "User ban failed!",
     "description": "Toast on unsuccesful user ban."
   },
-
   "copyChatId": {
     "message": "Copy Chat ID"
   },
-
   "updateGroup": {
     "message": "Update Group",
     "description":
       "Button action that the user can click to rename the group or add a new member"
   },
-
   "leaveGroup": {
     "message": "Leave Group",
     "description": "Button action that the user can click to leave the group"
   },
-
   "leaveGroupDialogTitle": {
     "message": "Are you sure you want to leave this group?",
     "description":
       "Title shown to the user to confirm they want to leave the group"
   },
-
   "copiedPublicKey": {
     "message": "Copied public key",
     "description": "A toast message telling the user that the key was copied"
@@ -2062,18 +2052,20 @@
     "message": "Edit profile",
     "description": "Button action that the user can click to edit their profile"
   },
-
   "createGroupDialogTitle": {
     "message": "Creating a Private Group Chat",
     "description": "Title for the dialog box used to create a new private group"
   },
-
   "updateGroupDialogTitle": {
     "message": "Updating a Private Group Chat",
     "description":
       "Title for the dialog box used to update an existing private group"
   },
-
+  "updatePublicGroupDialogTitle": {
+    "message": "Updating a Public Chat Channel",
+    "description":
+      "Title for the dialog box used to update an existing public chat channel"
+  },
   "showSeed": {
     "message": "Show seed",
     "description":
@@ -2093,25 +2085,21 @@
     "description":
       "Title for the dialog box used to connect to a new public server"
   },
-
   "createPrivateGroup": {
     "message": "Create Private Group",
     "description":
       "Button action that the user can click to show a dialog for creating a new private group chat"
   },
-
   "seedViewTitle": {
     "message":
       "Please save the seed below in a safe location. They can be used to restore your account if you lose access or migrate to a new device.",
     "description": "The title shown when the user views their seeds"
   },
-
   "copiedMnemonic": {
     "message": "Copied seed to clipboard",
     "description":
       "A toast message telling the user that the mnemonic seed was copied"
   },
-
   "passwordViewTitle": {
     "message": "Type in your password",
     "description":
@@ -2125,7 +2113,6 @@
     "description":
       "A button action that the user can click to reset the database"
   },
-
   "setPassword": {
     "message": "Set Password",
     "description": "Button action that the user can click to set a password"
@@ -2210,7 +2197,6 @@
     "message": "Invalid Pubkey Format",
     "description": "Error string shown when user types an invalid pubkey format"
   },
-
   "conversationsTab": {
     "message": "Conversations",
     "description": "conversation tab title"

--- a/js/background.js
+++ b/js/background.js
@@ -741,6 +741,20 @@
         'group'
       );
 
+      if (convo.isPublic()) {
+        const API = await convo.getPublicSendData();
+        if (await API.setChannelName(groupName)) {
+          // queue update from server
+          // and let that set the conversation
+          API.pollForChannelOnce();
+          // or we could just directly call
+          // convo.setGroupName(groupName);
+          // but gut is saying let the server be the definitive storage of the state
+          // and trickle down from there
+        }
+        return;
+      }
+
       const avatar = '';
       const options = {};
 

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1,5 +1,6 @@
 /* global
   _,
+  log,
   i18n,
   Backbone,
   ConversationController,
@@ -2346,14 +2347,21 @@
     // maybe "Backend" instead of "Source"?
     async setPublicSource(newServer, newChannelId) {
       if (!this.isPublic()) {
+        log.warn(
+          `trying to setPublicSource on non public chat conversation ${this.id}`
+        );
         return;
       }
       if (
         this.get('server') !== newServer ||
         this.get('channelId') !== newChannelId
       ) {
-        this.set({ server: newServer });
-        this.set({ channelId: newChannelId });
+        // mark active so it's not in the friends list but the conversation list
+        this.set({
+          server: newServer,
+          channelId: newChannelId,
+          active_at: Date.now(),
+        });
         await window.Signal.Data.updateConversation(this.id, this.attributes, {
           Conversation: Whisper.Conversation,
         });
@@ -2361,6 +2369,9 @@
     },
     getPublicSource() {
       if (!this.isPublic()) {
+        log.warn(
+          `trying to getPublicSource on non public chat conversation ${this.id}`
+        );
         return null;
       }
       return {
@@ -2370,18 +2381,8 @@
       };
     },
     async getPublicSendData() {
-      const serverAPI = await lokiPublicChatAPI.findOrCreateServer(
-        this.get('server')
-      );
-      if (!serverAPI) {
-        window.log.warn(
-          `Failed to get serverAPI (${this.get('server')}) for conversation (${
-            this.id
-          })`
-        );
-        return null;
-      }
-      const channelAPI = await serverAPI.findOrCreateChannel(
+      const channelAPI = await lokiPublicChatAPI.findOrCreateChannel(
+        this.get('server'),
         this.get('channelId'),
         this.id
       );

--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -145,7 +145,7 @@ class LokiAppDotNetServerAPI {
   }
 
   async setAvatar(url, profileKey) {
-    let value = null;
+    let value; // undefined will save bandwidth on the annotation if we don't need it (no avatar)
     if (url && profileKey) {
       value = { url, profileKey };
     }
@@ -666,7 +666,7 @@ class LokiPublicChannelAPI {
       `loki/v1/channels/${this.channelId}/moderators`
     );
     // FIXME: should this be window.storage.get('primaryDevicePubKey')?
-    const ourNumber = textsecure.storage.user.getNumber();;
+    const ourNumber = textsecure.storage.user.getNumber();
 
     // Get the list of moderators if no errors occurred
     const moderators = !res.err && res.response && res.response.moderators;

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -1,5 +1,6 @@
-/* global log */
+/* global log, window */
 const EventEmitter = require('events');
+const nodeFetch = require('node-fetch');
 const LokiAppDotNetAPI = require('./loki_app_dot_net_api');
 
 class LokiPublicChatFactoryAPI extends EventEmitter {
@@ -84,17 +85,16 @@ class LokiPublicChatFactoryAPI extends EventEmitter {
 
   // deallocate resources server uses
   unregisterChannel(serverUrl, channelId) {
-    let thisServer;
-    let i = 0;
-    for (; i < this.servers.length; i += 1) {
-      if (this.servers[i].baseServerUrl === serverUrl) {
-        thisServer = this.servers[i];
-        break;
-      }
-    }
-
-    if (!thisServer) {
+    const i = this.servers.findIndex(
+      server => server.baseServerUrl === serverUrl
+    );
+    if (i === -1) {
       log.warn(`Tried to unregister from nonexistent server ${serverUrl}`);
+      return;
+    }
+    const thisServer = this.servers[i];
+    if (!thisServer) {
+      log.warn(`Tried to unregister from nonexistent server ${i}`);
       return;
     }
     thisServer.unregisterChannel(channelId);

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -1,5 +1,123 @@
+/* global log */
+const EventEmitter = require('events');
 const LokiAppDotNetAPI = require('./loki_app_dot_net_api');
 
-class LokiPublicChatAPI extends LokiAppDotNetAPI {}
+class LokiPublicChatFactoryAPI extends EventEmitter {
+  constructor(ourKey) {
+    super();
+    this.ourKey = ourKey;
+    this.servers = [];
+    this.allMembers = [];
+    // Multidevice states
+    this.primaryUserProfileName = {};
+  }
 
-module.exports = LokiPublicChatAPI;
+  async close() {
+    await Promise.all(this.servers.map(server => server.close()));
+  }
+
+  // server getter/factory
+  async findOrCreateServer(serverUrl) {
+    let thisServer = this.servers.find(
+      server => server.baseServerUrl === serverUrl
+    );
+    if (!thisServer) {
+      log.info(`LokiAppDotNetAPI creating ${serverUrl}`);
+      thisServer = new LokiAppDotNetAPI(this.ourKey, serverUrl);
+      const gotToken = await thisServer.getOrRefreshServerToken();
+      if (!gotToken) {
+        log.warn(`Invalid server ${serverUrl}`);
+        return null;
+      }
+      log.info(`set token ${thisServer.token}`);
+
+      this.servers.push(thisServer);
+    }
+    return thisServer;
+  }
+
+  // channel getter/factory
+  async findOrCreateChannel(serverUrl, channelId, conversationId) {
+    const server = await this.findOrCreateServer(serverUrl);
+    if (!server) {
+      log.error(`Failed to create server for: ${serverUrl}`);
+      return null;
+    }
+    return server.findOrCreateChannel(this, channelId, conversationId);
+  }
+
+  // deallocate resources server uses
+  unregisterChannel(serverUrl, channelId) {
+    let thisServer;
+    let i = 0;
+    for (; i < this.servers.length; i += 1) {
+      if (this.servers[i].baseServerUrl === serverUrl) {
+        thisServer = this.servers[i];
+        break;
+      }
+    }
+
+    if (!thisServer) {
+      log.warn(`Tried to unregister from nonexistent server ${serverUrl}`);
+      return;
+    }
+    thisServer.unregisterChannel(channelId);
+    this.servers.splice(i, 1);
+  }
+
+  // shouldn't this be scoped per conversation?
+  async getListOfMembers() {
+    // enable in the next release
+    /*
+    let members = [];
+    await Promise.all(this.servers.map(async server => {
+      await Promise.all(server.channels.map(async channel => {
+        const newMembers = await channel.getSubscribers();
+        members = [...members, ...newMembers];
+      }));
+    }));
+    const results = members.map(member => {
+      return { authorPhoneNumber: member.username };
+    });
+    */
+    return this.allMembers;
+  }
+
+  // TODO: make this private (or remove altogether) when
+  // we switch to polling the server for group members
+  setListOfMembers(members) {
+    this.allMembers = members;
+  }
+
+  async setProfileName(profileName) {
+    await Promise.all(
+      this.servers.map(async server => {
+        await server.setProfileName(profileName);
+      })
+    );
+  }
+
+  async setHomeServer(homeServer) {
+    await Promise.all(
+      this.servers.map(async server => {
+        // this may fail
+        // but we can't create a sql table to remember to retry forever
+        // I think we just silently fail for now
+        await server.setHomeServer(homeServer);
+      })
+    );
+  }
+
+  async setAvatar(url, profileKey) {
+    await Promise.all(
+      this.servers.map(async server => {
+        // this may fail
+        // but we can't create a sql table to remember to retry forever
+        // I think we just silently fail for now
+        await server.setAvatar(url, profileKey);
+      })
+    );
+  }
+}
+
+module.exports = LokiPublicChatFactoryAPI;

--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -36,6 +36,42 @@ class LokiPublicChatFactoryAPI extends EventEmitter {
     return thisServer;
   }
 
+  static async getServerTime() {
+    const url = `${window.getDefaultFileServer()}/loki/v1/time`;
+    let timestamp = NaN;
+
+    try {
+      const res = await nodeFetch(url);
+      if (res.ok) {
+        timestamp = await res.text();
+      }
+    } catch (e) {
+      return timestamp;
+    }
+
+    return Number(timestamp);
+  }
+
+  static async getTimeDifferential() {
+    // Get time differential between server and client in seconds
+    const serverTime = await this.getServerTime();
+    const clientTime = Math.ceil(Date.now() / 1000);
+
+    if (Number.isNaN(serverTime)) {
+      return 0;
+    }
+    return serverTime - clientTime;
+  }
+
+  static async setClockParams() {
+    // Set server-client time difference
+    const maxTimeDifferential = 30;
+    const timeDifferential = await this.getTimeDifferential();
+
+    window.clientClockSynced = Math.abs(timeDifferential) < maxTimeDifferential;
+    return window.clientClockSynced;
+  }
+
   // channel getter/factory
   async findOrCreateChannel(serverUrl, channelId, conversationId) {
     const server = await this.findOrCreateServer(serverUrl);

--- a/js/modules/loki_rss_api.js
+++ b/js/modules/loki_rss_api.js
@@ -55,12 +55,14 @@ class LokiRssAPI extends EventEmitter {
 
   async getFeed() {
     let response;
-    let success = true;
     try {
       response = await nodeFetch(this.feedUrl);
     } catch (e) {
       log.error('fetcherror', e);
-      success = false;
+      return;
+    }
+    if (!response) {
+      return;
     }
     const responseXML = await response.text();
     let feedDOM = {};
@@ -71,9 +73,6 @@ class LokiRssAPI extends EventEmitter {
       );
     } catch (e) {
       log.error('xmlerror', e);
-      success = false;
-    }
-    if (!success) {
       return;
     }
     const feedObj = xml2json(feedDOM);

--- a/js/views/connecting_to_server_dialog_view.js
+++ b/js/views/connecting_to_server_dialog_view.js
@@ -50,6 +50,7 @@
       );
       await serverAPI.findOrCreateChannel(channelId, conversationId);
       await conversation.setPublicSource(sslServerUrl, channelId);
+      await conversation.set({ active_at: Date.now() });
       await conversation.setFriendRequestStatus(
         friends.friendRequestStatusEnum.friends
       );

--- a/js/views/connecting_to_server_dialog_view.js
+++ b/js/views/connecting_to_server_dialog_view.js
@@ -1,4 +1,4 @@
-/* global Whisper, i18n, lokiPublicChatAPI, ConversationController, friends */
+/* global Whisper, i18n, ConversationController, friends */
 
 // eslint-disable-next-line func-names
 (function() {
@@ -36,24 +36,19 @@
         return this.resolveWith({ errorCode: i18n('publicChatExists') });
       }
 
-      const serverAPI = await lokiPublicChatAPI.findOrCreateServer(
-        sslServerUrl
-      );
-      if (!serverAPI) {
-        // Url incorrect or server not compatible
-        return this.resolveWith({ errorCode: i18n('connectToServerFail') });
-      }
-
+      // create conversation
       const conversation = await ConversationController.getOrCreateAndWait(
         conversationId,
         'group'
       );
-      await serverAPI.findOrCreateChannel(channelId, conversationId);
+      // convert conversation to a public one
       await conversation.setPublicSource(sslServerUrl, channelId);
-      await conversation.set({ active_at: Date.now() });
+      // set friend and appropriate SYNC messages for multidevice
       await conversation.setFriendRequestStatus(
         friends.friendRequestStatusEnum.friends
       );
+      // and finally activate it
+      conversation.getPublicSendData(); // may want "await" if you want to use the API
       return this.resolveWith({ conversation });
     },
     resolveWith(result) {

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -223,6 +223,9 @@
           isOnline: this.model.isOnline(),
           isArchived: this.model.get('isArchived'),
           isPublic: this.model.isPublic(),
+          amMod: this.model.isModerator(
+            window.storage.get('primaryDevicePubKey')
+          ),
           members,
           expirationSettingName,
           showBackButton: Boolean(this.panels && this.panels.length),

--- a/js/views/create_group_dialog_view.js
+++ b/js/views/create_group_dialog_view.js
@@ -99,6 +99,7 @@
       this.cancelText = i18n('cancel');
       this.close = this.close.bind(this);
       this.onSubmit = this.onSubmit.bind(this);
+      this.isPublic = groupConvo.isPublic();
 
       const ourPK = textsecure.storage.user.getNumber();
 
@@ -115,9 +116,30 @@
       this.friendList = allMembers;
 
       // only give members that are not already in the group
-      const existingMembers = groupConvo.get('members');
+      let existingMembers = groupConvo.get('members');
+
+      // at least make sure it's an array
+      if (!Array.isArray(existingMembers)) {
+        existingMembers = [];
+      }
 
       this.existingMembers = existingMembers;
+
+      // public chat settings overrides
+      if (this.isPublic) {
+        // fix the title
+        this.titleText = `${i18n('updatePublicGroupDialogTitle')}: ${
+          this.groupName
+        }`;
+        // I'd much prefer to integrate mods with groupAdmins
+        // but lets discuss first...
+        this.isAdmin = groupConvo.isModerator(
+          window.storage.get('primaryDevicePubKey')
+        );
+        // zero out friendList for now
+        this.friendList = [];
+        this.existingMembers = [];
+      }
 
       this.$el.focus();
       this.render();
@@ -130,6 +152,7 @@
           titleText: this.titleText,
           groupName: this.groupName,
           okText: this.okText,
+          isPublic: this.isPublic,
           cancelText: this.cancelText,
           existingMembers: this.existingMembers,
           friendList: this.friendList,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Loki Messenger",
   "description": "Private messaging from your desktop",
   "repository": "https://github.com/loki-project/loki-messenger.git",
-  "version": "1.0.0-beta8",
+  "version": "1.0.0-beta9",
   "license": "GPL-3.0",
   "author": {
     "name": "Loki Project",

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -30,6 +30,7 @@ interface Props {
   isGroup: boolean;
   isArchived: boolean;
   isPublic: boolean;
+  amMod: boolean;
 
   members: Array<any>;
 
@@ -233,6 +234,7 @@ export class ConversationHeader extends React.Component<Props> {
       isClosable,
       isPublic,
       isGroup,
+      amMod,
       onDeleteMessages,
       onDeleteContact,
       onCopyPublicKey,
@@ -250,7 +252,7 @@ export class ConversationHeader extends React.Component<Props> {
         {this.renderPublicMenuItems()}
         <MenuItem onClick={onCopyPublicKey}>{copyIdLabel}</MenuItem>
         <MenuItem onClick={onDeleteMessages}>{i18n('deleteMessages')}</MenuItem>
-        {isPrivateGroup ? (
+        {isPrivateGroup || amMod ? (
           <MenuItem onClick={onUpdateGroup}>{i18n('updateGroup')}</MenuItem>
         ) : null}
         {isPrivateGroup ? (

--- a/ts/components/conversation/UpdateGroupDialog.tsx
+++ b/ts/components/conversation/UpdateGroupDialog.tsx
@@ -13,6 +13,7 @@ interface Props {
   titleText: string;
   groupName: string;
   okText: string;
+  isPublic: boolean;
   cancelText: string;
   // friends not in the group
   friendList: Array<any>;
@@ -88,15 +89,24 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
   public render() {
     const checkMarkedCount = this.getMemberCount(this.state.friendList);
 
-    const titleText = `${this.props.titleText} (Members: ${checkMarkedCount})`;
+    let titleText = `${this.props.titleText} (Members: ${checkMarkedCount})`;
 
     const okText = this.props.okText;
     const cancelText = this.props.cancelText;
 
-    const noFriendsClasses =
+    let noFriendsClasses =
       this.state.friendList.length === 0
         ? 'no-friends'
         : classNames('no-friends', 'hidden');
+
+    // alternatively, we can go back to const and use more trinary operators
+    // but this looks cleaner/more organized to me
+    if (this.props.isPublic) {
+      // remove member count from title
+      titleText = `${this.props.titleText}`;
+      // hide the no-friend message
+      noFriendsClasses = classNames('no-friends', 'hidden');
+    }
 
     const errorMsg = this.state.errorMessage;
     const errorMessageClasses = classNames(

--- a/ts/components/conversation/UpdateGroupDialog.tsx
+++ b/ts/components/conversation/UpdateGroupDialog.tsx
@@ -89,23 +89,24 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
   public render() {
     const checkMarkedCount = this.getMemberCount(this.state.friendList);
 
-    let titleText = `${this.props.titleText} (Members: ${checkMarkedCount})`;
-
     const okText = this.props.okText;
     const cancelText = this.props.cancelText;
 
-    let noFriendsClasses =
-      this.state.friendList.length === 0
-        ? 'no-friends'
-        : classNames('no-friends', 'hidden');
+    let titleText;
+    let noFriendsClasses;
 
-    // alternatively, we can go back to const and use more trinary operators
-    // but this looks cleaner/more organized to me
     if (this.props.isPublic) {
-      // remove member count from title
+      // no member count in title
       titleText = `${this.props.titleText}`;
       // hide the no-friend message
       noFriendsClasses = classNames('no-friends', 'hidden');
+    } else {
+      // private group
+      titleText = `${this.props.titleText} (Members: ${checkMarkedCount})`;
+      noFriendsClasses =
+        this.state.friendList.length === 0
+          ? 'no-friends'
+          : classNames('no-friends', 'hidden');
     }
 
     const errorMsg = this.state.errorMessage;


### PR DESCRIPTION
- Make sure public servers are in the conversation tabs (when no messages, not the friends tab)
- updateGroup now works with public chat conversations. When in public chat mode we:
  - remove members count for now
  - remove friendList
  - use different internationalized title
  - actually save back to the server
- clean up app_dot_net classes further
  - move specific public chat api class into `loki_public_chat_api.js`
  - make loki_app_dot_net_api expose the serverAPI class
  - make file server take advantage of that clean up
  - reorganize channelAPI, so serverAPI isn't dependent on the public chat api
- minor rss fix for an error I observed
- fixed an annoying typo in adn serverAPI's serverRequest()