### PR TITLE
fix disabled state of message input on sent friendrequest

### DIFF
--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -457,10 +457,6 @@
     resize: none;
     font-size: 1em;
     font-family: inherit;
-
-    &[disabled='disabled'] {
-      background: $color-light-35;
-    }
   }
   .capture-audio {
     float: right;

--- a/stylesheets/_theme_dark.scss
+++ b/stylesheets/_theme_dark.scss
@@ -49,7 +49,7 @@ body.dark-theme {
       outline: 0;
 
       &[disabled='disabled'] {
-        background: $color-light-90;
+        cursor: not-allowed;
       }
     }
   }


### PR DESCRIPTION
make the background the same color as the bottom form
a message is displayed and the cursor is set to "not-allowed"