### PR TITLE
Add a feature flag for snode proxy

### DIFF
--- a/config/swarm-testing.json
+++ b/config/swarm-testing.json
@@ -1,0 +1,12 @@
+{
+    "storageProfile": "swarm-testing",
+    "seedNodeList": [
+      {
+          "ip": "localhost",
+          "port": "22129"
+      }
+    ],
+    "openDevTools": true,
+    "defaultPublicChatServer": "https://team-chat.lokinet.org/"
+  }
+  

--- a/config/swarm-testing2.json
+++ b/config/swarm-testing2.json
@@ -1,0 +1,12 @@
+{
+    "storageProfile": "swarm-testing2",
+    "seedNodeList": [
+      {
+          "ip": "localhost",
+          "port": "22129"
+      }
+    ],
+    "openDevTools": true,
+    "defaultPublicChatServer": "https://team-chat.lokinet.org/"
+  }
+  

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -3,7 +3,7 @@
 /* global log, dcodeIO, window, callWorker, lokiP2pAPI, lokiSnodeAPI, textsecure */
 
 const _ = require('lodash');
-const { rpc } = require('./loki_rpc');
+const { loki_rpc } = require('./loki_rpc');
 
 const DEFAULT_CONNECTIONS = 3;
 const MAX_ACCEPTABLE_FAILURES = 1;
@@ -47,7 +47,7 @@ const trySendP2p = async (pubKey, data64, isPing, messageEventData) => {
     return false;
   }
   try {
-    await rpc(p2pDetails.address, p2pDetails.port, 'store', {
+    await loki_rpc(p2pDetails.address, p2pDetails.port, 'store', {
       data: data64,
     });
     lokiP2pAPI.setContactOnline(pubKey);
@@ -213,6 +213,7 @@ class LokiMessageAPI {
       const successfulSend = await this.sendToNode(
         snode.ip,
         snode.port,
+        snode,
         params
       );
       if (successfulSend) {
@@ -237,12 +238,12 @@ class LokiMessageAPI {
     return false;
   }
 
-  async sendToNode(address, port, params) {
+  async sendToNode(address, port, targetNode, params) {
     let successiveFailures = 0;
     while (successiveFailures < MAX_ACCEPTABLE_FAILURES) {
       await sleepFor(successiveFailures * 500);
       try {
-        const result = await rpc(`https://${address}`, port, 'store', params);
+        const result = await loki_rpc(`https://${address}`, port, 'store', params, {}, '/storage_rpc/v1', targetNode);
 
         // Make sure we aren't doing too much PoW
         const currentDifficulty = window.storage.get('PoWDifficulty', null);
@@ -365,12 +366,14 @@ class LokiMessageAPI {
       },
     };
 
-    const result = await rpc(
+    const result = await loki_rpc(
       `https://${nodeUrl}`,
       nodeData.port,
       'retrieve',
       params,
-      options
+      options,
+      '/storage_rpc/v1',
+      nodeData
     );
     return result.messages || [];
   }
@@ -386,10 +389,10 @@ class LokiMessageAPI {
       const lastHash = await window.Signal.Data.getLastHashBySnode(
         nodes[i].address
       );
+
       this.ourSwarmNodes[nodes[i].address] = {
+        ...nodes[i],
         lastHash,
-        ip: nodes[i].ip,
-        port: nodes[i].port,
       };
     }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "start-multi2": "NODE_APP_INSTANCE=2 electron .",
     "start-prod": "NODE_ENV=production NODE_APP_INSTANCE=devprod LOKI_DEV=1 electron .",
     "start-prod-multi": "NODE_ENV=production NODE_APP_INSTANCE=devprod1 LOKI_DEV=1 electron .",
+    "start-swarm-test": "NODE_ENV=swarm-testing NODE_APP_INSTANCE=test1 LOKI_DEV=1 electron .",
+    "start-swarm-test-2": "NODE_ENV=swarm-testing2 NODE_APP_INSTANCE=test2 LOKI_DEV=1 electron .",
     "grunt": "grunt",
     "icon-gen": "electron-icon-maker --input=images/icon_1024.png --output=./build",
     "generate": "yarn icon-gen && yarn grunt",

--- a/preload.js
+++ b/preload.js
@@ -471,4 +471,5 @@ window.SMALL_GROUP_SIZE_LIMIT = 10;
 window.lokiFeatureFlags = {
   multiDeviceUnpairing: true,
   privateGroupChats: false,
+  useSnodeProxy: false,
 };


### PR DESCRIPTION
This PR is meant as a demo for using the snode proxy. The main idea is to substitute the nodeFetch call for all snode requests and requests to `file.lokinet.org` with functions that will package the original request and send them to a random snode, the response should be identical (as far a the messenger is concerned) to what we would get without the proxy.