### PR TITLE
Closed group fixes

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -2112,13 +2112,16 @@
       const { wrap, sendOptions } = ConversationController.prepareForSend(
         data.source
       );
-      await wrap(
-        textsecure.messaging.sendDeliveryReceipt(
-          data.source,
-          data.timestamp,
-          sendOptions
-        )
-      );
+      const isGroup = data && data.message && data.message.group;
+      if (!isGroup) {
+        await wrap(
+          textsecure.messaging.sendDeliveryReceipt(
+            data.source,
+            data.timestamp,
+            sendOptions
+          )
+        );
+      }
     } catch (error) {
       window.log.error(
         `Failed to send delivery receipt to ${data.source} for message ${

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -72,6 +72,11 @@ function OutgoingMessage(
     options || {};
   this.numberInfo = numberInfo;
   this.isPublic = isPublic;
+  this.isGroup = !!(
+    this.message &&
+    this.message.dataMessage &&
+    this.message.dataMessage.group
+  );
   this.publicSendData = publicSendData;
   this.senderCertificate = senderCertificate;
   this.online = online;
@@ -348,7 +353,8 @@ OutgoingMessage.prototype = {
           if (
             conversation &&
             !conversation.isFriend() &&
-            !conversation.hasReceivedFriendRequest()
+            !conversation.hasReceivedFriendRequest() &&
+            !this.isGroup
           ) {
             // We want to send an automated friend request if:
             // - We aren't already friends

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -430,7 +430,7 @@ MessageSender.prototype = {
       } else {
         window.log.error(`No session for number: ${number}`);
         // If it was a message to a group then we need to send a session request
-        if (outgoing.isGroup && number !== ourNumber) {
+        if (outgoing.isGroup) {
           this.sendMessageToNumber(
             number,
             '(If you see this message, you must be using an out-of-date client)',

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -409,6 +409,8 @@ MessageSender.prototype = {
       options
     );
 
+    const ourNumber = textsecure.storage.user.getNumber();
+
     numbers.forEach(number => {
       // Note: if we are sending a private group message, we do our best to
       // ensure we have signal protocol sessions with every member, but if we
@@ -419,7 +421,7 @@ MessageSender.prototype = {
       );
 
       if (
-        number === textsecure.storage.user.getNumber() ||
+        number === ourNumber ||
         haveSession ||
         options.isPublic ||
         options.messageType === 'friend-request'
@@ -427,6 +429,20 @@ MessageSender.prototype = {
         this.queueJobForNumber(number, () => outgoing.sendToNumber(number));
       } else {
         window.log.error(`No session for number: ${number}`);
+        // If it was a message to a group then we need to send a session request
+        if (outgoing.isGroup && number !== ourNumber) {
+          this.sendMessageToNumber(
+            number,
+            '(If you see this message, you must be using an out-of-date client)',
+            [],
+            undefined,
+            [],
+            Date.now(),
+            undefined,
+            undefined,
+            { messageType: 'friend-request', sessionRequest: true }
+          );
+        }
       }
     });
   },


### PR DESCRIPTION
These were uncaught before merging #788 

The issue was that we were forcing all messages to be friend requests if we weren't friends with a user/ didn't receive a friend request. This is correct for private chats but not for group chats as we could potentially have a session but still not be friends with the user.

- Fix friend request messages being sent to users you don't have a session in closed groups.
- Disable typing messages in groups.
- Send out session request messages if you don't have a session with a member in the group.

