### PR TITLE
Fix token refreshing

### DIFF
--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -30,7 +30,7 @@ class LokiPublicChatFactoryAPI extends EventEmitter {
         log.warn(`Invalid server ${serverUrl}`);
         return null;
       }
-      log.info(`set token ${thisServer.token}`);
+      log.info(`set token ${thisServer.token} for ${serverUrl}`);
 
       this.servers.push(thisServer);
     }


### PR DESCRIPTION
if you token became invalid for whatever right, we had forgot to pass `true` to `getOrRefreshServerToken` to actually get a new token. Fixed that.

Also fixes the /token check on start up, so if it fails, it `forceRefresh` a new token.

improved logging and other minor cleanup.