### PR TITLE
Fix not showing messages from secondary devices

### DIFF
--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -1350,7 +1350,10 @@ class LokiPublicChannelAPI {
     /* eslint-enable no-param-reassign */
 
     // process remaining messages
-    Object.keys(slaveMessages).forEach(slaveKey => {
+    slaveMessages.forEach(messageData => {
+
+      const slaveKey = messageData.source;
+
       // prevent our own device sent messages from coming back in
       if (slaveKey === ourNumber) {
         // we originally sent these
@@ -1360,31 +1363,21 @@ class LokiPublicChannelAPI {
       // look up primary device once
       const primaryPubKey = slavePrimaryMap[slaveKey];
 
-      if (!Array.isArray(slaveMessages[slaveKey])) {
-        log.warn(
-          `messages for ${slaveKey} is not an array`,
-          slaveMessages[slaveKey]
-        );
-        return;
-      }
-
       // send out remaining messages for this merged identity
-      slaveMessages[slaveKey].forEach(messageDataP => {
-        const messageData = messageDataP; // for linter
-        if (slavePrimaryMap[messageData.source]) {
-          // rewrite source, profile
-          messageData.source = primaryPubKey;
-          const { name, avatar, profileKey } = this.primaryUserProfileName[
-            primaryPubKey
-          ];
-          messageData.message.profile.displayName = name;
-          messageData.message.profile.avatar = avatar;
-          messageData.message.profileKey = profileKey;
-        }
-        this.chatAPI.emit('publicMessage', {
-          message: messageData,
-        });
+      if (slavePrimaryMap[slaveKey]) {
+        // rewrite source, profile
+        messageData.source = primaryPubKey;
+        const { name, avatar, profileKey } = this.primaryUserProfileName[
+          primaryPubKey
+        ];
+        messageData.message.profile.displayName = name;
+        messageData.message.profile.avatar = avatar;
+        messageData.message.profileKey = profileKey;
+      }
+      this.chatAPI.emit('publicMessage', {
+        message: messageData,
       });
+
     });
 
     // if we received one of our own messages


### PR DESCRIPTION
It seems like `slaveMessages` was still treated like `Object` after it's been changed to `Array`.