### PR TITLE
Fix session request messages

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -2323,8 +2323,10 @@
               Friends -> Friends
 
               The cases where we auto accept are the following:
-                - We sent the user a friend request and that user sent us a friend request.
-                - We are friends with the user, and that user just sent us a friend request.
+                - We sent the user a friend request,
+                  and that user sent us a friend request.
+                - We are friends with the user,
+                  and that user just sent us a friend request.
               */
               const isFriend = sendingDeviceConversation.isFriend();
               const hasSentFriendRequest = sendingDeviceConversation.hasSentFriendRequest();

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1891,7 +1891,8 @@
       const authorisation = await libloki.storage.getGrantAuthorisationForSecondaryPubKey(
         source
       );
-      if (initialMessage.group) {
+      const isGroupMessage = !!initialMessage.group;
+      if (isGroupMessage) {
         conversationId = initialMessage.group.id;
       } else if (source !== ourNumber && authorisation) {
         // Ignore auth from our devices
@@ -1982,16 +1983,16 @@
                 Date.now(),
                 undefined,
                 undefined,
-                { messageType: 'friend-request', backgroundFriendReq: true }
+                { messageType: 'friend-request', sessionRequest: true }
               );
             });
           }
         });
       }
 
-      const backgroundFrReq =
+      const isSessionRequest =
         initialMessage.flags ===
-        textsecure.protobuf.DataMessage.Flags.BACKGROUND_FRIEND_REQUEST;
+        textsecure.protobuf.DataMessage.Flags.SESSION_REQUEST;
 
       if (
         // eslint-disable-next-line no-bitwise
@@ -2002,7 +2003,7 @@
         this.set({ endSessionType: 'ongoing' });
       }
 
-      if (message.isFriendRequest() && backgroundFrReq) {
+      if (message.isFriendRequest() && isSessionRequest) {
         // Check if the contact is a member in one of our private groups:
         const groupMember = window
           .getConversations()
@@ -2308,39 +2309,42 @@
           }
 
           let autoAccept = false;
-          if (message.get('type') === 'friend-request') {
-            /*
-            Here is the before and after state diagram for the operation before.
+          // Make sure friend request logic doesn't trigger on messages aimed at groups
+          if (!isGroupMessage) {
+            if (message.get('type') === 'friend-request') {
+              /*
+              Here is the before and after state diagram for the operation before.
 
-            None -> RequestReceived
-            PendingSend -> RequestReceived
-            RequestReceived -> RequestReceived
-            Sent -> Friends
-            Expired -> Friends
-            Friends -> Friends
+              None -> RequestReceived
+              PendingSend -> RequestReceived
+              RequestReceived -> RequestReceived
+              Sent -> Friends
+              Expired -> Friends
+              Friends -> Friends
 
-            The cases where we auto accept are the following:
-              - We sent the user a friend request and that user sent us a friend request.
-              - We are friends with the user, and that user just sent us a friend request.
-            */
-            const isFriend = sendingDeviceConversation.isFriend();
-            const hasSentFriendRequest = sendingDeviceConversation.hasSentFriendRequest();
-            autoAccept = isFriend || hasSentFriendRequest;
+              The cases where we auto accept are the following:
+                - We sent the user a friend request and that user sent us a friend request.
+                - We are friends with the user, and that user just sent us a friend request.
+              */
+              const isFriend = sendingDeviceConversation.isFriend();
+              const hasSentFriendRequest = sendingDeviceConversation.hasSentFriendRequest();
+              autoAccept = isFriend || hasSentFriendRequest;
 
-            if (autoAccept) {
-              message.set({ friendStatus: 'accepted' });
-            }
+              if (autoAccept) {
+                message.set({ friendStatus: 'accepted' });
+              }
 
-            if (isFriend) {
-              window.Whisper.events.trigger('endSession', source);
-            } else if (hasSentFriendRequest) {
+              if (isFriend) {
+                window.Whisper.events.trigger('endSession', source);
+              } else if (hasSentFriendRequest) {
+                await sendingDeviceConversation.onFriendRequestAccepted();
+              } else {
+                await sendingDeviceConversation.onFriendRequestReceived();
+              }
+            } else if (message.get('type') !== 'outgoing') {
+              // Ignore 'outgoing' messages because they are sync messages
               await sendingDeviceConversation.onFriendRequestAccepted();
-            } else {
-              await sendingDeviceConversation.onFriendRequestReceived();
             }
-          } else if (message.get('type') !== 'outgoing') {
-            // Ignore 'outgoing' messages because they are sync messages
-            await sendingDeviceConversation.onFriendRequestAccepted();
           }
           const id = await window.Signal.Data.saveMessage(message.attributes, {
             Message: Whisper.Message,

--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -496,7 +496,9 @@ class LokiAppDotNetServerAPI {
         ));
       } else {
         // disable check for .loki
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = endpoint.match(/\.loki\//) ? 0 : 1;
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = endpoint.match(/\.loki\//)
+          ? 0
+          : 1;
         result = await nodeFetch(url, fetchOptions);
         // always make sure this check is enabled
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = 1;
@@ -505,7 +507,12 @@ class LokiAppDotNetServerAPI {
       }
     } catch (e) {
       if (txtResponse) {
-        log.info(`serverRequest ${mode} error`, e.code, e.message, `json: ${txtResponse}`);
+        log.info(
+          `serverRequest ${mode} error`,
+          e.code,
+          e.message,
+          `json: ${txtResponse}`
+        );
       } else {
         log.info(`serverRequest ${mode} error`, e.code, e.message);
       }

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1848,7 +1848,7 @@ MessageReceiver.prototype.extend({
     } else if (decrypted.flags & FLAGS.PROFILE_KEY_UPDATE) {
       decrypted.body = null;
       decrypted.attachments = [];
-    } else if (decrypted.flags & FLAGS.BACKGROUND_FRIEND_REQUEST) {
+    } else if (decrypted.flags & FLAGS.SESSION_REQUEST) {
       // do nothing
     } else if (decrypted.flags & FLAGS.SESSION_RESTORE) {
       // do nothing

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -950,8 +950,8 @@ MessageSender.prototype = {
   ) {
     const profile = this.getOurProfile();
 
-    const flags = options.backgroundFriendReq
-      ? textsecure.protobuf.DataMessage.Flags.BACKGROUND_FRIEND_REQUEST
+    const flags = options.sessionRequest
+      ? textsecure.protobuf.DataMessage.Flags.SESSION_REQUEST
       : undefined;
 
     const { groupInvitation, sessionRestoration } = options;

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -107,7 +107,7 @@ message DataMessage {
     PROFILE_KEY_UPDATE        = 4;
     SESSION_RESTORE           = 64;
     UNPAIRING_REQUEST         = 128;
-    BACKGROUND_FRIEND_REQUEST = 256;
+    SESSION_REQUEST           = 256;
   }
 
   message Quote {


### PR DESCRIPTION
Renamed `BACKGROUND_FRIEND_REQUEST` to `SESSION_REQUEST` to match mobile clients.
Don't trigger friend request logic on a group message.